### PR TITLE
Fix analytics tracking compatibility

### DIFF
--- a/app/src/main/java/com/sirelon/marsroverphotos/DataManager.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/DataManager.kt
@@ -2,7 +2,6 @@ package com.sirelon.marsroverphotos
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.os.Bundle
 import com.sirelon.marsroverphotos.feature.images.ImagesRepository
 import com.sirelon.marsroverphotos.feature.photos.PhotosRepository
 import com.sirelon.marsroverphotos.feature.rovers.InsightId
@@ -11,6 +10,9 @@ import com.sirelon.marsroverphotos.firebase.photos.FirebaseProvider.firebasePhot
 import com.sirelon.marsroverphotos.network.RestApi
 import com.sirelon.marsroverphotos.storage.MarsImage
 import com.sirelon.marsroverphotos.tracker.ITracker
+import com.sirelon.marsroverphotos.tracker.normalizeClickEventName
+import com.sirelon.marsroverphotos.tracker.normalizeEventName
+import com.sirelon.marsroverphotos.tracker.toAnalyticsBundle
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -63,16 +65,13 @@ class DataManager(
     }
 
     fun trackClick(event: String) {
-        tracker.trackClick("click_$event")
+        tracker.trackClick(normalizeClickEventName(event))
     }
 
     fun trackEvent(event: String, params: Map<String, Any?> = emptyMap()) {
-        Timber.d("trackEvent() called with: event = $event, params = $params")
-        val bundle = Bundle()
-
-        params.forEach { bundle.putString(it.key, it.value.toString()) }
-
-        tracker.trackEvent(event, bundle)
+        val normalizedEvent = normalizeEventName(event)
+        Timber.d("trackEvent() called with: event = $event, normalized = $normalizedEvent, params = $params")
+        tracker.trackEvent(normalizedEvent, params.toAnalyticsBundle())
     }
 
     suspend fun cacheImages(photos: List<MarsImage>) {

--- a/app/src/main/java/com/sirelon/marsroverphotos/feature/images/ImageViewModel.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/feature/images/ImageViewModel.kt
@@ -173,7 +173,7 @@ class ImageViewModel(app: Application) : AndroidViewModel(app),
 
     fun trackSaveClick() {
         if (shouldTrack) {
-            getApplication<RoverApplication>().tracker.trackClick("save")
+            RoverApplication.APP.dataManger.trackClick("save")
         }
     }
 
@@ -194,7 +194,7 @@ class ImageViewModel(app: Application) : AndroidViewModel(app),
     fun shareMarsImage(marsImage: MarsImage) {
         val application = getApplication<RoverApplication>()
         if (shouldTrack) {
-            application.tracker.trackClick("share")
+            RoverApplication.APP.dataManger.trackClick("share")
         }
 
         viewModelScope.launch(io) {

--- a/app/src/main/java/com/sirelon/marsroverphotos/feature/rovers/RoversActivity.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/feature/rovers/RoversActivity.kt
@@ -275,7 +275,7 @@ class RoversActivity : FragmentActivity() {
                             exit = fadeOut() + shrinkVertically(),
                         ) {
                             UkraineBanner(modifier = Modifier.statusBarsPadding()) {
-                                RoverApplication.APP.tracker.trackClick("UkraineBanner_Top")
+                                RoverApplication.APP.dataManger.trackClick("UkraineBanner_Top")
                                 navState.push(RoversDestination.Ukraine, singleTop = true)
                             }
                         }

--- a/app/src/main/java/com/sirelon/marsroverphotos/feature/ukraine/Ukraine.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/feature/ukraine/Ukraine.kt
@@ -42,7 +42,7 @@ fun UkraineInfoScreen() {
         }
 
         UkraineBanner(title = "Glory to Ukraine") {
-            RoverApplication.APP.tracker.trackClick("UkraineBanner_Bottom")
+            RoverApplication.APP.dataManger.trackClick("UkraineBanner_Bottom")
             // Open twitter
             try {
                 uriHandler.openUri("twitter://search?query=%23StandWithUkraine")
@@ -72,7 +72,7 @@ private fun UkraineInfoContent(uriHandler: androidx.compose.ui.platform.UriHandl
 
         TextButton(
             onClick = {
-                RoverApplication.APP.tracker.trackClick("Ukraine_wiki")
+                RoverApplication.APP.dataManger.trackClick("Ukraine_wiki")
                 uriHandler.openUri("https://en.wikipedia.org/wiki/Rashism")
             }) {
             Text(text = "rashism.")
@@ -87,7 +87,7 @@ private fun UkraineInfoContent(uriHandler: androidx.compose.ui.platform.UriHandl
         Text(text = "Don't just scroll past this. Remember us. We need your unwavering support as the war rages on. We're fighting for democracy, for our lives, and for a better future for everyone.")
         Text(text = "For more gritty details and stories of resilience from Ukrainian heroes, check out ")
         TextButton(onClick = {
-            RoverApplication.APP.tracker.trackClick("Ukraine_site")
+            RoverApplication.APP.dataManger.trackClick("Ukraine_site")
             uriHandler.openUri("https://war.ukraine.ua/")
         }) {
             Text(text = "https://war.ukraine.ua/")
@@ -95,7 +95,7 @@ private fun UkraineInfoContent(uriHandler: androidx.compose.ui.platform.UriHandl
         Text(text = "If you have any question, reach me via email ")
 
         TextButton(onClick = {
-            RoverApplication.APP.tracker.trackClick("Ukraine_mail")
+            RoverApplication.APP.dataManger.trackClick("Ukraine_mail")
             uriHandler.openUri("mailto:sasha.sirelon@gmail.com")
         }) {
             Text(text = "sasha.sirelon@gmail.com")

--- a/app/src/main/java/com/sirelon/marsroverphotos/tracker/AnalyticsUtils.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/tracker/AnalyticsUtils.kt
@@ -1,0 +1,62 @@
+package com.sirelon.marsroverphotos.tracker
+
+import android.os.Bundle
+
+private const val MAX_ANALYTICS_NAME_LENGTH = 40
+
+internal fun normalizeClickEventName(rawEvent: String): String {
+    val trimmed = rawEvent.trim()
+    if (trimmed.isEmpty()) return "click"
+    return if (trimmed.startsWith("click_", ignoreCase = true)) {
+        trimmed
+    } else {
+        "click_$trimmed"
+    }
+}
+
+internal fun normalizeEventName(rawEvent: String): String =
+    normalizeAnalyticsName(rawEvent, "event")
+
+internal fun normalizeParamName(rawParam: String): String =
+    normalizeAnalyticsName(rawParam, "param")
+
+internal fun Map<String, Any?>.toAnalyticsBundle(): Bundle {
+    val bundle = Bundle()
+    forEach { (key, value) ->
+        val normalizedKey = normalizeParamName(key)
+        when (value) {
+            null -> Unit
+            is String -> bundle.putString(normalizedKey, value)
+            is CharSequence -> bundle.putString(normalizedKey, value.toString())
+            is Boolean -> bundle.putLong(normalizedKey, if (value) 1L else 0L)
+            is Byte -> bundle.putLong(normalizedKey, value.toLong())
+            is Short -> bundle.putLong(normalizedKey, value.toLong())
+            is Int -> bundle.putLong(normalizedKey, value.toLong())
+            is Long -> bundle.putLong(normalizedKey, value)
+            is Float -> bundle.putDouble(normalizedKey, value.toDouble())
+            is Double -> bundle.putDouble(normalizedKey, value)
+            is Number -> bundle.putDouble(normalizedKey, value.toDouble())
+            else -> bundle.putString(normalizedKey, value.toString())
+        }
+    }
+    return bundle
+}
+
+private fun normalizeAnalyticsName(rawValue: String, fallbackPrefix: String): String {
+    val normalized = rawValue
+        .trim()
+        .replace(Regex("([a-z0-9])([A-Z])"), "$1_$2")
+        .lowercase()
+        .replace(Regex("[^a-z0-9_]"), "_")
+        .replace(Regex("_+"), "_")
+        .trim('_')
+        .ifEmpty { "${fallbackPrefix}_unknown" }
+
+    val withPrefix = if (normalized.first().isLetter()) {
+        normalized
+    } else {
+        "${fallbackPrefix}_$normalized"
+    }
+
+    return withPrefix.take(MAX_ANALYTICS_NAME_LENGTH)
+}

--- a/app/src/main/java/com/sirelon/marsroverphotos/tracker/FirebaseTracker.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/tracker/FirebaseTracker.kt
@@ -16,6 +16,7 @@ class FirebaseTracker(context: Context) : ITracker {
     companion object {
         private const val EARTH_DATE: String = "earthDate"
         private const val SCREEN_NAME: String = "screenName"
+        private const val SHARE_PACKAGE: String = "sharePackage"
         private const val EVENT_MARS_PHOTO_SCALE: String = "Scale"
         private const val EVENT_MARS_PHOTO_SHARE: String = "SharePhoto"
         private const val EVENT_MARS_PHOTO_SAVE: String = "SavePhoto"
@@ -32,7 +33,9 @@ class FirebaseTracker(context: Context) : ITracker {
     }
 
     override fun trackShare(photo: MarsImage, packageName: String) {
-        fb.logEvent(EVENT_MARS_PHOTO_SHARE, photo.arguments())
+        val arguments = photo.arguments()
+        arguments.putString(SHARE_PACKAGE, packageName)
+        fb.logEvent(EVENT_MARS_PHOTO_SHARE, arguments)
     }
 
     override fun trackSave(photo: MarsImage) {
@@ -44,7 +47,7 @@ class FirebaseTracker(context: Context) : ITracker {
     }
 
     override fun trackEvent(event: String, params: Bundle) {
-        fb.logEvent(event, null)
+        fb.logEvent(event, params)
     }
 
     override fun trackFavorite(photo: MarsImage, from: String, fav: Boolean) {

--- a/app/src/main/java/com/sirelon/marsroverphotos/tracker/FullscreenImageTracker.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/tracker/FullscreenImageTracker.kt
@@ -57,7 +57,7 @@ class FullscreenImageTracker : MultitouchDetectorCallback {
     override var currentImage: MarsImage? = null
     override fun onTap() {
         Timber.d("onTap() called")
-        tracker.trackClick("tap_fullscreen_photo")
+        dataManager.trackClick("tap_fullscreen_photo")
     }
 
     override fun onDoubleTap(zoomToChange: Float) {


### PR DESCRIPTION
Normalize click events without changing legacy names and coerce analytics params to Firebase-supported types. Add share package logging and route click tracking through DataManager.