### PR TITLE
Add educational facts uploader

### DIFF
--- a/app/src/main/assets/facts/educational_facts.json
+++ b/app/src/main/assets/facts/educational_facts.json
@@ -1,0 +1,138 @@
+[
+  {
+    "id": "mars_red_planet",
+    "text": "Mars is called the Red Planet because iron minerals in its soil oxidize, giving it a rusty color."
+  },
+  {
+    "id": "mars_day_length",
+    "text": "A Martian day, called a sol, is about 24 hours and 39 minutes."
+  },
+  {
+    "id": "mars_moons",
+    "text": "Mars has two small moons: Phobos and Deimos."
+  },
+  {
+    "id": "mars_gravity",
+    "text": "Gravity on Mars is about 38 percent of Earth's gravity."
+  },
+  {
+    "id": "mars_size",
+    "text": "Mars is roughly half the diameter of Earth."
+  },
+  {
+    "id": "mars_atmosphere",
+    "text": "Mars has a thin atmosphere made mostly of carbon dioxide."
+  },
+  {
+    "id": "mars_polar_ice",
+    "text": "Mars has polar ice caps made of water ice and frozen carbon dioxide."
+  },
+  {
+    "id": "mars_seasons",
+    "text": "Mars has seasons because its axis is tilted, similar to Earth."
+  },
+  {
+    "id": "olympus_mons",
+    "text": "Olympus Mons is the largest volcano in the solar system."
+  },
+  {
+    "id": "valles_marineris",
+    "text": "Valles Marineris is a canyon system about 4,000 kilometers long."
+  },
+  {
+    "id": "mars_dust_storms",
+    "text": "Dust storms on Mars can grow large enough to cover the entire planet."
+  },
+  {
+    "id": "ancient_water",
+    "text": "Ancient river channels and lake beds suggest Mars once had liquid water on its surface."
+  },
+  {
+    "id": "sojourner_1997",
+    "text": "Sojourner, deployed by Mars Pathfinder in 1997, was the first rover to drive on Mars."
+  },
+  {
+    "id": "spirit_opportunity_2004",
+    "text": "Spirit and Opportunity landed in 2004 and explored opposite sides of Mars."
+  },
+  {
+    "id": "opportunity_long_life",
+    "text": "Opportunity operated for nearly 15 years and traveled over 45 kilometers."
+  },
+  {
+    "id": "curiosity_2012",
+    "text": "Curiosity landed in Gale Crater in 2012 to study Mars' habitability."
+  },
+  {
+    "id": "curiosity_sam",
+    "text": "Curiosity carries a chemistry lab called SAM to analyze rocks and gases."
+  },
+  {
+    "id": "perseverance_2021",
+    "text": "Perseverance landed in Jezero Crater in 2021 to collect rock samples for return to Earth."
+  },
+  {
+    "id": "perseverance_moxie",
+    "text": "Perseverance carries the MOXIE experiment, which demonstrated making oxygen from Mars' CO2 atmosphere."
+  },
+  {
+    "id": "ingenuity_first_flight",
+    "text": "Ingenuity achieved the first powered, controlled flight on another planet."
+  },
+  {
+    "id": "insight_interior",
+    "text": "InSight was a lander that studied Mars' interior using a seismometer."
+  },
+  {
+    "id": "rtg_power",
+    "text": "Curiosity and Perseverance use nuclear power sources called RTGs to keep working through dusty seasons."
+  },
+  {
+    "id": "solar_powered_rovers",
+    "text": "Spirit and Opportunity used solar panels for power."
+  },
+  {
+    "id": "cold_nights",
+    "text": "Mars is cold and dry; nighttime temperatures can drop below minus 100 degrees Celsius."
+  },
+  {
+    "id": "mars_sky",
+    "text": "Fine dust in the atmosphere gives the Martian sky a reddish tint."
+  },
+  {
+    "id": "largest_landforms",
+    "text": "Mars is home to the tallest mountain and some of the deepest canyons in the solar system."
+  },
+  {
+    "id": "tracks_last",
+    "text": "Rover tracks can persist for a long time because Mars has no rain to wash them away."
+  },
+  {
+    "id": "liquid_water_stability",
+    "text": "Mars' atmosphere is too thin for liquid water to remain stable on the surface for long."
+  },
+  {
+    "id": "mars_year",
+    "text": "A Mars year lasts about 687 Earth days."
+  },
+  {
+    "id": "stereo_cameras",
+    "text": "Many Mars rovers use stereo cameras to create 3D views of the terrain."
+  },
+  {
+    "id": "jezero_delta",
+    "text": "Jezero Crater contains an ancient river delta, making it a key site to search for past life."
+  },
+  {
+    "id": "gale_lake",
+    "text": "Curiosity found evidence that Gale Crater once held long-lived lakes."
+  },
+  {
+    "id": "opportunity_water_evidence",
+    "text": "Opportunity discovered evidence that water once flowed on the surface of Mars."
+  },
+  {
+    "id": "dust_devils",
+    "text": "Dust devils on Mars can clean solar panels and extend rover lifetimes."
+  }
+]

