### PR TITLE
Add AndroidX NavigationEvent with PredictiveBack support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -98,6 +98,8 @@ dependencies {
     implementation libs.navigation3.runtime
     implementation libs.navigation3.ui
     implementation libs.lifecycle.viewmodel.navigation3
+    implementation libs.navigationevent
+    implementation libs.navigationevent.compose
     implementation libs.koin.android
     implementation libs.koin.androidx.compose
     implementation libs.koin.compose.navigation3

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <application
         android:name=".RoverApplication"
         android:allowBackup="false"
+        android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,6 +44,8 @@ zoomable = "2.9.0"
 # https://developer.android.com/jetpack/androidx/releases/navigation3
 navigation3 = "1.0.0"
 lifecycle-navigation3 = "2.10.0"
+# https://developer.android.com/jetpack/androidx/releases/navigationevent
+navigationevent = "1.0.1"
 androidGradlePlugin = "8.13.2"
 
 [libraries]
@@ -87,6 +89,8 @@ androidx-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-com
 navigation3-runtime = { group = "androidx.navigation3", name = "navigation3-runtime", version.ref = "navigation3" }
 navigation3-ui = { group = "androidx.navigation3", name = "navigation3-ui", version.ref = "navigation3" }
 lifecycle-viewmodel-navigation3 = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-navigation3", version.ref = "lifecycle-navigation3" }
+navigationevent = { group = "androidx.navigationevent", name = "navigationevent", version.ref = "navigationevent" }
+navigationevent-compose = { group = "androidx.navigationevent", name = "navigationevent-compose", version.ref = "navigationevent" }
 mockito-kotlin = { module = "com.nhaarman:mockito-kotlin", version.ref = "mockito" }
 
 compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "compose" }


### PR DESCRIPTION
## Summary
Integrate the AndroidX NavigationEvent library to add predictive back gesture support with visual feedback during back navigation. Replaces the basic BackHandler with NavigationBackHandler for a modern Android 13+ UX.

## Changes
- Add navigationevent and navigationevent-compose dependencies (1.0.1 stable)
- Enable predictive back callback in AndroidManifest for Android 13-14
- Replace BackHandler with NavigationBackHandler for gesture progress support
- Add RoversNavigationInfo class for navigation state debugging

## Benefits
- Predictive back gestures match Android system behavior
- Users see preview of where they'll land before completing gesture
- Gracefully falls back to regular back on Android 12 and below

🤖 Generated with [Claude Code](https://claude.com/claude-code)