### PR TITLE
Add Glance widget loading layout

### DIFF
--- a/app/src/main/res/layout/glance_default_loading.xml
+++ b/app/src/main/res/layout/glance_default_loading.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/glance_default_loading"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <ProgressBar
+        android:id="@+id/glance_default_loading_progress"
+        style="?android:attr/progressBarStyleLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center" />
+</FrameLayout>


### PR DESCRIPTION
Adds a minimal loading layout referenced by the widget provider XML to fix resource linking. This unblocks debug builds that were failing during aapt2 linking.