--- a/app/src/main/java/com/sirelon/marsroverphotos/firebase/facts/EducationalFactsUploader.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/firebase/facts/EducationalFactsUploader.kt
@@ -1,0 +1,312 @@
+package com.sirelon.marsroverphotos.firebase.facts
+
+import android.content.Context
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import timber.log.Timber
+
+/**
+ * Utility class for uploading educational facts from assets to Firebase Firestore.
+ *
+ * This is a one-time data seeding utility that reads facts from JSON files
+ * in the assets folder and uploads them to the "educational_facts" collection.
+ */
+internal class EducationalFactsUploader(private val context: Context) {
+
+    private val firestore = FirebaseFirestore.getInstance()
+    private val factsCollection = firestore.collection("educational_facts")
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    /**
+     * Uploads all educational facts to Firestore.
+     * @return FactsUploadResult with success/failure counts and details
+     */
+    suspend fun uploadAllFacts(): FactsUploadResult {
+        val rawFacts = try {
+            loadFactsFromAssets()
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to load educational facts from assets")
+            return FactsUploadResult(
+                successCount = 0,
+                failureCount = 1,
+                details = listOf(
+                    SingleFactUploadResult(
+                        factId = ASSET_PATH,
+                        textPreview = "",
+                        success = false,
+                        error = "Failed to read facts: ${e.message}"
+                    )
+                )
+            )
+        }
+
+        val normalized = normalizeFacts(rawFacts)
+        val results = mutableListOf<SingleFactUploadResult>()
+
+        normalized.invalidFacts.forEach { invalid ->
+            results.add(
+                SingleFactUploadResult(
+                    factId = invalid.id.ifBlank { "<missing-id>" },
+                    textPreview = invalid.text,
+                    success = false,
+                    error = invalid.error
+                )
+            )
+        }
+
+        for (fact in normalized.validFacts) {
+            val result = uploadSingleFact(fact)
+            results.add(result)
+        }
+
+        val successCount = results.count { it.success }
+        val failureCount = results.count { !it.success }
+
+        Timber.i("Educational fact upload complete: $successCount succeeded, $failureCount failed")
+
+        return FactsUploadResult(
+            successCount = successCount,
+            failureCount = failureCount,
+            details = results
+        )
+    }
+
+    /**
+     * Verifies uploaded data by reading it back from Firestore.
+     */
+    suspend fun verifyUploadedData(): FactsVerificationResult {
+        val rawFacts = try {
+            loadFactsFromAssets()
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to load educational facts from assets")
+            return FactsVerificationResult(
+                totalChecked = 1,
+                foundCount = 0,
+                verifications = listOf(
+                    SingleFactVerification(
+                        factId = ASSET_PATH,
+                        found = false,
+                        textPresent = false,
+                        error = "Failed to read facts: ${e.message}"
+                    )
+                )
+            )
+        }
+
+        val normalized = normalizeFacts(rawFacts)
+        val verifications = mutableListOf<SingleFactVerification>()
+
+        normalized.invalidFacts.forEach { invalid ->
+            verifications.add(
+                SingleFactVerification(
+                    factId = invalid.id.ifBlank { "<missing-id>" },
+                    found = false,
+                    textPresent = false,
+                    error = invalid.error
+                )
+            )
+        }
+
+        for (fact in normalized.validFacts) {
+            try {
+                val doc = factsCollection.document(fact.id).get().await()
+                if (doc.exists()) {
+                    val text = doc.getString("text")
+                    val hasText = !text.isNullOrBlank()
+
+                    Timber.d("Verified fact ${fact.id} (textPresent=$hasText)")
+
+                    verifications.add(
+                        SingleFactVerification(
+                            factId = fact.id,
+                            found = true,
+                            textPresent = hasText,
+                            error = if (hasText) null else "Text field is blank"
+                        )
+                    )
+                } else {
+                    Timber.w("Fact ${fact.id} not found in Firestore")
+                    verifications.add(
+                        SingleFactVerification(
+                            factId = fact.id,
+                            found = false,
+                            textPresent = false,
+                            error = "Document not found"
+                        )
+                    )
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Error verifying fact ${fact.id}")
+                verifications.add(
+                    SingleFactVerification(
+                        factId = fact.id,
+                        found = false,
+                        textPresent = false,
+                        error = "Verification failed: ${e.message}"
+                    )
+                )
+            }
+        }
+
+        val foundCount = verifications.count { it.found }
+        return FactsVerificationResult(
+            totalChecked = verifications.size,
+            foundCount = foundCount,
+            verifications = verifications
+        )
+    }
+
+    private suspend fun uploadSingleFact(fact: EducationalFactSeed): SingleFactUploadResult {
+        return try {
+            factsCollection.document(fact.id)
+                .set(
+                    hashMapOf(
+                        "text" to fact.text
+                    )
+                )
+                .await()
+
+            Timber.d("Uploaded fact ${fact.id}")
+
+            SingleFactUploadResult(
+                factId = fact.id,
+                textPreview = fact.text,
+                success = true,
+                error = null
+            )
+        } catch (e: Exception) {
+            Timber.e(e, "Error uploading fact ${fact.id}")
+            SingleFactUploadResult(
+                factId = fact.id,
+                textPreview = fact.text,
+                success = false,
+                error = "Upload failed: ${e.message}"
+            )
+        }
+    }
+
+    private fun loadFactsFromAssets(): List<EducationalFactSeed> {
+        val jsonContent = readAssetFile(ASSET_FILE_NAME)
+        return json.decodeFromString<List<EducationalFactSeed>>(jsonContent)
+    }
+
+    private fun readAssetFile(fileName: String): String {
+        return context.assets.open("facts/$fileName").bufferedReader().use { it.readText() }
+    }
+
+    private fun normalizeFacts(rawFacts: List<EducationalFactSeed>): NormalizedFacts {
+        val seenIds = mutableSetOf<String>()
+        val validFacts = mutableListOf<EducationalFactSeed>()
+        val invalidFacts = mutableListOf<InvalidFact>()
+
+        rawFacts.forEach { fact ->
+            val id = fact.id.trim()
+            val text = fact.text.trim()
+
+            when {
+                id.isEmpty() -> invalidFacts.add(
+                    InvalidFact(
+                        id = id,
+                        text = text,
+                        error = "Missing fact id"
+                    )
+                )
+                text.isEmpty() -> invalidFacts.add(
+                    InvalidFact(
+                        id = id,
+                        text = text,
+                        error = "Missing fact text"
+                    )
+                )
+                !seenIds.add(id) -> invalidFacts.add(
+                    InvalidFact(
+                        id = id,
+                        text = text,
+                        error = "Duplicate fact id"
+                    )
+                )
+                else -> validFacts.add(
+                    EducationalFactSeed(
+                        id = id,
+                        text = text
+                    )
+                )
+            }
+        }
+
+        return NormalizedFacts(
+            validFacts = validFacts,
+            invalidFacts = invalidFacts
+        )
+    }
+
+    private data class NormalizedFacts(
+        val validFacts: List<EducationalFactSeed>,
+        val invalidFacts: List<InvalidFact>
+    )
+
+    private data class InvalidFact(
+        val id: String,
+        val text: String,
+        val error: String
+    )
+
+    companion object {
+        private const val ASSET_FILE_NAME = "educational_facts.json"
+        private const val ASSET_PATH = "assets/facts/educational_facts.json"
+    }
+}
+
+@Serializable
+internal data class EducationalFactSeed(
+    val id: String = "",
+    val text: String = ""
+)
+
+/**
+ * Result of uploading all facts.
+ */
+internal data class FactsUploadResult(
+    val successCount: Int,
+    val failureCount: Int,
+    val details: List<SingleFactUploadResult>
+) {
+    val isFullSuccess: Boolean get() = failureCount == 0
+    val totalProcessed: Int get() = successCount + failureCount
+}
+
+/**
+ * Result of uploading a single fact.
+ */
+internal data class SingleFactUploadResult(
+    val factId: String,
+    val textPreview: String,
+    val success: Boolean,
+    val error: String?
+)
+
+/**
+ * Result of verification.
+ */
+internal data class FactsVerificationResult(
+    val totalChecked: Int,
+    val foundCount: Int,
+    val verifications: List<SingleFactVerification>
+) {
+    val allFound: Boolean get() = foundCount == totalChecked
+}
+
+/**
+ * Single verification result.
+ */
+internal data class SingleFactVerification(
+    val factId: String,
+    val found: Boolean,
+    val textPresent: Boolean,
+    val error: String?
+)

--- a/app/src/main/java/com/sirelon/marsroverphotos/firebase/facts/EducationalFactsUploaderHelper.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/firebase/facts/EducationalFactsUploaderHelper.kt
@@ -1,0 +1,194 @@
+package com.sirelon.marsroverphotos.firebase.facts
+
+import android.content.Context
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * Debug utility for uploading educational facts to Firebase.
+ *
+ * This composable can be added to any debug screen for easy data upload.
+ */
+@Composable
+internal fun EducationalFactsUploadDebugPanel() {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var uploadStatus by remember { mutableStateOf("") }
+    var isUploading by remember { mutableStateOf(false) }
+    var verificationStatus by remember { mutableStateOf("") }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = "Educational Facts Uploader",
+                style = MaterialTheme.typography.titleMedium
+            )
+
+            Text(
+                text = "Upload educational facts to Firebase Firestore",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Button(
+                onClick = {
+                    scope.launch {
+                        isUploading = true
+                        uploadStatus = "Uploading..."
+                        try {
+                            val uploader = EducationalFactsUploader(context)
+                            val result = uploader.uploadAllFacts()
+
+                            uploadStatus = buildString {
+                                append("Upload complete!\n")
+                                append("Success: ${result.successCount}\n")
+                                append("Failed: ${result.failureCount}\n\n")
+                                result.details.forEach { detail ->
+                                    if (detail.success) {
+                                        append("OK ${detail.factId}\n")
+                                    } else {
+                                        append("FAIL ${detail.factId}: ${detail.error}\n")
+                                    }
+                                }
+                            }
+                        } catch (e: Exception) {
+                            uploadStatus = "Error: ${e.message}"
+                            Timber.e(e, "Upload failed")
+                        } finally {
+                            isUploading = false
+                        }
+                    }
+                },
+                enabled = !isUploading,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(if (isUploading) "Uploading..." else "Upload Educational Facts")
+            }
+
+            if (uploadStatus.isNotEmpty()) {
+                Text(
+                    text = uploadStatus,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+            }
+
+            Button(
+                onClick = {
+                    scope.launch {
+                        verificationStatus = "Verifying..."
+                        try {
+                            val uploader = EducationalFactsUploader(context)
+                            val result = uploader.verifyUploadedData()
+
+                            verificationStatus = buildString {
+                                append("Verification complete!\n")
+                                append("Found: ${result.foundCount}/${result.totalChecked}\n\n")
+                                result.verifications.forEach { verification ->
+                                    when {
+                                        verification.found && verification.textPresent ->
+                                            append("OK ${verification.factId}\n")
+                                        verification.found ->
+                                            append(
+                                                "WARN ${verification.factId}: ${verification.error ?: "Unknown issue"}\n"
+                                            )
+                                        else ->
+                                            append(
+                                                "MISSING ${verification.factId}: ${verification.error ?: "Unknown issue"}\n"
+                                            )
+                                    }
+                                }
+                            }
+                        } catch (e: Exception) {
+                            verificationStatus = "Verification error: ${e.message}"
+                            Timber.e(e, "Verification failed")
+                        }
+                    }
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Verify Uploaded Facts")
+            }
+
+            if (verificationStatus.isNotEmpty()) {
+                Text(
+                    text = verificationStatus,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Programmatic helper function to upload educational facts.
+ */
+internal suspend fun uploadEducationalFactsToFirebase(
+    context: Context,
+    onComplete: (FactsUploadResult) -> Unit = {}
+) {
+    try {
+        val uploader = EducationalFactsUploader(context)
+        val result = uploader.uploadAllFacts()
+        onComplete(result)
+    } catch (e: Exception) {
+        Timber.e(e, "Failed to upload educational facts")
+        onComplete(
+            FactsUploadResult(
+                successCount = 0,
+                failureCount = 1,
+                details = emptyList()
+            )
+        )
+    }
+}
+
+/**
+ * Programmatic helper function to verify uploaded data.
+ */
+internal suspend fun verifyEducationalFactsInFirebase(
+    context: Context,
+    onComplete: (FactsVerificationResult) -> Unit = {}
+) {
+    try {
+        val uploader = EducationalFactsUploader(context)
+        val result = uploader.verifyUploadedData()
+        onComplete(result)
+    } catch (e: Exception) {
+        Timber.e(e, "Failed to verify educational facts")
+        onComplete(
+            FactsVerificationResult(
+                totalChecked = 0,
+                foundCount = 0,
+                verifications = emptyList()
+            )
+        )
+    }
+}


### PR DESCRIPTION
Adds an educational facts seed list and an uploader/verification helper with a debug panel for Firestore seeding. No tests run.