### PR TITLE
Add Mars photo home screen widget

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -127,6 +127,8 @@ dependencies {
     implementation(libs.coil.network)
     implementation libs.androidx.appcompat
 
+    implementation libs.androidx.glance.appwidget
+
     implementation libs.ktor.core
     implementation libs.ktor.client.okhttp
     implementation libs.ktor.client.content.negotiation

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,27 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".widget.MarsPhotoWidgetConfigActivity"
+            android:exported="true"
+            android:theme="@style/Theme.AppCompat.DayNight.NoActionBar">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
+            </intent-filter>
+        </activity>
+
+        <receiver
+            android:name=".widget.MarsPhotoWidgetReceiver"
+            android:exported="true"
+            android:permission="android.permission.BIND_APPWIDGET">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/mars_photo_widget_info" />
+        </receiver>
+
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
             android:value="@string/ad_application_id" />

--- a/app/src/main/java/com/sirelon/marsroverphotos/network/RestApi.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/network/RestApi.kt
@@ -100,4 +100,14 @@ class RestApi {
 
     suspend fun getRoverInfo(roverName: String): RoverInfo =
         nasaApi.getRoverInfo(roverName).roverInfo
+
+    suspend fun getInsightLatestPhotos(): List<MarsImage> {
+        return nasaApi.getInsightRawImages().list.mapToUi()
+    }
+
+    suspend fun getPerseveranceLatestPhotos(count: Int = 1): List<MarsImage> {
+        val response = nasaApi.getPerseveranceRawImages(count = count)
+        _perseveranceTotalImages.value = response.totalImages
+        return response.photos.preveranceToUI()
+    }
 }

--- a/app/src/main/java/com/sirelon/marsroverphotos/widget/MarsPhotoWidget.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/widget/MarsPhotoWidget.kt
@@ -1,0 +1,189 @@
+package com.sirelon.marsroverphotos.widget
+
+import android.content.Intent
+import android.graphics.BitmapFactory
+import androidx.compose.runtime.Composable
+import androidx.glance.GlanceModifier
+import androidx.glance.Image
+import androidx.glance.ImageProvider
+import androidx.glance.LocalContext
+import androidx.glance.LocalSize
+import androidx.glance.action.actionStartActivity
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.SizeMode
+import androidx.glance.appwidget.state.PreferencesGlanceStateDefinition
+import androidx.glance.background
+import androidx.glance.currentState
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
+import androidx.glance.layout.Column
+import androidx.glance.layout.ContentScale
+import androidx.glance.layout.align
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.padding
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
+import androidx.glance.unit.DpSize
+import androidx.glance.unit.dp
+import androidx.glance.unit.sp
+import androidx.glance.state.Preferences
+import androidx.glance.state.longPreferencesKey
+import androidx.glance.state.stringPreferencesKey
+import com.sirelon.marsroverphotos.feature.rovers.CuriosityId
+import com.sirelon.marsroverphotos.feature.rovers.InsightId
+import com.sirelon.marsroverphotos.feature.rovers.OpportunityId
+import com.sirelon.marsroverphotos.feature.rovers.PerserveranceId
+import com.sirelon.marsroverphotos.feature.rovers.SpiritId
+import com.sirelon.marsroverphotos.feature.rovers.RoversActivity
+import java.io.File
+
+internal const val WidgetExtraImageId = "com.sirelon.marsroverphotos.widget.EXTRA_IMAGE_ID"
+
+internal object MarsPhotoWidgetState {
+    val roverIdKey = longPreferencesKey("mars_widget_rover_id")
+    val imagePathKey = stringPreferencesKey("mars_widget_image_path")
+    val imageIdKey = stringPreferencesKey("mars_widget_image_id")
+    val roverNameKey = stringPreferencesKey("mars_widget_rover_name")
+    val solKey = longPreferencesKey("mars_widget_sol")
+    val earthDateKey = stringPreferencesKey("mars_widget_earth_date")
+}
+
+internal const val DefaultRoverId = CuriosityId
+
+public class MarsPhotoWidget : GlanceAppWidget() {
+
+    override val stateDefinition = PreferencesGlanceStateDefinition
+
+    override val sizeMode: SizeMode = SizeMode.Responsive(
+        setOf(
+            DpSize(140.dp, 140.dp),
+            DpSize(200.dp, 140.dp),
+            DpSize(260.dp, 200.dp)
+        )
+    )
+
+    @Composable
+    override fun Content() {
+        val context = LocalContext.current
+        val state = currentState<Preferences>()
+        val configuredRoverId = state[MarsPhotoWidgetState.roverIdKey]
+        val roverId = configuredRoverId ?: DefaultRoverId
+        val hasConfiguredRover = configuredRoverId != null
+        val roverName = state[MarsPhotoWidgetState.roverNameKey] ?: roverNameForId(roverId)
+        val sol = state[MarsPhotoWidgetState.solKey] ?: 0L
+        val earthDate = state[MarsPhotoWidgetState.earthDateKey].orEmpty()
+        val imagePath = state[MarsPhotoWidgetState.imagePathKey]
+        val imageId = state[MarsPhotoWidgetState.imageIdKey]
+        val size = LocalSize.current
+
+        val imageProvider = imagePath?.let { path ->
+            val file = File(path)
+            if (file.exists()) {
+                BitmapFactory.decodeFile(file.absolutePath)?.let { bitmap ->
+                    ImageProvider(bitmap)
+                }
+            } else {
+                null
+            }
+        }
+
+        val launchIntent = Intent(context, RoversActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            if (!imageId.isNullOrBlank()) {
+                putExtra(WidgetExtraImageId, imageId)
+            }
+        }
+
+        val action = actionStartActivity(launchIntent)
+        val showDetails = size.width >= 200.dp && size.height >= 140.dp
+        val showOverlay = size.height >= 110.dp
+
+        Box(
+            modifier = GlanceModifier
+                .fillMaxSize()
+                .clickable(action)
+        ) {
+            if (imageProvider != null) {
+                Image(
+                    provider = imageProvider,
+                    contentDescription = roverName,
+                    modifier = GlanceModifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop
+                )
+            } else {
+                Box(
+                    modifier = GlanceModifier
+                        .fillMaxSize()
+                        .background(ColorProvider(androidx.compose.ui.graphics.Color(0xFF1A283D)))
+                ) {
+                    Text(
+                        text = if (hasConfiguredRover) "Updating photo" else "Select a rover",
+                        modifier = GlanceModifier
+                            .padding(12.dp)
+                            .align(Alignment.Center),
+                        style = TextStyle(
+                            color = ColorProvider(androidx.compose.ui.graphics.Color.White),
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 14.sp
+                        )
+                    )
+                }
+            }
+
+            if (showOverlay && imageProvider != null) {
+                Column(
+                    modifier = GlanceModifier
+                        .fillMaxWidth()
+                        .align(Alignment.BottomStart)
+                        .background(ColorProvider(androidx.compose.ui.graphics.Color(0xAA000000)))
+                        .padding(horizontal = 10.dp, vertical = 8.dp)
+                ) {
+                    Text(
+                        text = roverName,
+                        style = TextStyle(
+                            color = ColorProvider(androidx.compose.ui.graphics.Color.White),
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 14.sp
+                        )
+                    )
+                    if (showDetails) {
+                        val detail = if (sol > 0 && earthDate.isNotBlank()) {
+                            "Sol $sol - $earthDate"
+                        } else if (earthDate.isNotBlank()) {
+                            earthDate
+                        } else if (sol > 0) {
+                            "Sol $sol"
+                        } else {
+                            ""
+                        }
+                        if (detail.isNotBlank()) {
+                            Text(
+                                text = detail,
+                                style = TextStyle(
+                                    color = ColorProvider(androidx.compose.ui.graphics.Color(0xFFE0E0E0)),
+                                    fontWeight = FontWeight.Normal,
+                                    fontSize = 12.sp
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+internal fun roverNameForId(roverId: Long): String {
+    return when (roverId) {
+        PerserveranceId -> "Perseverance"
+        InsightId -> "Insight"
+        OpportunityId -> "Opportunity"
+        SpiritId -> "Spirit"
+        CuriosityId -> "Curiosity"
+        else -> "Mars Rover"
+    }
+}

--- a/app/src/main/java/com/sirelon/marsroverphotos/widget/MarsPhotoWidgetConfigActivity.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/widget/MarsPhotoWidgetConfigActivity.kt
@@ -1,0 +1,194 @@
+package com.sirelon.marsroverphotos.widget
+
+import android.app.Activity
+import android.appwidget.AppWidgetManager
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.weight
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.glance.appwidget.GlanceAppWidgetManager
+import androidx.glance.appwidget.state.PreferencesGlanceStateDefinition
+import androidx.glance.appwidget.state.getAppWidgetState
+import androidx.glance.appwidget.state.updateAppWidgetState
+import androidx.lifecycle.lifecycleScope
+import com.sirelon.marsroverphotos.feature.rovers.CuriosityId
+import com.sirelon.marsroverphotos.feature.rovers.InsightId
+import com.sirelon.marsroverphotos.feature.rovers.OpportunityId
+import com.sirelon.marsroverphotos.feature.rovers.PerserveranceId
+import com.sirelon.marsroverphotos.feature.rovers.SpiritId
+import com.sirelon.marsroverphotos.ui.MarsRoverPhotosTheme
+import kotlinx.coroutines.launch
+
+public class MarsPhotoWidgetConfigActivity : ComponentActivity() {
+
+    private var appWidgetId: Int = AppWidgetManager.INVALID_APPWIDGET_ID
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setResult(Activity.RESULT_CANCELED)
+
+        appWidgetId = intent?.getIntExtra(
+            AppWidgetManager.EXTRA_APPWIDGET_ID,
+            AppWidgetManager.INVALID_APPWIDGET_ID
+        ) ?: AppWidgetManager.INVALID_APPWIDGET_ID
+
+        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+            finish()
+            return
+        }
+
+        setContent {
+            MarsRoverPhotosTheme {
+                WidgetConfigScreen(
+                    appWidgetId = appWidgetId,
+                    onConfirm = { roverId ->
+                        saveSelection(roverId)
+                    }
+                )
+            }
+        }
+    }
+
+    private fun saveSelection(roverId: Long) {
+        lifecycleScope.launch {
+            val manager = GlanceAppWidgetManager(this@MarsPhotoWidgetConfigActivity)
+            val glanceId = manager.getGlanceIdBy(appWidgetId)
+
+            updateAppWidgetState(this@MarsPhotoWidgetConfigActivity, glanceId, PreferencesGlanceStateDefinition) { prefs ->
+                prefs[MarsPhotoWidgetState.roverIdKey] = roverId
+                prefs[MarsPhotoWidgetState.roverNameKey] = roverNameForId(roverId)
+                prefs.remove(MarsPhotoWidgetState.imagePathKey)
+                prefs.remove(MarsPhotoWidgetState.imageIdKey)
+                prefs.remove(MarsPhotoWidgetState.solKey)
+                prefs.remove(MarsPhotoWidgetState.earthDateKey)
+            }
+
+            MarsPhotoWidget().update(this@MarsPhotoWidgetConfigActivity, glanceId)
+            MarsPhotoWidgetWorker.enqueueOnce(this@MarsPhotoWidgetConfigActivity)
+            MarsPhotoWidgetWorker.enqueuePeriodic(this@MarsPhotoWidgetConfigActivity)
+
+            val resultValue = Intent().apply {
+                putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+            }
+            setResult(Activity.RESULT_OK, resultValue)
+            finish()
+        }
+    }
+}
+
+@Composable
+private fun WidgetConfigScreen(
+    appWidgetId: Int,
+    onConfirm: (Long) -> Unit
+) {
+    val context = LocalContext.current
+    val roverOptions = remember {
+        listOf(
+            RoverOption(PerserveranceId, "Perseverance"),
+            RoverOption(CuriosityId, "Curiosity"),
+            RoverOption(OpportunityId, "Opportunity"),
+            RoverOption(SpiritId, "Spirit"),
+            RoverOption(InsightId, "Insight")
+        )
+    }
+    var selectedId by remember { mutableStateOf(DefaultRoverId) }
+
+    LaunchedEffect(appWidgetId) {
+        val manager = GlanceAppWidgetManager(context)
+        val glanceId = manager.getGlanceIdBy(appWidgetId)
+        val prefs = getAppWidgetState(context, glanceId, PreferencesGlanceStateDefinition)
+        selectedId = prefs[MarsPhotoWidgetState.roverIdKey] ?: DefaultRoverId
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(text = "Choose rover") })
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.SpaceBetween
+        ) {
+            LazyColumn(
+                modifier = Modifier.weight(1f, fill = false)
+            ) {
+                items(roverOptions) { option ->
+                    RoverRow(
+                        option = option,
+                        selected = option.id == selectedId,
+                        onClick = { selectedId = option.id }
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Button(
+                onClick = { onConfirm(selectedId) },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(text = "Add widget")
+            }
+        }
+    }
+}
+
+@Composable
+private fun RoverRow(
+    option: RoverOption,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        RadioButton(selected = selected, onClick = onClick)
+        Spacer(modifier = Modifier.width(12.dp))
+        Column {
+            Text(text = option.name, style = MaterialTheme.typography.bodyLarge)
+            Text(text = "Latest photo", style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}
+
+private data class RoverOption(
+    val id: Long,
+    val name: String
+)

--- a/app/src/main/java/com/sirelon/marsroverphotos/widget/MarsPhotoWidgetReceiver.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/widget/MarsPhotoWidgetReceiver.kt
@@ -1,0 +1,26 @@
+package com.sirelon.marsroverphotos.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+
+public class MarsPhotoWidgetReceiver : GlanceAppWidgetReceiver() {
+
+    override val glanceAppWidget = MarsPhotoWidget()
+
+    override fun onEnabled(context: Context) {
+        super.onEnabled(context)
+        MarsPhotoWidgetWorker.enqueuePeriodic(context)
+        MarsPhotoWidgetWorker.enqueueOnce(context)
+    }
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray
+    ) {
+        super.onUpdate(context, appWidgetManager, appWidgetIds)
+        MarsPhotoWidgetWorker.enqueuePeriodic(context)
+        MarsPhotoWidgetWorker.enqueueOnce(context)
+    }
+}

--- a/app/src/main/java/com/sirelon/marsroverphotos/widget/MarsPhotoWidgetWorker.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/widget/MarsPhotoWidgetWorker.kt
@@ -1,0 +1,199 @@
+package com.sirelon.marsroverphotos.widget
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import androidx.glance.appwidget.GlanceAppWidgetManager
+import androidx.glance.appwidget.state.PreferencesGlanceStateDefinition
+import androidx.glance.appwidget.state.getAppWidgetState
+import androidx.glance.appwidget.state.updateAppWidgetState
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import coil3.ImageLoader
+import coil3.request.ImageRequest
+import com.sirelon.marsroverphotos.feature.images.ImagesRepository
+import com.sirelon.marsroverphotos.feature.rovers.CuriosityId
+import com.sirelon.marsroverphotos.feature.rovers.InsightId
+import com.sirelon.marsroverphotos.feature.rovers.OpportunityId
+import com.sirelon.marsroverphotos.feature.rovers.PerserveranceId
+import com.sirelon.marsroverphotos.feature.rovers.SpiritId
+import com.sirelon.marsroverphotos.models.PhotosQueryRequest
+import com.sirelon.marsroverphotos.network.RestApi
+import com.sirelon.marsroverphotos.storage.MarsImage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.io.File
+import java.io.FileOutputStream
+import java.util.concurrent.TimeUnit
+
+public class MarsPhotoWidgetWorker(
+    context: Context,
+    params: WorkerParameters
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        val glanceManager = GlanceAppWidgetManager(applicationContext)
+        val glanceIds = glanceManager.getGlanceIds(MarsPhotoWidget::class.java)
+        if (glanceIds.isEmpty()) {
+            return Result.success()
+        }
+
+        val api = RestApi()
+        val imagesRepository = ImagesRepository(applicationContext)
+        val widgetDir = File(applicationContext.cacheDir, "mars_widget")
+
+        var updatedCount = 0
+        var hadFailure = false
+
+        glanceIds.forEach { glanceId ->
+            val state = getAppWidgetState(applicationContext, glanceId, PreferencesGlanceStateDefinition)
+            val roverId = state[MarsPhotoWidgetState.roverIdKey] ?: DefaultRoverId
+
+            val latestPhoto = try {
+                fetchLatestPhoto(api, roverId)
+            } catch (error: Exception) {
+                hadFailure = true
+                Timber.e(error, "Failed to load latest photo for rover $roverId")
+                null
+            }
+
+            if (latestPhoto == null) {
+                return@forEach
+            }
+
+            val bitmap = loadBitmap(applicationContext, latestPhoto.imageUrl)
+            val imagePath = bitmap?.let { saveBitmap(widgetDir, glanceId.hashCode().toString(), it) }
+
+            try {
+                imagesRepository.saveImages(listOf(latestPhoto))
+                if (imagePath == null) {
+                    hadFailure = true
+                    return@forEach
+                }
+                updateAppWidgetState(applicationContext, glanceId, PreferencesGlanceStateDefinition) { prefs ->
+                    prefs[MarsPhotoWidgetState.roverIdKey] = roverId
+                    prefs[MarsPhotoWidgetState.roverNameKey] = roverNameForId(roverId)
+                    prefs[MarsPhotoWidgetState.imageIdKey] = latestPhoto.id
+                    prefs[MarsPhotoWidgetState.solKey] = latestPhoto.sol
+                    prefs[MarsPhotoWidgetState.earthDateKey] = latestPhoto.earthDate
+                    prefs[MarsPhotoWidgetState.imagePathKey] = imagePath
+                }
+                MarsPhotoWidget().update(applicationContext, glanceId)
+                updatedCount += 1
+            } catch (error: Exception) {
+                hadFailure = true
+                Timber.e(error, "Failed to update widget state for rover $roverId")
+            }
+        }
+
+        return if (updatedCount == 0 && hadFailure) {
+            Result.retry()
+        } else {
+            Result.success()
+        }
+    }
+
+    private suspend fun fetchLatestPhoto(api: RestApi, roverId: Long): MarsImage? {
+        return when (roverId) {
+            InsightId -> api.getInsightLatestPhotos().firstOrNull()
+            PerserveranceId -> api.getPerseveranceLatestPhotos().firstOrNull()
+            CuriosityId, OpportunityId, SpiritId -> fetchLatestByManifest(api, roverId)
+            else -> fetchLatestByManifest(api, roverId)
+        }
+    }
+
+    private suspend fun fetchLatestByManifest(api: RestApi, roverId: Long): MarsImage? {
+        val roverName = when (roverId) {
+            CuriosityId -> "curiosity"
+            OpportunityId -> "opportunity"
+            SpiritId -> "spirit"
+            PerserveranceId -> "perseverance"
+            else -> "curiosity"
+        }
+        val roverInfo = api.getRoverInfo(roverName)
+        var sol = roverInfo.maxSol
+
+        repeat(MaxSolLookback) {
+            val photos = api.getRoversPhotos(PhotosQueryRequest(roverId, sol, null))
+            if (photos.isNotEmpty()) {
+                return photos.first()
+            }
+            sol -= 1
+            if (sol <= 0) {
+                return null
+            }
+        }
+        return null
+    }
+
+    private suspend fun loadBitmap(context: Context, url: String): Bitmap? = withContext(Dispatchers.IO) {
+        if (url.isBlank()) {
+            return@withContext null
+        }
+        val loader = ImageLoader(context)
+        val request = ImageRequest.Builder(context)
+            .data(url)
+            .allowHardware(false)
+            .size(640)
+            .build()
+        val result = loader.execute(request)
+        (result.drawable as? BitmapDrawable)?.bitmap
+    }
+
+    private fun saveBitmap(directory: File, key: String, bitmap: Bitmap): String? {
+        if (!directory.exists() && !directory.mkdirs()) {
+            return null
+        }
+        val file = File(directory, "mars_photo_widget_$key.png")
+        FileOutputStream(file).use { out ->
+            bitmap.compress(Bitmap.CompressFormat.PNG, 90, out)
+        }
+        return file.absolutePath
+    }
+
+    companion object {
+        private const val UniqueWorkName = "mars_photo_widget_daily"
+        private const val UniqueImmediateWork = "mars_photo_widget_now"
+        private const val MaxSolLookback = 30
+
+        fun enqueuePeriodic(context: Context) {
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build()
+
+            val request = PeriodicWorkRequestBuilder<MarsPhotoWidgetWorker>(1, TimeUnit.DAYS)
+                .setConstraints(constraints)
+                .build()
+
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                UniqueWorkName,
+                ExistingPeriodicWorkPolicy.UPDATE,
+                request
+            )
+        }
+
+        fun enqueueOnce(context: Context) {
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build()
+
+            val request = OneTimeWorkRequestBuilder<MarsPhotoWidgetWorker>()
+                .setConstraints(constraints)
+                .build()
+
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                UniqueImmediateWork,
+                ExistingWorkPolicy.REPLACE,
+                request
+            )
+        }
+    }
+}

--- a/app/src/main/res/xml/mars_photo_widget_info.xml
+++ b/app/src/main/res/xml/mars_photo_widget_info.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:configure="com.sirelon.marsroverphotos.widget.MarsPhotoWidgetConfigActivity"
+    android:initialLayout="@layout/glance_default_loading"
+    android:minHeight="110dp"
+    android:minWidth="180dp"
+    android:resizeMode="horizontal|vertical"
+    android:updatePeriodMillis="0"
+    android:widgetCategory="home_screen" />

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ compose = "1.10.0"
 # https://developer.android.com/jetpack/androidx/releases/compose-material3
 compose-material3 = "1.4.0"
 compose-material3-adaptive-navigation-suite = "1.3.0"
+glance = "1.0.0"
 mockito = "1.6.0"
 # https://developer.android.com/jetpack/androidx/releases/paging
 paging = "3.3.6"
@@ -54,6 +55,7 @@ androidx-activity-compose = { module = "androidx.activity:activity-compose", ver
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 androidx-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "ktx" }
+androidx-glance-appwidget = { module = "androidx.glance:glance-appwidget", version.ref = "glance" }
 
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }


### PR DESCRIPTION
Adds a Glance-based Mars photo widget with configuration flow and background refresh. Includes widget deep-link handling and wiring updates in the manifest/Gradle files. Tests not run (not requested).