### PR TITLE
Add adaptive navigation and grid layouts

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,6 +91,7 @@ dependencies {
     implementation(libs.compose.ui.util)
     implementation(libs.compose.foundation)
     implementation(libs.compose.material3)
+    implementation(libs.compose.material3.adaptive.navigation.suite)
     implementation(libs.compose.ui.tooling)
 
     implementation libs.navigation.compose

--- a/app/src/main/java/com/sirelon/marsroverphotos/feature/favorite/FavoriteScreen.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/feature/favorite/FavoriteScreen.kt
@@ -40,6 +40,7 @@ import com.sirelon.marsroverphotos.storage.Prefs
 import com.sirelon.marsroverphotos.ui.CenteredProgress
 import com.sirelon.marsroverphotos.ui.MaterialSymbol
 import com.sirelon.marsroverphotos.ui.MaterialSymbolIcon
+import com.sirelon.marsroverphotos.ui.calculateAdaptiveColumns
 import java.util.UUID
 
 /**
@@ -150,13 +151,14 @@ fun FavoritePhotosContent(
         }
 
         val spacedBy = Arrangement.spacedBy(16.dp)
+        val adaptiveColumns = calculateAdaptiveColumns(minColumnWidth = 160.dp)
         LazyVerticalStaggeredGrid(
             modifier = modifier
                 .weight(1f)
                 .nestedScroll(scrollBehavior.nestedScrollConnection),
             contentPadding = PaddingValues(16.dp),
             columns = if (gridView) {
-                StaggeredGridCells.Fixed(2)
+                StaggeredGridCells.Fixed(adaptiveColumns)
             } else {
                 StaggeredGridCells.Fixed(1)
             },

--- a/app/src/main/java/com/sirelon/marsroverphotos/feature/photos/RoverPhotosScreen.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/feature/photos/RoverPhotosScreen.kt
@@ -59,6 +59,7 @@ import com.sirelon.marsroverphotos.storage.MarsImage
 import com.sirelon.marsroverphotos.ui.CenteredProgress
 import com.sirelon.marsroverphotos.ui.MaterialSymbol
 import com.sirelon.marsroverphotos.ui.MaterialSymbolIcon
+import com.sirelon.marsroverphotos.ui.adaptiveGridCells
 import java.util.Calendar
 import java.util.TimeZone
 
@@ -186,7 +187,7 @@ private fun PhotosList(
     onPhotoClick: (image: MarsImage) -> Unit
 ) {
 
-    LazyVerticalGrid(columns = GridCells.Fixed(2), modifier = modifier) {
+    LazyVerticalGrid(columns = adaptiveGridCells(minColumnWidth = 160.dp), modifier = modifier) {
         items(
             photos,
             key = { it.id },

--- a/app/src/main/java/com/sirelon/marsroverphotos/feature/rovers/RoversActivity.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/feature/rovers/RoversActivity.kt
@@ -248,8 +248,13 @@ class RoversActivity : FragmentActivity() {
                             }
                         }
                     }
-                ) {
-                    Column(modifier = Modifier.fillMaxSize()) {
+                ) { paddingValues ->
+                    val contentModifier = if (hideUI) {
+                        Modifier.fillMaxSize()
+                    } else {
+                        Modifier.fillMaxSize().padding(paddingValues)
+                    }
+                    Column(modifier = contentModifier) {
                         // Ukraine banner
                         AnimatedVisibility(
                             visible = !hideUI,

--- a/app/src/main/java/com/sirelon/marsroverphotos/feature/rovers/RoversActivity.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/feature/rovers/RoversActivity.kt
@@ -59,12 +59,10 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -217,16 +215,16 @@ class RoversActivity : FragmentActivity() {
                                                 imageVector = ImageVector.vectorResource(id = R.drawable.ic_rovers),
                                                 contentDescription = null
                                             )
-                                            RoversDestination.Favorite -> Icon(
-                                                imageVector = Icons.Outlined.Favorite,
+                                            RoversDestination.Favorite -> MaterialSymbolIcon(
+                                                symbol = MaterialSymbol.Favorite,
                                                 contentDescription = null
                                             )
-                                            RoversDestination.Popular -> Icon(
-                                                imageVector = Icons.Outlined.LocalFireDepartment,
+                                            RoversDestination.Popular -> MaterialSymbolIcon(
+                                                symbol = MaterialSymbol.LocalFireDepartment,
                                                 contentDescription = null
                                             )
-                                            RoversDestination.About -> Icon(
-                                                imageVector = Icons.Outlined.Info,
+                                            RoversDestination.About -> MaterialSymbolIcon(
+                                                symbol = MaterialSymbol.Info,
                                                 contentDescription = null
                                             )
                                         }

--- a/app/src/main/java/com/sirelon/marsroverphotos/ui/AdaptiveLayout.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/ui/AdaptiveLayout.kt
@@ -1,0 +1,55 @@
+package com.sirelon.marsroverphotos.ui
+
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Calculates the number of grid columns based on screen width.
+ * - Phones portrait: 2 columns
+ * - Phones landscape: 3-4 columns
+ * - Tablets portrait: 3-4 columns
+ * - Tablets landscape: 4-6 columns
+ */
+@Composable
+fun rememberAdaptiveGridColumns(minColumnWidth: Dp = 160.dp): GridCells {
+    val configuration = LocalConfiguration.current
+    val screenWidthDp = configuration.screenWidthDp.dp
+
+    // Calculate columns based on minimum column width
+    val columns = (screenWidthDp / minColumnWidth).toInt().coerceAtLeast(2)
+
+    return GridCells.Fixed(columns)
+}
+
+/**
+ * Returns the number of columns as an Int for use with Adaptive grid cells.
+ * Useful for LazyVerticalGrid with GridCells.Adaptive.
+ */
+@Composable
+fun calculateAdaptiveColumns(minColumnWidth: Dp = 160.dp): Int {
+    val configuration = LocalConfiguration.current
+    val screenWidthDp = configuration.screenWidthDp.dp
+
+    return (screenWidthDp / minColumnWidth).toInt().coerceAtLeast(2)
+}
+
+/**
+ * Determines if the device is in landscape mode.
+ */
+@Composable
+fun isLandscape(): Boolean {
+    val configuration = LocalConfiguration.current
+    return configuration.screenWidthDp > configuration.screenHeightDp
+}
+
+/**
+ * Returns an adaptive grid cells based on minimum column width.
+ * This allows the grid to automatically adjust columns based on available space.
+ */
+@Composable
+fun adaptiveGridCells(minColumnWidth: Dp = 160.dp): GridCells {
+    return GridCells.Adaptive(minColumnWidth)
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,10 @@
     <string name="no_photos_title">Rover didn\'t take any photos at this date.</string>
     <string name="favorite_empty_btn">Go to rovers</string>
     <string name="favorite_empty_title">No favourite photos yet. \nYou can save any photos which you like. \nJust mark them as "favourite".</string>
+
+    <!-- Navigation labels -->
+    <string name="nav_rovers">Rovers</string>
+    <string name="nav_favorite">Favorites</string>
+    <string name="nav_popular">Popular</string>
+    <string name="nav_about">About</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ lifecycle = "2.10.0"
 compose = "1.10.0"
 # https://developer.android.com/jetpack/androidx/releases/compose-material3
 compose-material3 = "1.4.0"
+compose-material3-adaptive-navigation-suite = "1.3.0"
 mockito = "1.6.0"
 # https://developer.android.com/jetpack/androidx/releases/paging
 paging = "3.3.6"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ lifecycle = "2.9.3"
 compose = "1.9.1"
 # https://developer.android.com/jetpack/androidx/releases/compose-material3
 compose-material3 = "1.4.0-rc01"
+compose-material3-adaptive-navigation-suite = "1.5.0-alpha11"
 mockito = "1.6.0"
 # https://developer.android.com/jetpack/androidx/releases/paging
 paging = "3.3.6"
@@ -85,6 +86,7 @@ compose-ui-util = { group = "androidx.compose.ui", name = "ui-util", version.ref
 compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "compose" }
 compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "compose" }
 compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "compose-material3" }
+compose-material3-adaptive-navigation-suite = { group = "androidx.compose.material3", name = "material3-adaptive-navigation-suite", version.ref = "compose-material3-adaptive-navigation-suite" }
 
 play-services-ads = { module = "com.google.android.gms:play-services-ads", version.ref = "playServicesAds" }
 user-messaging-platform = { module = "com.google.android.ump:user-messaging-platform", version.ref = "userMessagingPlatform" }


### PR DESCRIPTION
Add Material3 adaptive navigation suite and labels. Update rover/favorites/photo grids to adapt to screen width. Apply scaffold padding only when UI chrome is visible to preserve full-screen mode.