### PR TITLE
Upgrade to AGP 9.2, Gradle 9.5, and update dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,6 @@
 //@Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
     id 'kotlin-parcelize'
@@ -44,28 +43,24 @@ android {
     }
     buildTypes {
         release {
-            postprocessing {
-                removeUnusedCode true
-                removeUnusedResources true
-                obfuscate true
-                optimizeCode true
-                proguardFile 'proguard-rules.pro'
-            }
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
         debug {
         }
     }
 
-    configurations{
-        all*.exclude group: 'com.google.guava', module: 'listenablefuture'
+    configurations.all {
+        exclude group: 'com.google.guava', module: 'listenablefuture'
     }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = '17'
+    kotlin {
+        jvmToolchain(17)
     }
     buildFeatures {
         // Enables Jetpack Compose for this module

--- a/app/src/main/java/com/sirelon/marsroverphotos/di/AppModule.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/di/AppModule.kt
@@ -23,7 +23,7 @@ import com.sirelon.marsroverphotos.feature.rovers.RoversDestination
 import com.sirelon.marsroverphotos.feature.settings.AboutAppContent
 import com.sirelon.marsroverphotos.feature.ukraine.UkraineInfoScreen
 import org.koin.android.ext.koin.androidApplication
-import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.core.module.dsl.viewModel
 import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.dsl.navigation3.navigation
 import org.koin.dsl.module

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.jvm) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.google.services) apply false
     alias(libs.plugins.firebase.perf) apply false
     alias(libs.plugins.firebase.crashlytics) apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,5 @@
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 android.useAndroidX=true
 android.nonTransitiveRClass=true
-android.nonFinalResIds=false
+
+android.builtInKotlin=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,8 +7,8 @@ coil = "3.4.0"
 # https://developer.android.com/jetpack/androidx/releases/annotation
 annotation = "1.9.1"
 # https://firebase.google.com/support/release-notes/android
-firebaseBom = "34.11.0"
-kotlin = "2.3.0"
+firebaseBom = "34.12.0"
+kotlin = "2.3.21"
 # https://github.com/Kotlin/kotlinx.serialization/releases
 kotlin-serialization = "1.10.0"
 koin = "4.2.0"
@@ -17,7 +17,7 @@ koin = "4.2.0"
 kotlin-collections-immutable = "0.4.0"
 ktx = "1.18.0"
 # https://github.com/ktorio/ktor/releases
-ktor = "3.4.2"
+ktor = "3.4.3"
 # https://github.com/google/ksp/releases
 ksp = "2.3.6"
 # https://developer.android.com/jetpack/androidx/releases/lifecycle
@@ -31,7 +31,7 @@ compose-material3-adaptive-navigation-suite = "1.4.0"
 glance = "1.2.0-rc01"
 mockito = "1.6.0"
 # https://developer.android.com/jetpack/androidx/releases/paging
-paging = "3.3.6"
+paging = "3.4.2"
 playServicesAds = "25.1.0"
 # https://developer.android.com/jetpack/androidx/releases/room
 room = "2.8.4"
@@ -47,7 +47,7 @@ navigation3 = "1.0.0"
 lifecycle-navigation3 = "2.10.0"
 # https://developer.android.com/jetpack/androidx/releases/navigationevent
 navigationevent = "1.0.1"
-androidGradlePlugin = "8.13.2"
+androidGradlePlugin = "9.2.0"
 material3WindowSizeClass = "1.4.0"
 
 [libraries]
@@ -117,7 +117,7 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 firebase-perf = { id = "com.google.firebase.firebase-perf", version = "2.0.2" }
-firebase-crashlytics = { id = "com.google.firebase.crashlytics", version = "3.0.6" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version = "3.0.7" }
 google-services = { id = "com.google.gms.google-services", version = "4.4.4" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Upgrades Android Gradle Plugin from 8.13.2 → 9.2.0 and Gradle wrapper from 9.4.1 → 9.5.0, including the required AGP 9.0 migration: built-in Kotlin support (`android.builtInKotlin=true`), removal of the deprecated `postprocessing` block (replaced with `minifyEnabled`/`shrinkResources`), new `kotlin { jvmToolchain(17) }` DSL, and fixed `configurations.all` syntax.
- Bumps Kotlin 2.3.0 → 2.3.21, Firebase BOM 34.11.0 → 34.12.0, Ktor 3.4.2 → 3.4.3, Paging 3.3.6 → 3.4.2, and Firebase Crashlytics plugin 3.0.6 → 3.0.7.
- Migrates Koin ViewModel DSL import to `org.koin.core.module.dsl.viewModel` and removes the deprecated `android.nonFinalResIds=false` property.
- Adds `google-services.json` for Firebase configuration.

## Test plan
- [x] `assembleDebug` builds successfully with no errors
- [x] APK installed on Samsung Galaxy A505 (Android 11) — no crashes observed
- [x] Firebase Sessions connected and fetched settings successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)