### PR TITLE
Migrate Material Icons Extended to Google Fonts Material Symbols

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,7 +90,6 @@ dependencies {
     implementation(libs.compose.ui.util)
     implementation(libs.compose.foundation)
     implementation(libs.compose.material3)
-    implementation(libs.compose.material.icons.extended)
     implementation(libs.compose.ui.tooling)
 
     implementation libs.navigation.compose

--- a/app/src/main/java/com/sirelon/marsroverphotos/feature/MarsImage.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/feature/MarsImage.kt
@@ -14,15 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.FavoriteBorder
-import androidx.compose.material.icons.filled.Save
-import androidx.compose.material.icons.filled.Share
-import androidx.compose.material.icons.filled.Visibility
-import androidx.compose.material.icons.filled.ZoomIn
 import androidx.compose.material3.Card
-import androidx.compose.material3.Icon
 import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -32,8 +24,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -45,6 +35,8 @@ import coil3.request.placeholder
 import coil3.size.Scale
 import com.sirelon.marsroverphotos.R
 import com.sirelon.marsroverphotos.storage.MarsImage
+import com.sirelon.marsroverphotos.ui.MaterialSymbol
+import com.sirelon.marsroverphotos.ui.MaterialSymbolIcon
 
 /**
  * Created on 01.03.2021 22:33 for Mars-Rover-Photos.
@@ -110,10 +102,10 @@ fun PhotoStats(marsImage: MarsImage, onFavoriteClick: () -> Unit) {
         verticalArrangement = Arrangement.Center
     ) {
 
-        StatsInfoText(stats.see, Icons.Filled.Visibility, "counterSee")
-        StatsInfoText(stats.scale, Icons.Filled.ZoomIn, "counterScale")
-        StatsInfoText(stats.save, Icons.Filled.Save, "counterSave")
-        StatsInfoText(stats.share, Icons.Filled.Share, "counterShare")
+        StatsInfoText(stats.see, MaterialSymbol.Visibility, "counterSee")
+        StatsInfoText(stats.scale, MaterialSymbol.ZoomIn, "counterScale")
+        StatsInfoText(stats.save, MaterialSymbol.Save, "counterSave")
+        StatsInfoText(stats.share, MaterialSymbol.Share, "counterShare")
 
         MarsImageFavoriteToggle(
             modifier = Modifier.fillMaxWidth(),
@@ -134,9 +126,10 @@ fun MarsImageFavoriteToggle(
         checked = checked,
         onCheckedChange = onCheckedChange
     ) {
-        Icon(
-            imageVector = if (checked) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,
-            contentDescription = null // handled by click label of parent
+        MaterialSymbolIcon(
+            symbol = MaterialSymbol.Favorite,
+            contentDescription = null, // handled by click label of parent
+            filled = checked
         )
     }
 }
@@ -167,15 +160,15 @@ fun NetworkImage(
 }
 
 @Composable
-private fun StatsInfoText(counter: Long, image: ImageVector, desc: String) {
+private fun StatsInfoText(counter: Long, symbol: MaterialSymbol, desc: String) {
 
     if (counter <= 0) return
 
     Row(verticalAlignment = Alignment.CenterVertically) {
-        Icon(
-            modifier = Modifier.size(20.dp),
-            painter = rememberVectorPainter(image = image),
+        MaterialSymbolIcon(
+            symbol = symbol,
             contentDescription = desc,
+            size = 20.dp
         )
         Spacer(modifier = Modifier.width(6.dp))
         Text(

--- a/app/src/main/java/com/sirelon/marsroverphotos/feature/favorite/FavoriteScreen.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/feature/favorite/FavoriteScreen.kt
@@ -9,11 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ViewList
-import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
@@ -42,6 +38,8 @@ import com.sirelon.marsroverphotos.feature.popular.PopularPhotosViewModel
 import com.sirelon.marsroverphotos.storage.MarsImage
 import com.sirelon.marsroverphotos.storage.Prefs
 import com.sirelon.marsroverphotos.ui.CenteredProgress
+import com.sirelon.marsroverphotos.ui.MaterialSymbol
+import com.sirelon.marsroverphotos.ui.MaterialSymbolIcon
 import java.util.UUID
 
 /**
@@ -128,13 +126,13 @@ fun FavoritePhotosContent(
                     },
                 ) {
                     if (gridView) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ViewList,
+                        MaterialSymbolIcon(
+                            symbol = MaterialSymbol.ViewList,
                             contentDescription = "Change to List View",
                         )
                     } else {
-                        Icon(
-                            imageVector = Icons.Default.GridView,
+                        MaterialSymbolIcon(
+                            symbol = MaterialSymbol.GridView,
                             contentDescription = "Change to Grid View",
                         )
                     }

--- a/app/src/main/java/com/sirelon/marsroverphotos/feature/images/ImagesScreen.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/feature/images/ImagesScreen.kt
@@ -21,12 +21,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Save
-import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
@@ -45,7 +41,6 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -59,6 +54,8 @@ import com.sirelon.marsroverphotos.feature.NetworkImage
 import com.sirelon.marsroverphotos.storage.MarsImage
 import com.sirelon.marsroverphotos.ui.CenteredProgress
 import com.sirelon.marsroverphotos.ui.MarsSnackbar
+import com.sirelon.marsroverphotos.ui.MaterialSymbol
+import com.sirelon.marsroverphotos.ui.MaterialSymbolIcon
 import com.sirelon.marsroverphotos.ui.NoScrollEffect
 import kotlinx.coroutines.launch
 import net.engawapg.lib.zoomable.rememberZoomState
@@ -231,8 +228,8 @@ private fun SaveIcon(
     onClick: () -> Unit
 ) {
     IconButton(onClick = onClick) {
-        Icon(
-            painter = rememberVectorPainter(image = Icons.Filled.Save),
+        MaterialSymbolIcon(
+            symbol = MaterialSymbol.Save,
             contentDescription = "Save"
         )
     }
@@ -241,8 +238,8 @@ private fun SaveIcon(
 @Composable
 private fun ShareIcon(onClick: () -> Unit) {
     IconButton(onClick = onClick) {
-        Icon(
-            painter = rememberVectorPainter(image = Icons.Filled.Share),
+        MaterialSymbolIcon(
+            symbol = MaterialSymbol.Share,
             contentDescription = "Share"
         )
     }

--- a/app/src/main/java/com/sirelon/marsroverphotos/feature/photos/RoverPhotosScreen.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/feature/photos/RoverPhotosScreen.kt
@@ -25,13 +25,10 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Autorenew
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
@@ -60,6 +57,8 @@ import com.sirelon.marsroverphotos.feature.NetworkImage
 import com.sirelon.marsroverphotos.feature.navigateToImages
 import com.sirelon.marsroverphotos.storage.MarsImage
 import com.sirelon.marsroverphotos.ui.CenteredProgress
+import com.sirelon.marsroverphotos.ui.MaterialSymbol
+import com.sirelon.marsroverphotos.ui.MaterialSymbolIcon
 import java.util.Calendar
 import java.util.TimeZone
 
@@ -170,8 +169,8 @@ private fun RefreshButton(
                 modifier = Modifier.align(Alignment.BottomEnd),
                 onClick = onClick
             ) {
-                Icon(
-                    imageVector = Icons.Filled.Autorenew,
+                MaterialSymbolIcon(
+                    symbol = MaterialSymbol.Autorenew,
                     contentDescription = "refresh"
                 )
             }

--- a/app/src/main/java/com/sirelon/marsroverphotos/feature/rovers/RoversActivity.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/feature/rovers/RoversActivity.kt
@@ -35,13 +35,7 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Favorite
-import androidx.compose.material.icons.outlined.Info
-import androidx.compose.material.icons.outlined.LocalFireDepartment
-import androidx.compose.material.icons.outlined.ViewCarousel
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -57,12 +51,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -103,6 +95,8 @@ import com.sirelon.marsroverphotos.models.drawableRes
 import com.sirelon.marsroverphotos.storage.Prefs
 import com.sirelon.marsroverphotos.storage.Theme
 import com.sirelon.marsroverphotos.ui.MarsRoverPhotosTheme
+import com.sirelon.marsroverphotos.ui.MaterialSymbol
+import com.sirelon.marsroverphotos.ui.MaterialSymbolIcon
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -310,10 +304,7 @@ class RoversActivity : FragmentActivity() {
             bottomItems.forEach { screen ->
                 NavigationBarItem(
                     icon = {
-                        Icon(
-                            screen.iconCreator.invoke(),
-                            contentDescription = null
-                        )
+                        screen.Icon(contentDescription = null)
                     },
                     selected = navDestination?.hierarchy?.any { it.route == screen.route } == true,
 //                    colors = NavigationBarItemColors(),
@@ -477,18 +468,49 @@ class RoversActivity : FragmentActivity() {
     }
 }
 
-sealed class Screen(val route: String, val iconCreator: @Composable () -> ImageVector) {
-    data object Rovers : Screen("rovers", {
-        ImageVector.vectorResource(id = R.drawable.ic_rovers)
-    })
+sealed class Screen(val route: String) {
+    open val drawableRes: Int? = null
+    open val symbol: MaterialSymbol? = null
 
-    data object Favorite : Screen("favorite", { Icons.Outlined.Favorite })
-    data object Popular : Screen("popular", { Icons.Outlined.LocalFireDepartment })
-    data object About : Screen("about", { Icons.Outlined.Info })
+    data object Rovers : Screen("rovers") {
+        override val drawableRes = R.drawable.ic_rovers
+    }
 
-    class Rover(val id: Long) : Screen("rover", { Icons.Outlined.ViewCarousel })
+    data object Favorite : Screen("favorite") {
+        override val symbol = MaterialSymbol.Favorite
+    }
 
-    data object Ukraine : Screen("ukraine", { Icons.Outlined.Info })
+    data object Popular : Screen("popular") {
+        override val symbol = MaterialSymbol.LocalFireDepartment
+    }
+
+    data object About : Screen("about") {
+        override val symbol = MaterialSymbol.Info
+    }
+
+    class Rover(val id: Long) : Screen("rover") {
+        override val symbol = MaterialSymbol.ViewCarousel
+    }
+
+    data object Ukraine : Screen("ukraine") {
+        override val symbol = MaterialSymbol.Info
+    }
+
+    @Composable
+    fun Icon(contentDescription: String? = null) {
+        drawableRes?.let {
+            androidx.compose.material3.Icon(
+                painter = painterResource(id = it),
+                contentDescription = contentDescription
+            )
+        }
+        symbol?.let {
+            MaterialSymbolIcon(
+                symbol = it,
+                contentDescription = contentDescription
+            )
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/sirelon/marsroverphotos/ui/MaterialSymbolIcon.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/ui/MaterialSymbolIcon.kt
@@ -1,0 +1,100 @@
+package com.sirelon.marsroverphotos.ui
+
+import android.os.Build
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontVariation
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.sirelon.marsroverphotos.R
+
+/**
+ * Material Symbols icon names used in the app.
+ * These names correspond to ligatures in the Material Symbols font.
+ *
+ * @see <a href="https://fonts.google.com/icons">Material Symbols</a>
+ */
+enum class MaterialSymbol(val iconName: String) {
+    Favorite("favorite"),
+    Save("save"),
+    Share("share"),
+    Visibility("visibility"),
+    ZoomIn("zoom_in"),
+    Autorenew("autorenew"),
+    Info("info"),
+    LocalFireDepartment("local_fire_department"),
+    ViewCarousel("view_carousel"),
+    ViewList("view_list"),
+    GridView("grid_view")
+}
+
+/**
+ * Displays a Material Symbol icon using the Material Symbols font.
+ *
+ * The icon is rendered using font ligatures - the [symbol] name is converted
+ * to the corresponding icon glyph by the font.
+ *
+ * @param symbol The icon to display from [MaterialSymbol] enum
+ * @param contentDescription Accessibility description for the icon
+ * @param modifier Modifier to be applied to the icon
+ * @param tint Color to tint the icon
+ * @param size Size of the icon (default 24.dp)
+ * @param filled Whether to show the filled variant (true) or outlined (false)
+ * @param weight Font weight from 100 to 700 (default 400)
+ */
+@Composable
+fun MaterialSymbolIcon(
+    symbol: MaterialSymbol,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    tint: Color = LocalContentColor.current,
+    size: Dp = 24.dp,
+    filled: Boolean = false,
+    weight: Int = 400
+) {
+    val fontFamily = rememberMaterialSymbolsFont(filled = filled, weight = weight)
+    val fontSize = with(LocalDensity.current) { size.toSp() }
+
+    androidx.compose.material3.Text(
+        text = symbol.iconName,
+        modifier = modifier.size(size),
+        color = tint,
+        fontFamily = fontFamily,
+        fontSize = fontSize,
+        textAlign = TextAlign.Center,
+        maxLines = 1
+    )
+}
+
+@Composable
+private fun rememberMaterialSymbolsFont(
+    filled: Boolean,
+    weight: Int
+): FontFamily {
+    return remember(filled, weight) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            FontFamily(
+                Font(
+                    R.font.material_symbols_outlined,
+                    variationSettings = FontVariation.Settings(
+                        FontVariation.Setting("FILL", if (filled) 1f else 0f),
+                        FontVariation.Setting("wght", weight.toFloat()),
+                        FontVariation.Setting("GRAD", 0f),
+                        FontVariation.Setting("opsz", 24f)
+                    )
+                )
+            )
+        } else {
+            // Fallback for API < 26 - variable font settings not supported
+            FontFamily(Font(R.font.material_symbols_outlined))
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -88,7 +88,6 @@ compose-ui-util = { group = "androidx.compose.ui", name = "ui-util", version.ref
 compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "compose" }
 compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "compose" }
 compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "compose-material3" }
-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version = "1.7.8" }
 
 play-services-ads = { module = "com.google.android.gms:play-services-ads", version.ref = "playServicesAds" }
 user-messaging-platform = { module = "com.google.android.ump:user-messaging-platform", version.ref = "userMessagingPlatform" }


### PR DESCRIPTION
## Summary
- Replaced deprecated `compose-material-icons-extended` with Google Fonts Material Symbols variable font
- Added `MaterialSymbol` enum with all 11 icons used in the app
- Created `MaterialSymbolIcon` composable with support for variable font axes (fill, weight) on API 26+

## Test plan
- Verify all icon renders correctly in navigation bar, screens, and buttons
- Test icon state changes (filled/unfilled for Favorite icon)
- Confirm no old Material Icons imports remain
- Build should succeed once `google-services.json` is provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)