### PR TITLE
Remove ConstraintLayout Compose dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -94,7 +94,6 @@ dependencies {
     implementation(libs.compose.ui.tooling)
 
     implementation libs.navigation.compose
-    implementation libs.androidx.constraintlayout.compose
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation libs.kotlin.stdlib

--- a/app/src/main/java/com/sirelon/marsroverphotos/feature/rovers/RoversActivity.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/feature/rovers/RoversActivity.kt
@@ -67,8 +67,6 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.constraintlayout.compose.ConstraintLayout
-import androidx.constraintlayout.compose.Dimension
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -276,26 +274,13 @@ class RoversActivity : FragmentActivity() {
         navController: NavHostController,
         onHideUi: (Boolean) -> Unit,
     ) {
-        ConstraintLayout(
+        Column(
             modifier = modifier.fillMaxSize()
         ) {
-            val (content, ad) = createRefs()
-
-            val contentModifier = Modifier.constrainAs(content) {
-                height = Dimension.fillToConstraints
-                bottom.linkTo(ad.top)
-                top.linkTo(parent.top)
-            }
-
-            Box(modifier = contentModifier) {
+            Box(modifier = Modifier.weight(1f)) {
                 RoversNavHost(navController, onHideUi = onHideUi)
             }
-            val adModifier = Modifier.constrainAs(ad) {
-                bottom.linkTo(parent.bottom)
-                end.linkTo(parent.end)
-                start.linkTo(parent.start)
-            }
-            ComposableBannerAd(adModifier)
+            ComposableBannerAd(modifier = Modifier.fillMaxWidth())
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,8 +5,6 @@ activityCompose = "1.11.0"
 appcompat = "1.7.1"
 # https://github.com/coil-kt/coil/blob/main/CHANGELOG.md
 coil = "3.3.0"
-# https://developer.android.com/jetpack/androidx/releases/constraintlayout
-constraintlayoutCompose = "1.1.1"
 # https://developer.android.com/jetpack/androidx/releases/annotation
 annotation = "1.9.1"
 # https://firebase.google.com/support/release-notes/android
@@ -48,7 +46,6 @@ androidGradlePlugin = "8.13.0"
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
-androidx-constraintlayout-compose = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "constraintlayoutCompose" }
 androidx-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "ktx" }
 
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }


### PR DESCRIPTION
Replaces ConstraintLayout with a standard Column layout in MarsRoverContent. The new implementation uses weight(1f) for flexible content sizing and fillMaxWidth() for the ad banner, achieving identical behavior with fewer dependencies.

This simplifies the layout logic while maintaining the same visual result: content fills available space with the ad banner fixed at the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)