### PR TITLE
Migrate Compose navigation to Navigation 3

### DIFF
--- a/app/src/main/java/com/sirelon/marsroverphotos/feature/Utils.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/feature/Utils.kt
@@ -1,6 +1,7 @@
 package com.sirelon.marsroverphotos.feature
 
 import androidx.navigation.NavController
+import com.sirelon.marsroverphotos.feature.rovers.ImageViewerRoute
 import com.sirelon.marsroverphotos.storage.MarsImage
 
 /**
@@ -12,5 +13,11 @@ fun NavController.navigateToImages(
     trackingEnabled: Boolean = true
 ) {
     val ids = allphotos.map { it.id }
-    navigate("photos/${image.id}?ids=${ids.joinToString()}&shouldTrack=$trackingEnabled")
+    navigate(
+        ImageViewerRoute(
+            pid = image.id,
+            ids = ids,
+            shouldTrack = trackingEnabled,
+        )
+    )
 }

--- a/app/src/main/java/com/sirelon/marsroverphotos/feature/favorite/FavoriteScreen.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/feature/favorite/FavoriteScreen.kt
@@ -39,6 +39,7 @@ import com.sirelon.marsroverphotos.feature.MarsImageComposable
 import com.sirelon.marsroverphotos.feature.navigateToImages
 import com.sirelon.marsroverphotos.feature.photos.EmptyPhotos
 import com.sirelon.marsroverphotos.feature.popular.PopularPhotosViewModel
+import com.sirelon.marsroverphotos.feature.rovers.RoversRoute
 import com.sirelon.marsroverphotos.storage.MarsImage
 import com.sirelon.marsroverphotos.storage.Prefs
 import com.sirelon.marsroverphotos.ui.CenteredProgress
@@ -71,7 +72,7 @@ fun FavoriteScreen(
                 btnTitle = stringResource(id = R.string.favorite_empty_btn)
             ) {
                 viewModel.track("click_empty_favorite")
-                navController.navigate("rovers")
+                navController.navigate(RoversRoute)
             }
         }
     )

--- a/app/src/main/java/com/sirelon/marsroverphotos/feature/rovers/RoversDestinations.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/feature/rovers/RoversDestinations.kt
@@ -1,0 +1,28 @@
+package com.sirelon.marsroverphotos.feature.rovers
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+object RoversRoute
+
+@Serializable
+object FavoriteRoute
+
+@Serializable
+object PopularRoute
+
+@Serializable
+object AboutRoute
+
+@Serializable
+object UkraineRoute
+
+@Serializable
+data class RoverRoute(val roverId: Long)
+
+@Serializable
+data class ImageViewerRoute(
+    val pid: String,
+    val ids: List<String>,
+    val shouldTrack: Boolean = true,
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,7 +41,7 @@ work = "2.10.4"
 # https://github.com/usuiat/Zoomable/releases
 zoomable = "2.8.1"
 # https://developer.android.com/jetpack/androidx/releases/navigation
-navigation = "2.9.4"
+navigation = "3.0.0"
 androidGradlePlugin = "8.13.0"
 
 [libraries]


### PR DESCRIPTION
## Summary
- upgrade the Navigation Compose dependency to version 3.0.0
- add serializable route models to represent all navigation targets
- refactor the activity, favorite screen, and helper navigation calls to use Navigation 3's typed APIs

## Testing
- `./gradlew assembleDebug` *(fails: Android SDK is not available in the container and bundled KSP is too old for Kotlin 2.2.20)*
- `./gradlew testDebugUnitTest` *(fails: Android SDK is not available in the container and bundled KSP is too old for Kotlin 2.2.20)*
- `./gradlew detekt` *(fails: remote Maven repository returned HTTP 403 when downloading detekt-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68c87efb94a8833386a22e18a0f88946