### PR TITLE
Update library versions and migrate to Room 3.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,10 +2,10 @@
 # Core
 kotlin = "2.3.21"
 androidGradlePlugin = "9.2.0"
-ksp = "2.3.6"
+ksp = "2.3.7"
 
 # Compose Multiplatform
-compose-multiplatform = "1.10.3"
+compose-multiplatform = "1.11.0"
 
 # AndroidX
 # https://developer.android.com/jetpack/androidx/releases/activity
@@ -30,23 +30,23 @@ glance = "1.2.0-rc01"
 paging = "3.4.2"
 paging-kmp = "3.4.2"
 # https://developer.android.com/jetpack/androidx/releases/room
-room = "2.8.4"
+room = "3.0.0-alpha05"
 # https://developer.android.com/jetpack/androidx/releases/work
 work = "2.11.0"
 # https://developer.android.com/jetpack/androidx/releases/core
-core-splashscreen = "1.2.0-beta02"
+core-splashscreen = "1.2.0"
 
 # Multiplatform libraries
 # https://github.com/coil-kt/coil/blob/main/CHANGELOG.md
 coil = "3.4.0"
 # https://github.com/Kotlin/kotlinx.serialization/releases
-kotlin-serialization = "1.10.0"
+kotlin-serialization = "1.11.0"
 # https://github.com/Kotlin/kotlinx.collections.immutable
 kotlin-collections-immutable = "0.4.0"
 # https://github.com/Kotlin/kotlinx-datetime
 kotlinx-datetime = "0.7.1"
 # https://github.com/Kotlin/kotlinx.coroutines
-kotlinx-coroutines = "1.10.2"
+kotlinx-coroutines = "1.11.0"
 # https://github.com/ktorio/ktor/releases
 ktor = "3.4.3"
 # https://github.com/touchlab/Kermit
@@ -60,7 +60,7 @@ navigation-compose = "2.9.2"
 
 # Firebase
 # https://firebase.google.com/support/release-notes/android
-firebaseBom = "34.12.0"
+firebaseBom = "34.13.0"
 firebaseAnalyticsVersion = "23.0.0"
 firebaseCrashlyticsVersion = "20.0.3"
 firebaseFirestoreVersion = "26.0.2"
@@ -89,10 +89,9 @@ androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "a
 androidx-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "ktx" }
 androidx-glance-appwidget = { module = "androidx.glance:glance-appwidget", version.ref = "glance" }
 
-androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
-androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
-androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
-androidx-room-paging = { group = "androidx.room", name = "room-paging", version.ref = "room" }
+androidx-room-runtime = { group = "androidx.room3", name = "room3-runtime", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room3", name = "room3-compiler", version.ref = "room" }
+androidx-room-paging = { group = "androidx.room3", name = "room3-paging", version.ref = "room" }
 androidx-paging-compose = { group = "androidx.paging", name = "paging-compose", version.ref = "paging" }
 androidx-paging-runtime-ktx = { group = "androidx.paging", name = "paging-runtime-ktx", version.ref = "paging" }
 
@@ -189,7 +188,7 @@ firebase-perf = { id = "com.google.firebase.firebase-perf", version = "2.0.2" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version = "3.0.7" }
 google-services = { id = "com.google.gms.google-services", version = "4.4.4" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
-room = { id = "androidx.room", version.ref = "room" }
+room = { id = "androidx.room3", version.ref = "room" }
 
 [bundles]
 firebase = [

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -47,18 +47,6 @@ kotlin {
     //     browser()
     // }
 
-    // Workaround for Room KMP alpha issue with coroutines-android on iOS
-    configurations.all {
-        resolutionStrategy {
-            eachDependency {
-                if (requested.group == "org.jetbrains.kotlinx" && requested.name == "kotlinx-coroutines-android") {
-                    useTarget("org.jetbrains.kotlinx:kotlinx-coroutines-core:${requested.version}")
-                    because("Room KMP uses coroutines-android which is not compatible with iOS")
-                }
-            }
-        }
-    }
-
     sourceSets {
         // Common source set - shared across all platforms
         commonMain.dependencies {
@@ -123,8 +111,7 @@ kotlin {
             implementation(libs.koin.androidx.compose)
             implementation(libs.lifecycle.viewmodel.navigation3)
 
-            // Room extensions (Android-only)
-            implementation(libs.androidx.room.ktx)
+            // Room paging (Android-only)
             implementation(libs.androidx.room.paging)
 
             // Firebase (Android-only)
@@ -189,7 +176,7 @@ android {
     }
 }
 
-room {
+room3 {
     schemaDirectory("$projectDir/schemas")
 }
 

--- a/shared/src/androidMain/kotlin/com/sirelon/marsroverphotos/platform/DatabaseBuilder.android.kt
+++ b/shared/src/androidMain/kotlin/com/sirelon/marsroverphotos/platform/DatabaseBuilder.android.kt
@@ -1,8 +1,8 @@
 package com.sirelon.marsroverphotos.platform
 
 import android.content.Context
-import androidx.room.Room
-import androidx.room.RoomDatabase
+import androidx.room3.Room
+import androidx.room3.RoomDatabase
 import com.sirelon.marsroverphotos.data.database.AppDataBase
 
 /**
@@ -19,11 +19,8 @@ actual fun getDatabaseBuilder(): RoomDatabase.Builder<AppDataBase> {
     val context = androidContext
         ?: throw IllegalStateException("Android context not initialized. Call initAndroidDatabase() first.")
 
-    return Room.databaseBuilder(
-        context,
-        AppDataBase::class.java,
-        "mars-rover-photos-database"
-    )
+    val dbPath = context.getDatabasePath("mars-rover-photos-database").absolutePath
+    return Room.databaseBuilder<AppDataBase>(name = dbPath)
         .fallbackToDestructiveMigration(false)
         .addMigrations(AppDataBase.migration7To8, AppDataBase.migration8To9)
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/AppDataBase.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/AppDataBase.kt
@@ -1,10 +1,10 @@
 package com.sirelon.marsroverphotos.data.database
 
-import androidx.room.ConstructedBy
-import androidx.room.Database
-import androidx.room.RoomDatabase
-import androidx.room.RoomDatabaseConstructor
-import androidx.room.migration.Migration
+import androidx.room3.ConstructedBy
+import androidx.room3.Database
+import androidx.room3.RoomDatabase
+import androidx.room3.RoomDatabaseConstructor
+import androidx.room3.migration.Migration
 import androidx.sqlite.SQLiteConnection
 import androidx.sqlite.execSQL
 import com.sirelon.marsroverphotos.data.database.dao.FactDisplayDao
@@ -38,14 +38,14 @@ abstract class AppDataBase : RoomDatabase() {
 
     companion object {
         val migration7To8 = object : Migration(7, 8) {
-            override fun migrate(connection: SQLiteConnection) {
+            override suspend fun migrate(connection: SQLiteConnection) {
                 connection.execSQL("ALTER TABLE images ADD COLUMN description TEXT")
                 connection.execSQL("ALTER TABLE images ADD COLUMN credit TEXT")
             }
         }
 
         val migration8To9 = object : Migration(8, 9) {
-            override fun migrate(connection: SQLiteConnection) {
+            override suspend fun migrate(connection: SQLiteConnection) {
                 connection.execSQL(
                     "CREATE TABLE IF NOT EXISTS `fact_displays` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `factId` TEXT NOT NULL, `displayTimestamp` INTEGER NOT NULL, `sessionId` TEXT NOT NULL)"
                 )

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/dao/FactDisplayDao.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/dao/FactDisplayDao.kt
@@ -1,9 +1,9 @@
 package com.sirelon.marsroverphotos.data.database.dao
 
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
-import androidx.room.Query
+import androidx.room3.Dao
+import androidx.room3.Insert
+import androidx.room3.OnConflictStrategy
+import androidx.room3.Query
 import com.sirelon.marsroverphotos.data.database.entities.FactDisplay
 
 /**

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/dao/ImagesDao.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/dao/ImagesDao.kt
@@ -1,12 +1,12 @@
 package com.sirelon.marsroverphotos.data.database.dao
 
 import androidx.paging.PagingSource
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
-import androidx.room.Query
-import androidx.room.Transaction
-import androidx.room.Update
+import androidx.room3.Dao
+import androidx.room3.Insert
+import androidx.room3.OnConflictStrategy
+import androidx.room3.Query
+import androidx.room3.Transaction
+import androidx.room3.Update
 import com.sirelon.marsroverphotos.data.database.entities.MarsImage
 import com.sirelon.marsroverphotos.data.database.entities.StatsUpdate
 import kotlinx.coroutines.flow.Flow

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/dao/RoverDao.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/dao/RoverDao.kt
@@ -1,9 +1,9 @@
 package com.sirelon.marsroverphotos.data.database.dao
 
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
-import androidx.room.Query
+import androidx.room3.Dao
+import androidx.room3.Insert
+import androidx.room3.OnConflictStrategy
+import androidx.room3.Query
 import com.sirelon.marsroverphotos.domain.models.Rover
 import kotlinx.coroutines.flow.Flow
 

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/entities/FactDisplay.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/entities/FactDisplay.kt
@@ -1,7 +1,7 @@
 package com.sirelon.marsroverphotos.data.database.entities
 
-import androidx.room.Entity
-import androidx.room.PrimaryKey
+import androidx.room3.Entity
+import androidx.room3.PrimaryKey
 import kotlin.time.Clock
 
 /**

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/entities/MarsImage.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/entities/MarsImage.kt
@@ -1,8 +1,8 @@
 package com.sirelon.marsroverphotos.data.database.entities
 
-import androidx.room.Embedded
-import androidx.room.Entity
-import androidx.room.PrimaryKey
+import androidx.room3.Embedded
+import androidx.room3.Entity
+import androidx.room3.PrimaryKey
 import com.sirelon.marsroverphotos.domain.models.RoverCamera
 
 /**

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/repositories/RoversRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/repositories/RoversRepositoryImpl.kt
@@ -14,7 +14,6 @@ import com.sirelon.marsroverphotos.utils.Logger
 import com.sirelon.marsroverphotos.utils.RoverDateUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -51,7 +50,7 @@ class RoversRepositoryImpl(
             return
         }
 
-        initializationJob = applicationScope.launch(SupervisorJob()) {
+        initializationJob = applicationScope.launch {
             try {
                 // Seed initial rover data
                 seedRovers()

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/domain/models/Rover.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/domain/models/Rover.kt
@@ -2,8 +2,8 @@ package com.sirelon.marsroverphotos.domain.models
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
-import androidx.room.Entity
-import androidx.room.PrimaryKey
+import androidx.room3.Entity
+import androidx.room3.PrimaryKey
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/platform/DatabaseBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/platform/DatabaseBuilder.kt
@@ -1,6 +1,6 @@
 package com.sirelon.marsroverphotos.platform
 
-import androidx.room.RoomDatabase
+import androidx.room3.RoomDatabase
 import com.sirelon.marsroverphotos.data.database.AppDataBase
 
 /**

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/PlatformDatePicker.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/PlatformDatePicker.kt
@@ -12,7 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import kotlin.time.Clock
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.toLocalDateTime

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/utils/RoverDateUtil.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/utils/RoverDateUtil.kt
@@ -2,7 +2,7 @@ package com.sirelon.marsroverphotos.utils
 
 import com.sirelon.marsroverphotos.domain.models.Rover
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.toLocalDateTime

--- a/shared/src/desktopMain/kotlin/com/sirelon/marsroverphotos/platform/DatabaseBuilder.desktop.kt
+++ b/shared/src/desktopMain/kotlin/com/sirelon/marsroverphotos/platform/DatabaseBuilder.desktop.kt
@@ -1,7 +1,7 @@
 package com.sirelon.marsroverphotos.platform
 
-import androidx.room.Room
-import androidx.room.RoomDatabase
+import androidx.room3.Room
+import androidx.room3.RoomDatabase
 import com.sirelon.marsroverphotos.data.database.AppDataBase
 import java.io.File
 

--- a/shared/src/iosMain/kotlin/com/sirelon/marsroverphotos/platform/DatabaseBuilder.ios.kt
+++ b/shared/src/iosMain/kotlin/com/sirelon/marsroverphotos/platform/DatabaseBuilder.ios.kt
@@ -1,7 +1,7 @@
 package com.sirelon.marsroverphotos.platform
 
-import androidx.room.Room
-import androidx.room.RoomDatabase
+import androidx.room3.Room
+import androidx.room3.RoomDatabase
 import com.sirelon.marsroverphotos.data.database.AppDataBase
 import platform.Foundation.NSDocumentDirectory
 import platform.Foundation.NSFileManager


### PR DESCRIPTION
## Summary
- Bumps Compose Multiplatform 1.10.3 → 1.11.0 (iOS concurrent rendering on by default, native UIView text input opt-in), KSP 2.3.6 → 2.3.7, kotlinx-coroutines/serialization 1.10.x → 1.11.0, Firebase BOM 34.12.0 → 34.13.0, core-splashscreen beta02 → stable 1.2.0.
- Migrates Room 2.8.4 → 3.0.0-alpha05: new `androidx.room3` package coordinates, `room-ktx` removed (merged into runtime), Gradle plugin renamed to `androidx.room3`, `room {}` → `room3 {}`, Android builder updated to path-based `Room.databaseBuilder<T>(name)`, `Migration.migrate()` made `suspend`, coroutines-android resolution workaround removed.
- Fixes two deprecation warnings: `kotlinx.datetime.Instant` → `kotlin.time.Instant` in `PlatformDatePicker` and `RoverDateUtil`; `launch(SupervisorJob())` → `launch` in `RoversRepositoryImpl`.

## Test plan
- [x] `./gradlew :androidApp:assembleDebug` — passes
- [x] `./gradlew :shared:linkDebugFrameworkIosSimulatorArm64` — passes
- [ ] Smoke test on Android emulator (Room 3.0 alpha — verify DB opens and migrations run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)