### PR TITLE
Migrate rovers home to shared KMP

### DIFF
--- a/KMP_MIGRATION_PLAN.md
+++ b/KMP_MIGRATION_PLAN.md
@@ -358,7 +358,7 @@ all placeholder screens still render; new abstractions are wired through Koin.
 
 ---
 
-### Ticket S1 — Rovers home
+### ~~Ticket S1 — Rovers home~~ ✅
 
 **Goal:** real list of rovers in `commonMain`, replacing `RoversScreen` placeholder.
 
@@ -386,11 +386,13 @@ exposing `StateFlow<List<Rover>>` via `roversRepository.loadAllRovers()`. Bind i
 `viewModelModule`.
 
 **DoD:**
-- `RoversScreen(onNavigateToPhotos, onMissionInfoClick)` is fully in `commonMain`,
+- ✅ `RoversScreen(onNavigateToPhotos, onMissionInfoClick)` is fully in `commonMain`,
   shows real rovers on Android + iOS simulator + desktop.
-- Bottom-nav (Rovers / Favorite / Popular / About) still works on Android.
-- Navigation suite logic moves to `commonMain` as `MarsBottomBar` (it's CMP-compatible)
+- ✅ Bottom-nav (Rovers / Favorite / Popular / About) still works on Android.
+- ✅ Navigation suite logic moves to `commonMain` as `MarsBottomBar` (it's CMP-compatible)
   with `AdSlot` rendered only on Android.
+
+*Note: `androidx.compose.material3:material3-adaptive-navigation-suite` is not available for the enabled iOS targets, so `MarsBottomBar` uses common Material3 `NavigationBar` instead of `NavigationSuiteScaffold` for now.*
 
 ---
 

--- a/KMP_MIGRATION_PLAN.md
+++ b/KMP_MIGRATION_PLAN.md
@@ -1,765 +1,531 @@
-# Mars Rover Photos — Android + iOS KMP Migration Plan
+# Mars Rover Photos KMP Migration Plan
 
-> Living document. Goal: ship the app on both Android and iOS off a single shared codebase,
-> with Desktop kept building as a side-benefit. Web/WASM stays deferred (see `WASM_WEB_SUPPORT.md`).
+> Goal: ship Mars Rover Photos on Android and iOS from one shared Kotlin Multiplatform
+> codebase, while keeping Desktop building as a useful side benefit. Web/WASM is deferred
+> to `WASM_WEB_SUPPORT.md`.
 
----
-
-## 1. Executive summary
-
-The KMP scaffolding is **already in place**: shared module, Android shell (`androidApp/`),
-desktop shell (`desktopApp/`), iOS Swift shell (`iosApp/`), Koin DI, Room KMP, Ktor, Navigation 3,
-Compose Multiplatform 1.10.3, Kotlin 2.3.21 (see §2.1 for the full version snapshot).
-
-What is **not done yet**: every real feature screen still lives in the legacy `app/` module
-(commented out in `settings.gradle.kts`). `shared/src/commonMain/.../presentation/screens/PlaceholderScreens.kt`
-is a stub set wired into Koin/Navigation 3 — running the app on any platform today shows seven
-"(Screen pending migration)" placeholders.
-
-The migration is therefore **mostly a UI port + cross-cutting-abstraction job**, screen by screen,
-plus filling in three iOS implementation gaps (Firebase, photo library save/share, Xcode project).
-
-Rough size: ~4,800 LOC of Kotlin UI to move (across 25 feature files), the heaviest being
-`RoversActivity.kt` (656 lines), `RoverMissionInfoScreen.kt` (514), `ImagesScreen.kt` (401),
-`RoverPhotosScreen.kt` (456), `AboutAppScreen.kt` (244), `FavoriteScreen.kt` (230), `Ukraine.kt` (159).
+This document is meant to be read top-down. The main plan is first. Background and
+technical reference notes are at the bottom.
 
 ---
 
-## 2. Current module layout
+## Main Plan
 
-```
-settings.gradle.kts
-├── :shared        (kotlin-multiplatform + android.library + CMP) — common code, all platforms
-├── :androidApp    (android.application)                          — Android shell, Activity, manifest, AdMob, widgets
-├── :desktopApp    (kotlin-jvm + CMP)                             — Desktop shell, Window {} + App()
-├── (:iosApp)      Swift + Xcode (no .xcodeproj checked in yet)   — wraps shared.framework
-└── (:app)         legacy Android-only module — commented out, kept as reference
-```
+### Current State
 
-Target source sets in `:shared`:
-- `commonMain` — domain, data, presentation (Compose), DI scaffolding, expects.
-- `androidMain` — Android actuals + Firebase Android SDK + Ktor OkHttp + Glance-free helpers.
-- `iosMain` — iOS actuals (NSUserDefaults, Documents dir, Ktor Darwin) — Firebase + photo I/O are **stubs**.
-- `desktopMain` — JVM actuals (Java Prefs, file system, Ktor OkHttp, Swing dispatcher) — Firebase is a stub.
+- ✅ KMP scaffolding exists: `shared/`, `androidApp/`, `desktopApp/`, and `iosApp/`.
+- ✅ Shared Navigation 3, Koin, common resources, tracking, BuildInfo, Crashlytics hooks,
+  shared image UI helpers, zoom support, and ad slots are in place.
+- ✅ Ticket S0 is done.
+- ✅ Ticket S1, Rovers home, is done.
+- ⏭️ Next main ticket: **S2 — Rover photos grid**.
+- ⚠️ iOS still needs Firebase, save/share, an Xcode project, and deep links before the app
+  is fully useful there.
+- 🚫 Web/WASM remains out of scope for this milestone.
 
-Targets declared in `shared/build.gradle.kts`: `androidTarget`, `iosX64`, `iosArm64`, `iosSimulatorArm64`, `jvm("desktop")`. WASM block commented out.
+### How Agents Should Use This Plan
 
-iOS framework output (after `./gradlew :shared:linkDebugFrameworkIosSimulatorArm64`):
-`shared/build/bin/iosSimulatorArm64/debugFramework/shared.framework` (Debug ≈ 240 MB —
-Kotlin/Native runtime + Compose runtime + transitive deps).
+1. Confirm which ticket you own before editing: `S0`, `S1`, `S2`, ..., `S9`,
+   or iOS work `6.1`, `6.2`, `6.3`, `6.4`.
+2. Stay inside the owned ticket. Other agents may be working nearby.
+3. Use the legacy `app/` module only as a reference. Do not modify it.
+4. Do not re-add `:app` to `settings.gradle.kts`.
+5. Do not bump Gradle or library versions unless the ticket explicitly requires it.
+6. After finishing a ticket, update this file with minimal additive edits:
+   mark DoD bullets with ✅, mark the ticket header complete, and add any blocker note.
 
-### 2.1 Tech stack snapshot
+### Migration Board
 
-Pulled from `gradle/libs.versions.toml` (verify there for ground truth):
-
-| Layer | Component | Version |
+| Ticket | Status | Main outcome |
 |---|---|---|
-| Compiler | Kotlin | 2.3.21 |
-| Compiler | KSP | 2.3.6 |
-| Build | Android Gradle Plugin | 9.2.0 |
-| UI | Compose Multiplatform | 1.10.3 |
-| UI | Compose BOM (Android) | 1.11.0 |
-| UI | Material3 (Android) | 1.4.0 |
-| Data | Room (KMP stable) | 2.8.4 |
-| Data | Paging (Android + KMP) | 3.4.2 |
-| Data | Ktor | 3.4.3 |
-| DI | Koin / Koin Compose | 4.2.1 |
-| Logging | Kermit | 2.1.0 |
-| Image loading | Coil (KMP) | 3.4.0 |
-| Lang | kotlinx-serialization | 1.10.0 |
-| Lang | kotlinx-coroutines | 1.10.2 |
-| Lang | kotlinx-datetime | 0.7.1 |
-| Lang | kotlinx-collections-immutable | 0.4.0 |
-| Lifecycle | AndroidX Lifecycle (KMP) | 2.10.0 |
-| Android-only | Glance | 1.2.0-rc01 |
-| Android-only | WorkManager | 2.11.0 |
-| Android-only | Core Splashscreen | 1.2.0-beta02 |
-
-**Known caveat baked into the build (`gradle.properties`):**
-`android.builtInKotlin=false` and `android.newDsl=false` to keep the shared `kotlin.multiplatform + android.library` combo working under AGP 9.x. The proper fix is to migrate `:shared` to `com.android.kotlin.multiplatform.library` — tracked separately, not blocking screen ports. See §9.
-
-**Room caveat:** `room-paging` is Android-only AAR — already isolated to
-`androidMain.dependencies` in `shared/build.gradle.kts`. DAO `PagingSource` methods only
-compile on Android; common code uses `Flow<List<T>>` instead. The Paging *Compose* layer
-(`collectAsLazyPagingItems`) is multiplatform via Paging 3.4.2 — see ticket S0 / §4.5.
+| S0 — Cross-cutting prerequisites | ✅ Done | Shared resources, tracker, BuildInfo, Crashlytics hook, paging-compose, zoom, image UI helpers, ad slot |
+| S1 — Rovers home | ✅ Done | Real shared rover list, rover images, bottom navigation, mission/photos navigation |
+| S2 — Rover photos grid | Next | Real rover photos screen with sol/date filters |
+| S3 — Image gallery + photo info sheet | Pending | Fullscreen gallery, zoom, photo info sheet, save/share hooks |
+| S4 — Favorites | Pending | Shared favorites grid backed by Room/Paging |
+| S5 — Popular photos | Pending | Shared popular tab backed by Firebase data on Android |
+| S6 — Mission info | Pending | Shared rover mission detail screen |
+| S7 — About/settings | Pending | Shared settings UI: theme, facts, cache, rate app |
+| S8 — Ukraine route decision | Pending | Shared Ukraine banner and Ukraine screen |
+| S9 — Android widget adaptation | Pending | Keep widget Android-only, but wire it to shared repositories/settings/tracker |
+| 6.1 — Firebase iOS | Pending | Popular data, analytics, Crashlytics on iOS |
+| 6.2 — iOS image save/share | Pending | Save to Photos and native share sheet |
+| 6.3 — Xcode project bootstrap | Pending | Checked-in iOS project/workspace that teammates can run |
+| 6.4 — iOS deep links | Pending | `marsrover://` and universal-link handling on iOS |
+| Final cleanup | Pending | Delete legacy `app/`, final smoke tests, CI gate |
 
 ---
 
-## 3. Inventory — what's already in `shared/`
+## Screen Migration Tickets
 
-### 3.1 Already migrated (works in `commonMain`)
+### ~~Ticket S0 — Cross-Cutting Prerequisites~~ ✅
 
-**Domain (`domain/`)**
-- Models: `Rover` (`expect class` w/ Android `drawableRes()`), `MarsPhoto`, `RoverCamera`,
-  `PhotosQueryRequest`, `EducationalFact`, `FirebasePhoto`, `RoverConstants`,
-  `mission/CameraSpec`, `mission/RoverMissionData`, `mission/RoverMissionFacts`.
-- Repositories (interfaces): `RoversRepository`, `PhotosRepository`, `ImagesRepository`,
-  `FactsRepository`, `MissionRepository`.
-- Settings: `AppSettings`, `Theme`.
+**Goal:** create the shared pieces that real screens need before they move into `commonMain`.
 
-**Data (`data/`)**
-- Database: `AppDataBase` (Room KMP, `@ConstructedBy(AppDataBaseConstructor)`, migrations 7→8 and 8→9),
-  entities `MarsImage`, `FactDisplay`, plus `Rover` entity from domain.
-- DAOs: `RoverDao`, `ImagesDao`, `FactDisplayDao`.
-- Network: `RestApi`, `NasaApi` (Ktor), `models/RoverResponse`, `models/PhotosResponse`, `Mappers`.
-- Repositories: `RoversRepositoryImpl`, `PhotosRepositoryImpl`, `ImagesRepositoryImpl`,
-  `FactsRepositoryImpl`; `MissionRepositoryImpl` is `expect class` (Android has Firestore impl,
-  iOS/desktop are stubs).
-- Paging: `PopularRemoteMediator` (`androidx.paging.RemoteMediator` from Paging KMP).
+**Done:**
+- ✅ Compose resources moved into `shared/src/commonMain/composeResources/`.
+- ✅ `Tracker` interface and platform implementations are wired through Koin.
+- ✅ `BuildInfo` is initialized by each platform entry point.
+- ✅ `recordException` expect/actual exists.
+- ✅ Paging Compose is available from common code.
+- ✅ Shared `Modifier.zoomable` exists.
+- ✅ Shared `MarsImageComposable`, stats, favorite toggle, and network image UI exist.
+- ✅ `AdSlot` expect composable exists; platform implementations are safe placeholders unless
+  Android chooses to render a real ad.
 
-**Presentation (`presentation/`)**
-- Entry: `App.kt` (theme + Surface + AppNavigation), `navigation/AppNavigation.kt` (Navigation 3,
-  Koin `koinEntryProvider`), `navigation/AppDestinations.kt` (`@Serializable sealed interface AppDestination`
-  with Rovers/Photos/Images/Favorite/Popular/Mission/About), `navigation/AppNavigator.kt`,
-  `navigation/AppNavEntryDecorators.kt`, `navigation/DeepLink.kt`.
-- ViewModels: `PhotosViewModel`, `ImageViewModel`, `FavoriteImagesViewModel`,
-  `RoverMissionInfoViewModel`, `PopularPhotosViewModel` (all on `androidx.lifecycle.ViewModel`,
-  registered via `viewModelOf(::…)`).
-- Theme: `theme/Theme.kt` (`MarsRoverPhotosTheme` is an expect/actual composable;
-  Android pulls dynamic colors).
-- Shared UI helpers in `presentation/ui/`: `MaterialSymbolIcon`, `MarsSnackbar`,
-  `RadioButtonText`, `NoScrollEffect` (expect), `PlatformDatePickerDialog`,
-  `PlatformToastHost`/`rememberPlatformToastState`, `PlatformUriHandler` (expect),
-  `CenteredComponents`, `AdaptiveLayout` (expect), `DynamicColor` (expect), `SystemTheme` (expect).
-- Models: `GridItem`, `GridItemTransformer`.
-- Screens: `screens/PlaceholderScreens.kt` — **all seven are stubs**.
+**Validation expectation:** Android builds, iOS framework links, Desktop still compiles/runs,
+and the old placeholders still render before real screens replace them.
 
-**Platform abstractions (`platform/`)** — expects in `commonMain`, actuals per platform
-| Capability | expect | Android actual | iOS actual | Desktop actual |
-|---|---|---|---|---|
-| HTTP engine | `createHttpClientEngine()` | OkHttp | Darwin | OkHttp |
-| Room DB builder | `getDatabaseBuilder()` | filesDir | Documents dir | user.home |
-| Preferences | `PlatformPreferences` | SharedPreferences | NSUserDefaults | java.util.prefs |
-| Firebase Analytics | `class FirebaseAnalytics` | Firebase Android SDK | `println` stub | `println` stub |
-| Firestore | `IFirebasePhotos` | `AndroidFirebasePhotos` | **stub returning empty** | stub |
-| Image save/share | `ImageOperations` | MediaStore + Share Intent | **stub returns Error** | not implemented |
-| Theme bits | `supportsDynamicColor`, `isSystemInDarkTheme` | Material-You | static false | static system |
-
-**Koin DI (`di/`)** — `KoinInit.initKoin(platformModule, …)` wires `databaseModule`, `networkModule`,
-`repositoryModule`, `viewModelModule`, `navigationModule`. `navigationModule` already maps every
-`AppDestination` to its placeholder composable through `koinEntryProvider<NavKey>()`.
-
-**Compose Resources** — `shared/src/commonMain/composeResources/` has only `font/material_symbols_outlined.ttf`
-today. **All strings and drawables are still under `app/src/main/res/`** and must be ported.
-
-### 3.2 Still **only** in the legacy `app/` module
-
-| Path | Lines | Status |
-|---|---:|---|
-| `feature/rovers/RoversActivity.kt` | 656 | Root screen + NavigationSuiteScaffold + AdMob banner + Ukraine banner + edge-to-edge |
-| `feature/rovers/RoversNavigation.kt` | 131 | Sealed `RoversDestination`, `RoversNavigationState`, in-screen Nav3 wiring |
-| `feature/mission/RoverMissionInfoScreen.kt` | 514 | Mission detail UI, NumberFormat, drawables |
-| `feature/photos/RoverPhotosScreen.kt` | 456 | Sol/Earth-date pickers, grid/list view, facts mixed in |
-| `feature/images/ImagesScreen.kt` | 401 | Fullscreen pager + zoom + share + save |
-| `feature/settings/AboutAppScreen.kt` | 244 | About/settings, theme switcher, clear cache, rate-us |
-| `feature/favorite/FavoriteScreen.kt` | 230 | Favorites grid with Paging Compose |
-| `feature/photos/PhotosViewModel.kt` | 197 | **Already migrated** (shared copy is more complete) |
-| `feature/mission/RoverMissionInfoViewModel.kt` | 197 | Already migrated |
-| `feature/mission/RoverMissionData.kt` | 183 | Already migrated |
-| `feature/images/MarsImageFavoriteToggle`, `feature/MarsImage.kt` | 178 | `MarsImageComposable`, `PhotoStats`, `MarsImageFavoriteToggle`, `NetworkImage` — **shared reusable, not yet ported** |
-| `feature/ukraine/Ukraine.kt` | 159 | `UkraineInfoScreen`, `UkraineBanner` |
-| `feature/images/PhotoInfoBottomSheet.kt` | 156 | Photo info bottom sheet |
-| `feature/photos/FactCard.kt`, `EmptyPhotos.kt`, `Mapper.kt`, etc. | ~290 | Helper composables not yet ported |
-| `feature/popular/PopularPhotoDataSource.kt` | 77 | Already migrated as `data/paging/PopularRemoteMediator` |
-| `feature/popular/PopularPhotosViewModel.kt` | 28 | Already migrated; **but `PopularPhotosScreen` was never extracted** — it's inlined inside FavoriteScreen body in legacy |
-| `feature/favorite/FavoriteImagesViewModel.kt` | 37 | `AndroidViewModel` legacy; shared has a clean `ViewModel` version |
-| `feature/gdpr/GdprHelper.kt` | 75 | Android-only by design |
-| `feature/firebase/*`, `firebase/photos/*`, `firebase/mission/*`, `firebase/facts/*` | ~250 | Mostly Android-only Firebase admin/upload tooling |
-| `widget/*` (4 files) | ~330 | Glance widget — Android-only by design |
-| `tracker/*` (5 files) | ~250 | `ITracker`, `FirebaseTracker`, `AnalyticsUtils`, `DataFlowCollector`, `FullscreenImageTracker`. **Not yet ported** as a common abstraction |
-| `DataManager.kt`, `RoverApplication.kt`, `extensions/Extensions.kt`, `ui/Theme.kt`, `ui/widgets.kt`, `ui/AdaptiveLayout.kt`, `ui/MaterialSymbolIcon.kt`, `ui/centered.kt` | mixed | Reference only; new code already in `shared/.../presentation/ui` and `androidApp/` |
-
-Resources still in `app/src/main/res/`:
-- `drawable/ic_rovers.xml`, `drawable-*/alien_icon`, `drawable-nodpi/img_placeholder`,
-  `drawable-*/mars*` per-rover images.
-- `values/strings.xml` (rovers/photos/favorite/popular/about + all CTAs).
-- `font/material_symbols_outlined.ttf` (already duplicated into `shared/composeResources`).
-
-### 3.3 Still only in `androidApp/`
-
-`androidApp/src/main/kotlin/com/sirelon/marsroverphotos/MainActivity.kt`,
-`MarsRoverApplication.kt`, `AndroidManifest.xml`, app icons, theme XML. These are
-**already a thin wrapper**: Activity calls `App(deepLink, onDeepLinkConsumed)` from
-`commonMain`. Deep links (`marsrover://rover/{id}`, `marsrover://photo/{id}`, and
-`https://marsroverphotos.app/...`) parsed in `MainActivity.handleDeepLink` and pushed
-into `App` as `DeepLink`. This is the model to keep — Android remains responsible
-for Intent → `DeepLink` translation.
-
-### 3.4 What's in `iosApp/` today
-
-- `iosApp/iosApp/MarsRoverApp.swift` — `KoinInitKt.initKoinIos()` in `init`, then `WindowGroup { ContentView() }`.
-- `iosApp/iosApp/ContentView.swift` — `UIViewControllerRepresentable` → `Main_iosKt.MainViewController()`.
-- `iosApp/Podfile` — empty placeholder, no Firebase pods installed.
-- `iosApp/Info.plist` — present but not bound to a real Xcode project.
-- **No `.xcodeproj` / `.xcworkspace` checked in.** `iosApp/SETUP.md` walks the user through
-  creating the project manually in Xcode. This needs to be checked in before iOS can be
-  built on CI / by anyone but the author.
+**Notes:**
+- `paging-compose-common` does not exist on Maven Central. The working artifact is
+  `androidx.paging:paging-compose:3.4.2`.
 
 ---
 
-## 4. Common abstractions still missing
+### ~~Ticket S1 — Rovers Home~~ ✅
 
-These must land **before or alongside** screen ports because most screens depend on them.
-Putting them up first lets every screen migration be small and self-contained.
+**Goal:** replace the shared `RoversScreen` placeholder with the real rover list.
 
-### 4.1 Compose Resources port (BLOCKER for any screen)
+**Done:**
+- ✅ `RoversScreen(onNavigateToPhotos, onMissionInfoClick)` lives in `commonMain`.
+- ✅ `RoversViewModel` exposes real rover data from `RoversRepository`.
+- ✅ Rover images resolve from Compose Multiplatform resources.
+- ✅ Rover taps navigate to photos.
+- ✅ Mission-info taps navigate to mission detail.
+- ✅ Bottom navigation for Rovers, Favorites, Popular, and About is available from common code.
+- ✅ Desktop and iOS Koin startup include navigation entries and initialize rover data.
+- ✅ `KMP_MIGRATION_PLAN.md` marks S1 complete.
 
-Move into `shared/src/commonMain/composeResources/`:
-- `values/strings.xml` → `values/strings.xml` (CMP picks up the same XML format).
-- `drawable/ic_rovers.xml` → `drawable/ic_rovers.xml` (vector XML is CMP-compatible).
-- All rover/landing JPEGs and `alien_icon`, `img_placeholder`, `mars-bg` to `drawable/`.
-
-After porting, replace every `R.string.x` / `R.drawable.x` with
-`org.jetbrains.compose.resources.stringResource(Res.string.x)` /
-`painterResource(Res.drawable.x)`. The `packageOfResClass` is already
-`com.sirelon.marsroverphotos.shared.resources`.
-
-### 4.2 Tracker abstraction (BLOCKER for Rovers/Favorite/Popular/Ukraine/About)
-
-Today every screen calls `RoverApplication.APP.dataManger.trackClick(...)` and
-`RoverApplication.APP.tracker.trackFavorite(...)`. The legacy `ITracker` takes
-`android.os.Bundle`, which can't move as-is.
-
-Add to `shared/.../platform/Tracker.kt`:
-
-```kotlin
-interface Tracker {
-    fun trackClick(event: String)
-    fun trackEvent(event: String, params: Map<String, String> = emptyMap())
-    fun trackFavorite(photo: MarsImage, from: String, fav: Boolean)
-    fun trackSeen(photo: MarsImage)
-    fun trackScale(photo: MarsImage)
-    fun trackSave(photo: MarsImage)
-    fun trackShare(photo: MarsImage, packageName: String?)
-}
-```
-
-Provide actuals: `AndroidTracker` (Firebase Analytics + DataManager merged),
-`IosTracker` (logs only until Firebase iOS lands), `DesktopTracker` (logs only).
-Bind via `platformModule`. Inject into ViewModels — strip the `RoverApplication.APP` references.
-
-### 4.3 Build/version info expect
-
-```kotlin
-// commonMain
-expect object BuildInfo {
-    val versionName: String
-    val isDebug: Boolean
-    val packageName: String
-}
-```
-
-- Android actual reads `BuildConfig` from `androidApp` (small `androidApp/src/main/kotlin/.../BuildInfo.android.kt`,
-  but since `BuildConfig` is in androidApp, the actual must live in `:shared` `androidMain` as a `expect val`
-  that's overridden by a generated constant — simplest is `BuildKonfig` plugin
-  (`com.codingfeline.buildkonfig`) wired in `:shared`.
-- iOS/desktop actuals: read from `Bundle.main.infoDictionary` / system properties (or hard-code in BuildKonfig).
-
-### 4.4 Crashlytics expect
-
-```kotlin
-expect fun recordException(t: Throwable)
-```
-
-Android wires to `FirebaseCrashlytics.getInstance().recordException`; iOS/desktop log via Kermit.
-
-### 4.5 Paging Compose multiplatform
-
-`FavoriteScreen` and `PopularScreen` need `collectAsLazyPagingItems()` in `commonMain`.
-Paging KMP 3.4.2 ships `androidx.paging.compose` as a multiplatform artifact —
-add to `shared/build.gradle.kts`:
-
-```kotlin
-commonMain.dependencies {
-    implementation(libs.paging.common)
-    implementation(libs.paging.compose) // androidx.paging:paging-compose:3.4.2 (multiplatform)
-}
-```
-
-(`libs.versions.toml` already pins `paging-kmp = "3.4.2"`. If the multiplatform Compose
-adapter is still missing on iOS in your alignment, fall back to
-`app.cash.paging:paging-compose-common`.)
-
-### 4.6 Zoomable replacement (BLOCKER for Image gallery)
-
-Legacy uses `net.engawapg.lib.zoomable` — JVM-only artifact. Options, ranked:
-1. **Custom modifier with `Modifier.graphicsLayer` + `pointerInput(detectTransformGestures)`** —
-   ~60 lines, fully in `commonMain`. Recommended.
-2. `me.saket.telephoto:zoomable` — Android-only, would need expect/actual.
-3. KMP fork (`com.diamondedge:compose-zoomable`, `pro.respawn:apiresult-zoomable`) — small ecosystem, evaluate stability.
-
-Recommendation: ship our own `Modifier.zoomable(state)` in `presentation/ui/` since the
-feature set we use is small (pan + double-tap reset + scale).
-
-### 4.7 Open-saved-image expect
-
-`ImagesScreen` opens the saved file with `Intent.ACTION_VIEW`. Add:
-
-```kotlin
-expect fun openLocalImage(uri: String): Boolean
-```
-
-Android → `Intent(Intent.ACTION_VIEW, Uri.parse(uri)) | FLAG_ACTIVITY_NEW_TASK`.
-iOS → can present a preview via `UIDocumentInteractionController`; for v1, log and return false.
-Desktop → `Desktop.getDesktop().open(File(uri))`.
-
-### 4.8 "Rate the app" expect
-
-```kotlin
-expect fun openAppStore()
-```
-
-Android → `market://details?id=…` then fallback to Play Store https URL.
-iOS → `itms-apps://apps.apple.com/app/idXXX`.
-Desktop → no-op (or open the GitHub repo).
-
-### 4.9 NumberFormat / locale formatting
-
-`RoverMissionInfoScreen` uses `java.text.NumberFormat.getNumberInstance(Locale.US)`.
-Replace with a tiny common util — kotlinx-datetime gives `LocalDate`; for thousands
-separators just use a manual formatter or expect `formatThousands(Long): String`.
-
-### 4.10 Android-only kept in `androidApp/`
-
-Stays in `androidApp/` (not migrated):
-- AdMob (`MobileAds`, `AdView`, `AdRequest`) — wrap entry from common via expect `AdSlot(modifier)`
-  composable; Android renders the banner, iOS/desktop return `Box(modifier)`.
-- `GdprHelper` (UMP) — same expect-`Composable` strategy.
-- Glance widget (`widget/*`) — App Widget. Stays Android-only.
-- Firebase admin uploaders (`firebase/mission/MissionDataUploader`, `firebase/facts/EducationalFactsUploader`) —
-  developer tools, keep in `androidApp/` under a debug flag.
-- Splashscreen (`installSplashScreen`) — Android API 12 splash; stays in `MainActivity`.
-- Edge-to-edge wiring — kept in `MainActivity`, with the common `SystemTheme` expect
-  exposing dark-mode signal to common.
+**Notes:**
+- `androidx.compose.material3:material3-adaptive-navigation-suite` does not resolve for the
+  enabled iOS targets, so `MarsBottomBar` currently uses common Material3 `NavigationBar`
+  instead of `NavigationSuiteScaffold`.
 
 ---
 
-## 5. Screen-by-screen migration tickets
+### Ticket S2 — Rover Photos Grid
 
-Order follows `AGENTS.md`'s "screen migration order" rule and goes smallest-blast-radius first.
-Each ticket lists files to port, Android-only blockers to swap, DI/expect work, and Definition of Done.
+**Goal:** replace the shared `PhotosScreen` placeholder with the real rover photo browser.
 
-### ~~Ticket S0 — Cross-cutting prerequisites (do FIRST)~~ ✅
+**Port from legacy:**
+- `feature/photos/RoverPhotosScreen.kt`
+- `feature/photos/EmptyPhotos.kt`
+- `feature/photos/FactCard.kt`
+- `feature/photos/Mapper.kt`
+- Any small photo-screen helpers still needed by the screen
 
-Land everything in §4 that the first screen will touch. Concretely:
-- ✅ Compose Resources port: `strings.xml` + `ic_rovers`, `alien_icon`, `img_placeholder`, and rover JPEGs → `shared/src/commonMain/composeResources/`.
-- ✅ `Tracker` interface + Android/iOS/desktop actuals + Koin bindings.
-- ✅ `BuildInfo` hand-rolled singleton initialized from each platform entry point.
-- ✅ `recordException` expect/actual (Crashlytics on Android, Kermit on iOS/desktop).
-- ✅ Add `androidx.paging:paging-compose:3.4.2` to `commonMain` deps (raw coordinate — TOML alias `paging-compose-common` maps to a non-existent artifact).
-- ✅ Ship `Modifier.zoomable` in `presentation/ui/Zoomable.kt`.
-- ✅ Port `feature/MarsImage.kt` content (`MarsImageComposable`, `PhotoStats`, `MarsImageFavoriteToggle`, `NetworkImage`) into `presentation/ui/MarsImage.kt`.
-- ✅ `AdSlot` expect composable added (Box stub on all platforms; real AdMob stays in androidApp).
+**Already available in shared:**
+- `PhotosViewModel`
+- `GridItemTransformer`
+- `GridItem`
+- `RoverDateUtil`
+- `PhotosRepository`
 
-**DoD:** ✅ App still builds on Android, iOS framework still links, desktop runs;
-all placeholder screens still render; new abstractions are wired through Koin.
+**Use these replacements:**
+- Android `R.string.*` and `R.drawable.*` → Compose Multiplatform `Res.string.*` /
+  `Res.drawable.*`
+- `java.util.Calendar` or `TimeZone` → `kotlinx-datetime`
+- Direct Material3 DatePicker usage → existing `PlatformDatePickerDialog`
+- `rememberSaveable` local state is fine to keep
 
-*Note: `paging-compose-common` artifact doesn't exist on Maven Central — the correct KMP artifact is `androidx.paging:paging-compose:3.4.2` (added as raw coordinate).*
-
----
-
-### ~~Ticket S1 — Rovers home~~ ✅
-
-**Goal:** real list of rovers in `commonMain`, replacing `RoversScreen` placeholder.
-
-**Files to port (source → destination):**
-- `app/.../feature/rovers/RoversActivity.kt` (parts only) →
-  `shared/.../presentation/screens/RoversScreen.kt`. **Only** the `RoversContent` /
-  `RoverItem` composables move here; the `RoversActivity` shell stays Android-only.
-- `app/.../models/Rover.kt::drawableRes(Context)` →
-  replace with `Rover.painter(): Painter` in common, looking up by `id` in a `when {}`
-  that returns CMP `Res.drawable.*`.
-
-**Android-only blockers and replacements:**
-| Blocker | Replacement |
-|---|---|
-| `FragmentActivity` + edge-to-edge + window-insets | Already handled by `MainActivity` + common theme. Don't move. |
-| `painterResource(R.drawable.ic_rovers)` | CMP `painterResource(Res.drawable.ic_rovers)` |
-| `stringResource(R.string.nav_*)` | CMP `stringResource(Res.string.nav_*)` |
-| `RoverApplication.APP.dataManger.trackClick("…")` | Inject `Tracker` and call `tracker.trackClick("…")` |
-| AdMob / `GdprHelper` | Keep in `androidApp/`. Expose `AdSlot()` expect composable in `presentation/ui/`; iOS/desktop actuals render `Box`. |
-| `calculateWindowSizeClass(activity)` | `currentWindowAdaptiveInfo()` (CMP) — already imported in legacy file. |
-| `Timber.d(...)` | `Logger.d(...)` (Kermit, already in shared). |
-
-**ViewModel:** new `RoversViewModel(roversRepository, tracker)` in `presentation/viewmodels`,
-exposing `StateFlow<List<Rover>>` via `roversRepository.loadAllRovers()`. Bind in
-`viewModelModule`.
-
-**DoD:**
-- ✅ `RoversScreen(onNavigateToPhotos, onMissionInfoClick)` is fully in `commonMain`,
-  shows real rovers on Android + iOS simulator + desktop.
-- ✅ Bottom-nav (Rovers / Favorite / Popular / About) still works on Android.
-- ✅ Navigation suite logic moves to `commonMain` as `MarsBottomBar` (it's CMP-compatible)
-  with `AdSlot` rendered only on Android.
-
-*Note: `androidx.compose.material3:material3-adaptive-navigation-suite` is not available for the enabled iOS targets, so `MarsBottomBar` uses common Material3 `NavigationBar` instead of `NavigationSuiteScaffold` for now.*
+**Definition of Done:**
+- `PhotosScreen(roverId, ...)` is fully in `commonMain`.
+- Photos load for the selected rover.
+- Sol filtering works.
+- Earth-date picking works.
+- Android, iOS framework, and Desktop compile.
 
 ---
 
-### Ticket S2 — Rover photos (grid)
+### Ticket S3 — Image Gallery + Photo Info Sheet
 
-**Files to port:**
-- `feature/photos/RoverPhotosScreen.kt` →
-  `presentation/screens/PhotosScreen.kt`.
-- `feature/photos/EmptyPhotos.kt`, `feature/photos/FactCard.kt`, `feature/photos/Mapper.kt`
-  (anything still Android-only).
+**Goal:** replace the shared `ImagesScreen` placeholder with the real fullscreen gallery.
 
-**Already migrated:** `PhotosViewModel`, `GridItemTransformer`, `GridItem`, `RoverDateUtil`,
-`PhotosRepository`.
+**Port from legacy:**
+- `feature/images/ImagesScreen.kt`
+- `feature/images/PhotoInfoBottomSheet.kt`
 
-**Blockers:**
-| Blocker | Replacement |
-|---|---|
-| `R.string.*` | CMP resources |
-| `java.util.Calendar` / `TimeZone` for date math | kotlinx-datetime — already used elsewhere in shared. |
-| `androidx.compose.material3.DatePicker` directly | Use `PlatformDatePickerDialog` (already in `presentation/ui`). |
-| `rememberSaveable { mutableStateOf(false) }` | OK in CMP — keep. |
+**Already available in shared:**
+- `ImageViewModel`
+- `ImageOperations`
+- `MarsImage`
+- `Modifier.zoomable`
 
-**DoD:** `PhotosScreen(roverId, …)` shows real photos for the rover, with the sol slider
-dialog and earth-date picker working on both platforms.
+**Use these replacements:**
+- Legacy JVM-only zoomable library → shared `Modifier.zoomable`
+- `BuildConfig.DEBUG` → `BuildInfo.isDebug`
+- Android image-open `Intent` → `openLocalImage(uri)` expect API if needed
+- `LocalHapticFeedback` can stay if it compiles in CMP
 
----
-
-### Ticket S3 — Image gallery + photo info sheet
-
-**Files:**
-- `feature/images/ImagesScreen.kt` → `presentation/screens/ImagesScreen.kt`.
-- `feature/images/PhotoInfoBottomSheet.kt` → `presentation/screens/PhotoInfoBottomSheet.kt`.
-
-**Already migrated:** `ImageViewModel`, `ImageOperations` (interface), `MarsImage` entity.
-
-**Blockers:**
-| Blocker | Replacement |
-|---|---|
-| `net.engawapg.lib.zoomable` (`rememberZoomState`, `Modifier.zoomable`) | Custom `Modifier.zoomable(state)` shipped in S0 |
-| `BuildConfig.DEBUG` | `BuildInfo.isDebug` (S0) |
-| `Intent.ACTION_VIEW` to open saved image | `openLocalImage(uri)` expect (S0) |
-| `LocalHapticFeedback` | Works in CMP — keep |
-
-**iOS gap unblocked here:** `IosImageOperations.saveImage` / `shareImage` must be
-implemented before this screen is useful on iOS — see §6.2. Until then the screen still
-renders and pages through images on iOS, but Save/Share show an error snackbar.
-
-**DoD:** Fullscreen swipeable gallery with zoom and tap-to-toggle UI works on both
-platforms. Share works on Android via `UIActivityViewController` on iOS (after §6.2).
+**Definition of Done:**
+- Fullscreen image paging works.
+- Zoom and pan work.
+- Tap-to-toggle controls work.
+- Photo info sheet works.
+- Android share/save still works.
+- iOS renders the screen; Save/Share can remain limited until ticket `6.2`.
 
 ---
 
 ### Ticket S4 — Favorites
 
-**Files:** `feature/favorite/FavoriteScreen.kt` → `presentation/screens/FavoriteScreen.kt`.
+**Goal:** replace the shared `FavoriteScreen` placeholder with the real favorites grid.
 
-**Already migrated:** `FavoriteImagesViewModel` (clean common ViewModel exists alongside
-the legacy `AndroidViewModel` variant — discard the legacy one).
+**Port from legacy:**
+- `feature/favorite/FavoriteScreen.kt`
 
-**Blockers:**
-| Blocker | Replacement |
-|---|---|
-| `androidx.paging.compose.LazyPagingItems` / `collectAsLazyPagingItems()` | Paging Compose multiplatform (S0) |
-| `R.string.*`, `R.drawable.*` | CMP resources |
-| `java.util.UUID` | `kotlin.uuid.Uuid.random()` (Kotlin 2.0+) |
-| `Prefs` direct access | `AppSettings` via Koin |
+**Already available in shared:**
+- Common `FavoriteImagesViewModel`
+- Shared `MarsImageComposable`
+- Paging Compose dependency from S0
 
-**Reuse:** `MarsImageComposable` ported in S0.
+**Use these replacements:**
+- Android `LazyPagingItems` assumptions → multiplatform Paging Compose APIs
+- Android resources → Compose Multiplatform resources
+- `java.util.UUID` → `kotlin.uuid.Uuid.random()`
+- Direct `Prefs` access → `AppSettings` through Koin
 
-**DoD:** Favorites grid loads from Room on both platforms with proper Paging Compose.
-
----
-
-### Ticket S5 — Popular photos
-
-**Files:** extract a `PopularScreen` composable (it's currently implemented inline in legacy
-through the same scaffolding `FavoriteScreen` uses) → `presentation/screens/PopularScreen.kt`.
-
-**Already migrated:** `PopularPhotosViewModel`, `PopularRemoteMediator`, `IFirebasePhotos` (Android impl real, iOS stub).
-
-**Caveats:**
-- On iOS the Firestore stub returns an empty list — Popular tab will be empty until §6.1 lands.
-- Same Paging Compose multiplatform dependency as S4.
-
-**DoD:** Popular tab renders the staggered grid on Android with real data; on iOS empty-state
-shows until Firebase iOS SDK is wired.
+**Definition of Done:**
+- Favorites grid loads from Room.
+- Favorite/unfavorite behavior still works.
+- Empty state works.
+- Android, iOS framework, and Desktop compile.
 
 ---
 
-### Ticket S6 — Mission info
+### Ticket S5 — Popular Photos
 
-**Files:** `feature/mission/RoverMissionInfoScreen.kt` →
-`presentation/screens/MissionInfoScreen.kt`.
+**Goal:** extract and migrate the popular-photos tab into shared UI.
 
-**Already migrated:** `RoverMissionInfoViewModel`, `RoverMissionData`, `CameraSpec`,
-`MissionInfoUtils`.
+**Port from legacy:**
+- Popular tab UI currently embedded in the legacy favorite/popular scaffolding
+- Create `presentation/screens/PopularScreen.kt`
 
-**Blockers:**
-| Blocker | Replacement |
-|---|---|
-| `LocalContext.current` to resolve `rover.drawableRes(context)` | `Rover.painter()` (added in S1) |
-| `java.text.NumberFormat` | Tiny common `formatThousands(Long)` helper |
-| `coil3.compose.AsyncImage` | Already CMP-compatible. Keep. |
+**Already available in shared:**
+- `PopularPhotosViewModel`
+- `PopularRemoteMediator`
+- `IFirebasePhotos`
 
-**DoD:** Mission info screen renders the rover header, mission stats, and camera grid
-on both platforms.
+**Important caveat:**
+- Android can show real data.
+- iOS will show the empty state until Firebase iOS work in ticket `6.1` is done.
 
----
-
-### Ticket S7 — About / settings
-
-**Files:** `feature/settings/AboutAppScreen.kt` →
-`presentation/screens/AboutScreen.kt`.
-
-**Blockers:**
-| Blocker | Replacement |
-|---|---|
-| `BuildConfig.VERSION_NAME` | `BuildInfo.versionName` (S0) |
-| `R.drawable.alien_icon`, `R.string.about_description` | CMP resources |
-| `Prefs.themeLiveData` | `AppSettings.themeFlow` |
-| `Calendar` for "Year ${year}" copyright | kotlinx-datetime |
-| "Clear cache" hook that touches Coil's disk cache + Android `Formatter.formatFileSize` | Inject a `CacheManager` interface; Android impl uses `coil3.ImageLoader(context).diskCache`; iOS/desktop use Coil 3 KMP cache APIs (Coil 3 disk cache is multiplatform). Format bytes manually. |
-
-**DoD:** Settings screen lets the user pick theme, toggle facts, clear cache, rate app
-(via `openAppStore`), all on both platforms.
+**Definition of Done:**
+- Popular tab renders the grid on Android with real data.
+- iOS and Desktop compile and show a sane empty state where Firebase is not available.
 
 ---
 
-### Ticket S8 — Ukraine route decision
+### Ticket S6 — Mission Info
 
-**Files:** `feature/ukraine/Ukraine.kt` → `presentation/screens/UkraineScreen.kt`
-plus `presentation/ui/UkraineBanner.kt`.
+**Goal:** replace the shared mission placeholder with the real rover mission detail screen.
 
-**Blockers:**
-| Blocker | Replacement |
-|---|---|
-| `RoverApplication.APP.dataManger.trackClick` | Injected `Tracker` |
-| `recordException(e)` | `recordException` expect (S0) |
-| `LocalUriHandler.current` | Use the existing CMP `LocalUriHandler` — works on all platforms. |
+**Port from legacy:**
+- `feature/mission/RoverMissionInfoScreen.kt`
 
-**Decision point:** the Ukraine banner is part of the root scaffold today. After S1, that
-banner lives in `commonMain` and is shown on both platforms.
+**Already available in shared:**
+- `RoverMissionInfoViewModel`
+- `RoverMissionData`
+- `CameraSpec`
+- `MissionInfoUtils`
+- `Rover.painter()` from S1
 
-**DoD:** Ukraine banner appears under the status bar on both platforms; tapping pushes
-`UkraineScreen` which contains the messaging + outbound links.
+**Use these replacements:**
+- `LocalContext.current` image lookup → `Rover.painter()`
+- `java.text.NumberFormat` → small common thousands-format helper
+- `coil3.compose.AsyncImage` can stay
+
+**Definition of Done:**
+- Rover header renders.
+- Mission stats render.
+- Camera grid renders.
+- Android, iOS framework, and Desktop compile.
 
 ---
 
-### Ticket S9 — Android widget (no migration, keep & adapt)
+### Ticket S7 — About / Settings
 
-**Files stay in `androidApp/`:**
-- `widget/MarsPhotoWidget.kt`, `MarsPhotoWidgetReceiver.kt`, `MarsPhotoWidgetWorker.kt`,
-  `MarsPhotoWidgetConfigActivity.kt`.
+**Goal:** complete the shared About/settings screen.
+
+**Port from legacy:**
+- `feature/settings/AboutAppScreen.kt`
+
+**Use these replacements:**
+- `BuildConfig.VERSION_NAME` → `BuildInfo.versionName`
+- Android resources → Compose Multiplatform resources
+- `Prefs.themeLiveData` → `AppSettings.themeFlow`
+- Calendar year formatting → `kotlinx-datetime`
+- Android cache formatting → common byte formatting
+- Android rate-app intent → `openAppStore()` or platform callback
+
+**Definition of Done:**
+- Theme selection works.
+- Facts toggle works.
+- Clear cache works.
+- Rate app action works or degrades safely on each platform.
+- Android, iOS framework, and Desktop compile.
+
+---
+
+### Ticket S8 — Ukraine Route Decision
+
+**Goal:** decide and implement the shared Ukraine banner/screen flow.
+
+**Port from legacy:**
+- `feature/ukraine/Ukraine.kt`
+
+**Target shared files:**
+- `presentation/screens/UkraineScreen.kt`
+- `presentation/ui/UkraineBanner.kt`
+
+**Use these replacements:**
+- `RoverApplication.APP.dataManger.trackClick` → injected `Tracker`
+- Existing `recordException` expect API for error reporting
+- Existing CMP URI handler for outbound links
+
+**Definition of Done:**
+- Ukraine banner appears in the intended root location.
+- Tapping the banner opens `UkraineScreen`.
+- Outbound links work or degrade safely on all platforms.
+- Android, iOS framework, and Desktop compile.
+
+---
+
+### Ticket S9 — Android Widget Adaptation
+
+**Goal:** keep the widget Android-only, but make it use shared data contracts.
+
+**Keep in `androidApp/`:**
+- `widget/MarsPhotoWidget.kt`
+- `widget/MarsPhotoWidgetReceiver.kt`
+- `widget/MarsPhotoWidgetWorker.kt`
+- `widget/MarsPhotoWidgetConfigActivity.kt`
 
 **Work:**
-- Replace `Prefs.*` reads with `AppSettings` injected from the shared Koin container.
-- Replace direct DB access with the `ImagesRepository` interface.
-- Replace `RoverApplication.APP.tracker` with the `Tracker` from S0.
+- Replace `Prefs.*` reads with shared `AppSettings`.
+- Replace direct DB access with `ImagesRepository`.
+- Replace `RoverApplication.APP.tracker` with shared `Tracker`.
 
-**DoD:** Widget builds in `androidApp/`, talks to shared repositories, can still launch
-the app via `WidgetExtraImageId` deep link.
-
----
-
-## 6. iOS-specific work
-
-iOS can build the framework today, but two flows are stubbed and the Xcode project isn't
-checked in. These can run **in parallel** with the screen tickets (different files, no
-conflict) — they unblock real functionality, not compilation.
-
-### 6.1 Firebase iOS SDK
-
-`shared/.../iosMain/.../platform/FirebasePhotosImpl.ios.kt` and `FirebaseAnalytics.ios.kt`
-are no-op stubs.
-
-**Steps:**
-1. In `iosApp/Podfile`, add `pod 'FirebaseFirestore'`, `pod 'FirebaseAnalytics'`,
-   `pod 'FirebaseCrashlytics'`. Run `pod install`. Commit `Podfile.lock`.
-2. Add `iosApp/GoogleService-Info.plist` (not committed — keep `keystore.properties`-style
-   gitignored entry; provide a template).
-3. Bridge via Kotlin/Native cinterop. Two options:
-   - **Direct cinterop** to the ObjC Firebase classes (`FIRApp`, `FIRFirestore`, `FIRQuery`,
-     `FIRDocumentSnapshot`) — verbose but no extra layer.
-   - **GitLive Firebase KMP** (`dev.gitlive:firebase-firestore`, `firebase-analytics`,
-     `firebase-crashlytics`) — wraps both Android + iOS SDKs in one API. Strongly
-     recommended; adopt and rewrite both `AndroidFirebasePhotos` and `IosFirebasePhotos`
-     using the GitLive APIs in `commonMain` as a single class, dropping the expect/actual split.
-
-If choosing GitLive, also rewrite `FirebaseAnalytics` and `recordException` against
-`dev.gitlive:firebase-analytics` + `firebase-crashlytics`.
-
-**DoD:** Popular tab and stat counters work on iOS. Crashlytics receives test crash from iOS.
-
-### 6.2 Image save / share on iOS
-
-`IosImageOperations.saveImage` / `shareImage` are stubs returning `Error`.
-
-**saveImage:**
-1. Download bytes via `NSURLSession.sharedSession.dataTaskWithRequest(...)`.
-2. Wrap in `UIImage(data: …)`.
-3. Request `PHPhotoLibrary.requestAuthorizationForAccessLevel(.addOnly)`.
-4. `PHPhotoLibrary.sharedPhotoLibrary.performChanges { PHAssetChangeRequest.creationRequestForAssetFromImage(...) }`.
-5. Add `NSPhotoLibraryAddUsageDescription` to `iosApp/iosApp/Info.plist`.
-
-**shareImage:**
-1. Build `UIActivityViewController(activityItems = [imageUrl, shareText])`.
-2. Present from the topmost `UIViewController` (helper: walk `keyWindow.rootViewController`).
-3. Handle iPad popover-source bug — set `popoverPresentationController.sourceView`.
-
-**DoD:** From `ImagesScreen`, Save lands the photo in the iOS Photos app and Share opens
-the native share sheet.
-
-### 6.3 Xcode project bootstrap
-
-Today nothing under `iosApp/` is buildable without doing the manual setup in `SETUP.md`.
-
-**Steps (one-time):**
-1. Create `iosApp/iosApp.xcodeproj` using Xcode "iOS App" template, point it at the existing
-   Swift files in `iosApp/iosApp/`.
-2. Add a "Build Shared Framework" Run Script Phase before Compile Sources:
-   ```bash
-   cd "$SRCROOT/.."
-   ./gradlew :shared:embedAndSignAppleFrameworkForXcode \
-     -Pkotlin.native.cocoapods.target=$ARCHS \
-     -Pkotlin.native.cocoapods.configuration=$CONFIGURATION
-   ```
-   (or use the `cocoapods` Gradle plugin and `pod install`).
-3. Add Framework Search Path: `$(BUILT_PRODUCTS_DIR)/../shared.framework` (or use
-   `embedAndSignAppleFrameworkForXcode` which handles this).
-4. Commit `iosApp/iosApp.xcodeproj` and `iosApp/Podfile.lock`.
-
-**Strongly recommended:** enable the `kotlin("native.cocoapods")` plugin in
-`shared/build.gradle.kts` and generate `shared.podspec`. That removes the manual framework
-linking step and makes `pod install` from `iosApp/` self-sufficient.
-
-**DoD:** A teammate can clone, `pod install` in `iosApp/`, open `iosApp.xcworkspace`,
-hit Run, and see the app.
-
-### 6.4 iOS deep links
-
-`MainActivity` already converts `marsrover://rover/{id}` and `https://marsroverphotos.app/...`
-into `DeepLink`. On iOS, replicate in Swift:
-
-- Add `CFBundleURLSchemes = ["marsrover"]` to `Info.plist`.
-- Add Associated Domains entitlement for `applinks:marsroverphotos.app` (requires Apple Developer
-  AASA file hosted at `https://marsroverphotos.app/.well-known/apple-app-site-association`).
-- In `MarsRoverApp.swift`:
-  ```swift
-  @State private var pendingDeepLink: DeepLink? = nil
-  …
-  WindowGroup {
-      ContentView(deepLink: pendingDeepLink, onConsumed: { pendingDeepLink = nil })
-        .onOpenURL { url in pendingDeepLink = parseDeepLink(url) }
-        .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in
-            pendingDeepLink = activity.webpageURL.flatMap(parseDeepLink)
-        }
-  }
-  ```
-- `ContentView` passes `deepLink` to `Main_iosKt.MainViewController(deepLink:onConsumed:)` —
-  this means updating `Main.ios.kt` to accept the same args as `App()`.
-
-**DoD:** Tapping `marsrover://rover/5` in Safari on iOS navigates to the Curiosity photos
-screen.
+**Definition of Done:**
+- Widget builds from `androidApp`.
+- Widget reads shared settings/repositories.
+- Widget can still deep link into the app through `WidgetExtraImageId`.
 
 ---
 
-## 7. Android-only modules to leave in `androidApp/`
+## iOS Work That Can Run in Parallel
 
-These are intentionally **not** ported — they don't belong in `commonMain`.
+### 6.1 — Firebase iOS SDK
 
-| Concern | Stays where | Notes |
-|---|---|---|
-| AdMob banner | `androidApp/` | Expose `AdSlot()` expect-composable; iOS/desktop return `Box`. |
-| UMP / GDPR consent | `androidApp/` (`GdprHelper.kt`) | Expose `rememberConsentFlow()` expect; iOS/desktop no-op. |
-| Glance widget | `androidApp/widget/` | App Widget is Android-only. Talk to shared repos via injected Koin scope. |
-| Firebase Crashlytics init / Performance | `androidApp/MarsRoverApplication.kt` | Already wired correctly. |
-| Splashscreen (`installSplashScreen`) | `androidApp/MainActivity.kt` | Already wired. iOS uses LaunchScreen storyboard. |
-| Mission/facts uploader admin tools (`firebase/mission/*`, `firebase/facts/*`) | `androidApp/` (debug-only) | Developer maintenance — gate behind `BuildInfo.isDebug`. |
-| `MainActivity` deep-link Intent parsing | `androidApp/` | Translates Android Intent → common `DeepLink`. |
+**Goal:** make Firebase-backed features work on iOS.
+
+**Work:**
+- Add Firebase dependencies to `iosApp/Podfile`.
+- Keep `GoogleService-Info.plist` local/gitignored and provide a template if needed.
+- Prefer GitLive Firebase KMP if it reduces platform-specific wrapper code.
+- Replace the current iOS no-op Firebase implementations.
+
+**Definition of Done:**
+- Popular data works on iOS.
+- Analytics works on iOS.
+- Crashlytics can receive a test crash from iOS.
 
 ---
 
-## 8. Build / verification checklist
+### 6.2 — Image Save / Share on iOS
 
-After each ticket:
+**Goal:** make image save and share useful from the iOS gallery.
+
+**Work:**
+- Implement `IosImageOperations.saveImage`.
+- Request add-only Photos permission.
+- Add `NSPhotoLibraryAddUsageDescription`.
+- Implement `IosImageOperations.shareImage` with a native share sheet.
+- Handle iPad popover source configuration.
+
+**Definition of Done:**
+- Save writes the current photo to the iOS Photos app.
+- Share opens the native iOS share sheet from `ImagesScreen`.
+
+---
+
+### 6.3 — Xcode Project Bootstrap
+
+**Goal:** make the iOS app buildable by a teammate without manual project setup.
+
+**Work:**
+- Check in an iOS Xcode project/workspace.
+- Wire the shared framework build step.
+- Prefer a CocoaPods-based setup if it makes framework integration cleaner.
+- Commit `Podfile.lock` if CocoaPods is used.
+
+**Definition of Done:**
+- A teammate can clone, run `pod install` if needed, open the workspace/project, press Run,
+  and see the app.
+
+---
+
+### 6.4 — iOS Deep Links
+
+**Goal:** match Android deep-link behavior on iOS.
+
+**Work:**
+- Add `marsrover://` URL scheme.
+- Add associated domains for universal links if the required AASA file is hosted.
+- Parse incoming Swift URLs into shared `DeepLink`.
+- Pass the pending deep link into `MainViewController`.
+
+**Definition of Done:**
+- Opening `marsrover://rover/5` on iOS navigates to Curiosity photos.
+- Universal links work once domain setup is available.
+
+---
+
+## Verification
+
+Before declaring a ticket done, run:
 
 ```bash
-./gradlew :shared:assemble                  # all targets compile
-./gradlew :shared:linkDebugFrameworkIosSimulatorArm64
-./gradlew :androidApp:assembleDebug
-./gradlew :desktopApp:run
-./gradlew :shared:testDebugUnitTest
-./gradlew detekt
+./gradlew :androidApp:assembleDebug \
+          :shared:linkDebugFrameworkIosSimulatorArm64 \
+          :shared:testDebugUnitTest detekt
 ```
 
-Manual smoke flow per platform:
-- **Android emulator:** open app → cycle through 4 bottom tabs → drill into a rover → open a
-  photo → save → share.
-- **iOS simulator (after §6.3):** same flow. Skip save/share assertions until §6.2 is in.
-- **Desktop:** `./gradlew :desktopApp:run` → confirm the same tabs render. Acceptable to skip
-  Firebase-driven Popular tab on desktop.
+Use extra checks when they are relevant:
 
-CI gate to add (suggested): `:shared:compileKotlinIosSimulatorArm64` + `:androidApp:assembleDebug`
-on every PR.
+```bash
+./gradlew :shared:compileKotlinDesktop
+./gradlew :desktopApp:run
+./gradlew connectedDebugAndroidTest
+```
 
----
+Manual smoke flow after migrated screens exist:
 
-## 9. Risks & sequencing notes
-
-- **Single biggest risk:** the `shared` module is configured as `android.library + kotlin.multiplatform`
-  with `android.builtInKotlin=false` and `android.newDsl=false` (see `gradle.properties`). AGP 9.0
-  expects KMP libraries to use `com.android.kotlin.multiplatform.library`. Migrating to that
-  plugin is a separate ticket — track it but don't block S0 on it.
-- **Paging Compose multiplatform** (3.4.2) should be stable now, but if iOS bindings still
-  misbehave, fall back to `app.cash.paging:paging-compose-common` (the Cash App fork is
-  rock-solid on iOS).
-- **Coil 3 KMP** image loader is already wired in `shared` deps, so `AsyncImage` / `rememberAsyncImagePainter`
-  should "just work" on iOS. If you see crashes loading images, double-check that the
-  `coil-network-ktor` is present.
-- **Compose Multiplatform 1.10.3 + Material3 adaptive APIs** (`NavigationSuiteScaffold`,
-  `currentWindowAdaptiveInfo`, `calculateFromAdaptiveInfo`) — confirm the
-  `material3-adaptive-navigation-suite` artifact (1.4.0) is wired into `commonMain`
-  before S1; today it only ships with Compose BOM on Android.
-- **ViewModel `viewModelScope` on iOS** — works as of Kotlin 2.3.21 + Lifecycle 2.10.0. If
-  init-time coroutines never fire on iOS, double-check the `lifecycle.runtime.compose.multiplatform`
-  artifact is present (it is).
-- **Don't touch legacy `app/`** during the migration. It's already excluded from `settings.gradle.kts`.
-  Use it as the reference implementation, then delete the whole module at the end of S9.
+1. Open the app.
+2. Cycle through Rovers, Favorites, Popular, and About.
+3. Open a rover.
+4. Open a photo.
+5. Exercise save/share where the platform supports it.
 
 ---
 
-## 10. Suggested order & rough sizing
+## Whole Migration Done Means
 
-Single-engineer days, assuming the engineer is comfortable with KMP + CMP:
-
-| Ticket | Est. | Notes |
-|---|---:|---|
-| S0 Cross-cutting | 2–3 d | Resources port + Tracker + BuildInfo + paging-compose + zoomable + MarsImageComposable port |
-| S1 Rovers home | 1 d | Most groundwork done by S0; just port the composables. |
-| S2 Photos | 1.5 d | Date pickers / sol UI is the meaty part. |
-| S3 Image gallery | 1.5 d | Custom zoomable + bottom sheet. iOS save/share blocked on §6.2. |
-| S4 Favorites | 0.5 d | Paging compose is the main risk. |
-| S5 Popular | 0.5 d | Mostly the same as S4. |
-| S6 Mission info | 1 d | Long but straightforward. |
-| S7 About / settings | 1 d | Coil cache clearing on iOS is the only twist. |
-| S8 Ukraine | 0.5 d | Easy. |
-| S9 Widget adaptation | 0.5 d | Android only. |
-| §6.1 Firebase iOS | 1–2 d | If we adopt GitLive Firebase KMP. |
-| §6.2 iOS save/share | 1 d | cinterop with PhotoKit + UIActivityViewController. |
-| §6.3 Xcode project | 0.5 d | One-time; commit project + Podfile.lock. |
-| §6.4 iOS deep links | 0.5 d | Plus AASA file hosting. |
-| §8 Stabilize + delete `app/` | 0.5 d | Removal commit, manifest cleanup. |
-
-**Total:** ~13–16 engineering days, depending on Firebase strategy and zoom polish.
+1. `settings.gradle.kts` lists only active KMP app modules; legacy `:app` is gone.
+2. `PlaceholderScreens.kt` is gone.
+3. Every `AppDestination` maps to a real shared composable or a platform-owned route.
+4. Android has feature parity with the legacy app.
+5. iOS builds and runs from a checked-in project/workspace.
+6. iOS has Firebase, save/share, and deep-link behavior.
+7. Desktop opens the same shared UI, with acceptable no-op behavior for mobile-only features.
+8. CI runs the important Android, iOS framework, unit-test, and detekt checks.
 
 ---
 
-## 11. Definition of "done" for the whole migration
+## Reference Details
 
-1. `settings.gradle.kts` lists `:shared`, `:androidApp`, `:iosApp` (Xcode-driven), `:desktopApp`. Legacy `:app` directory deleted.
-2. `shared/src/commonMain/.../presentation/screens/PlaceholderScreens.kt` is gone — every `AppDestination`
-   maps to a real composable.
-3. `./gradlew :androidApp:assembleDebug` builds; the resulting APK has feature parity with
-   the legacy app (rovers list, photos, gallery, favorites, popular, mission info, about, Ukraine, widget).
-4. `./gradlew :shared:linkDebugFrameworkIosSimulatorArm64` builds; `iosApp.xcworkspace`
-   opens, builds, and runs in the simulator with the same feature set (Firebase + photo
-   save/share included, GoogleService-Info.plist supplied locally).
-5. `./gradlew :desktopApp:run` opens the app with the same UI (Firebase / AdMob slots are
-   no-ops — acceptable).
-6. `detekt` + unit tests pass on CI for every push to main.
+The sections below are for implementation context. They are intentionally below the main plan.
+
+### Module Layout
+
+```text
+settings.gradle.kts
+├── :shared      common KMP code, Compose UI, domain/data, DI
+├── :androidApp  Android shell: Activity, manifest, app icons, Android-only services
+├── :desktopApp  Desktop shell
+├── iosApp/      Swift/iOS shell; project bootstrap still pending
+└── app/         legacy Android app, reference-only during migration
+```
+
+### Source Set Responsibilities
+
+- `shared/src/commonMain`: shared domain, repositories, view models, common Compose UI,
+  common navigation, common interfaces, and common resources.
+- `shared/src/androidMain`: Android actuals and Android platform integrations.
+- `shared/src/iosMain`: iOS actuals and iOS platform integrations.
+- `shared/src/desktopMain`: Desktop actuals and Desktop platform integrations.
+- `androidApp/`: Android app shell and Android-only features.
+- `iosApp/`: Swift shell, iOS project files, iOS app metadata.
+- `desktopApp/`: Desktop app shell.
+- `app/`: legacy reference only; do not edit during screen migration.
+
+### Shared Code Already Available
+
+- Domain models and repository interfaces for rovers, photos, images, facts, mission data,
+  settings, and themes.
+- Room database, DAOs, network API, repository implementations, and paging mediator.
+- Shared app entry, Navigation 3 destinations, navigator, and Koin navigation entries.
+- Shared view models for photos, image gallery, favorites, popular photos, mission info,
+  about/settings, and rovers.
+- Shared UI helpers: material-symbol icons, snackbar, platform date picker, toast host,
+  URI handling, dynamic color/system theme expects, adaptive layout, zoom, image cards,
+  rover painter, ad slot, and bottom navigation.
+
+### Legacy Reference Files
+
+Use these files as references only:
+
+| Legacy area | Reference files |
+|---|---|
+| Rovers home | `feature/rovers/RoversActivity.kt`, `feature/rovers/RoversNavigation.kt` |
+| Rover photos | `feature/photos/RoverPhotosScreen.kt`, `EmptyPhotos.kt`, `FactCard.kt`, `Mapper.kt` |
+| Gallery | `feature/images/ImagesScreen.kt`, `PhotoInfoBottomSheet.kt` |
+| Favorites | `feature/favorite/FavoriteScreen.kt` |
+| Popular | Popular UI embedded around the legacy favorite/popular flow |
+| Mission info | `feature/mission/RoverMissionInfoScreen.kt` |
+| About/settings | `feature/settings/AboutAppScreen.kt` |
+| Ukraine | `feature/ukraine/Ukraine.kt` |
+| Widget | `widget/*` |
+
+### Do Not Move These Into `commonMain`
+
+- Android `Application`, `Activity`, `ComponentActivity`, manifests, intents, splash setup,
+  edge-to-edge setup, Android system UI/theme APIs.
+- Android `R.string`, `R.drawable`, `painterResource`, `stringResource`.
+- `AndroidViewModel`, `Application` injection, `koin-android`.
+- Firebase Android SDKs, Google Play services, AdMob, UMP, Glance, WorkManager.
+- `room-ktx`, `room-paging`, Android `Room.databaseBuilder(context, ...)`.
+- `SharedPreferences`, `Context`, `Bitmap`, `MediaStore`, `ContentResolver`.
+- Android platform Ktor engines.
+- AndroidX Navigation 3 APIs that are not available to the enabled shared targets.
+- `Parcelable`, `@Parcelize`, AndroidX annotations like `@DrawableRes`.
+- Timber.
+
+### Preferred Common Replacements
+
+- KMP `ViewModel`.
+- Injected repositories/settings.
+- Compose Multiplatform resources.
+- Common interfaces with platform actuals or callbacks.
+- Koin core, Koin Compose, and Koin ViewModel APIs.
+- Kermit/logging wrapper.
+- Ktor core in common with platform engines in source sets.
+- Room runtime only for enabled Android/iOS/Desktop targets.
+
+### Android-Only Features That Stay in `androidApp`
+
+| Concern | Owner |
+|---|---|
+| AdMob banner | Android app shell or Android actual slot |
+| GDPR/UMP consent | Android app shell |
+| Glance widget | `androidApp/widget/` |
+| Firebase Crashlytics init / Performance | `androidApp/MarsRoverApplication.kt` |
+| Splashscreen | `androidApp/MainActivity.kt` |
+| Mission/facts uploader tooling | Android debug-only tooling |
+| Android intent parsing | `androidApp/MainActivity.kt`, converted to shared `DeepLink` |
+
+### Known Caveats
+
+- The shared module still uses `kotlin.multiplatform + com.android.library` with AGP compatibility
+  flags. Migrating to `com.android.kotlin.multiplatform.library` is separate work.
+- Some dependency-resolution warnings mention `iosX64`; the required simulator framework target is
+  `iosSimulatorArm64`.
+- Material3 adaptive navigation suite is not currently usable from this shared iOS setup.
+- Popular photos on iOS stay empty until Firebase iOS is implemented.
+- Save/share on iOS stays limited until ticket `6.2`.
+- Desktop can use no-op Firebase/ad behavior as long as shared UI compiles and opens.
+
+### Version Details
+
+This plan deliberately does not list library versions. Use `gradle/libs.versions.toml` as the
+source of truth for versions.

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/di/NavigationModule.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/di/NavigationModule.kt
@@ -21,6 +21,9 @@ val navigationModule = module {
         RoversScreen(
             onNavigateToPhotos = { roverId ->
                 navigator.navigate(AppDestination.Photos(roverId))
+            },
+            onMissionInfoClick = { roverId ->
+                navigator.navigate(AppDestination.Mission(roverId))
             }
         )
     }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/di/ViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/di/ViewModelModule.kt
@@ -5,6 +5,7 @@ import com.sirelon.marsroverphotos.presentation.viewmodels.FavoriteImagesViewMod
 import com.sirelon.marsroverphotos.presentation.viewmodels.ImageViewModel
 import com.sirelon.marsroverphotos.presentation.viewmodels.PhotosViewModel
 import com.sirelon.marsroverphotos.presentation.viewmodels.PopularPhotosViewModel
+import com.sirelon.marsroverphotos.presentation.viewmodels.RoversViewModel
 import com.sirelon.marsroverphotos.presentation.viewmodels.RoverMissionInfoViewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
@@ -20,5 +21,6 @@ val viewModelModule = module {
     viewModelOf(::ImageViewModel)
     viewModelOf(::PhotosViewModel)
     viewModelOf(::PopularPhotosViewModel)
+    viewModelOf(::RoversViewModel)
     viewModelOf(::RoverMissionInfoViewModel)
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppNavigation.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppNavigation.kt
@@ -1,5 +1,8 @@
 package com.sirelon.marsroverphotos.presentation.navigation
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -9,9 +12,12 @@ import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
 import androidx.savedstate.serialization.SavedStateConfiguration
+import com.sirelon.marsroverphotos.platform.Tracker
+import com.sirelon.marsroverphotos.presentation.ui.AdSlot
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
+import org.koin.compose.koinInject
 import org.koin.compose.navigation3.koinEntryProvider
 import org.koin.core.annotation.KoinExperimentalAPI
 
@@ -33,6 +39,8 @@ fun AppNavigation(
     val navigator = remember(backStack) { AppNavigator(backStack) }
     val entryDecorators = rememberAppNavEntryDecorators()
     val entryProvider = koinEntryProvider<NavKey>()
+    val tracker: Tracker = koinInject()
+    val currentDestination = backStack.lastOrNull() as? AppDestination ?: startDestination
 
     LaunchedEffect(deepLink) {
         val target = deepLink ?: return@LaunchedEffect
@@ -44,15 +52,47 @@ fun AppNavigation(
     }
 
     CompositionLocalProvider(LocalAppNavigator provides navigator) {
-        NavDisplay(
-            backStack = backStack,
-            modifier = modifier,
-            onBack = { navigator.goBack() },
-            entryDecorators = entryDecorators,
-            entryProvider = entryProvider
-        )
+        Column(modifier = modifier) {
+            Box(modifier = Modifier.weight(1f)) {
+                NavDisplay(
+                    backStack = backStack,
+                    onBack = { navigator.goBack() },
+                    entryDecorators = entryDecorators,
+                    entryProvider = entryProvider
+                )
+            }
+            AdSlot(modifier = Modifier.fillMaxWidth())
+            MarsBottomBar(
+                selectedDestination = currentDestination.topLevelDestination(),
+                onDestinationClick = { destination ->
+                    tracker.trackClick("bottom_${destination.analyticsTag}")
+                    navigator.selectTopLevel(destination)
+                }
+            )
+        }
     }
 }
+
+private fun AppDestination.topLevelDestination(): AppDestination {
+    return when (this) {
+        AppDestination.Rovers,
+        is AppDestination.Photos,
+        is AppDestination.Images,
+        is AppDestination.Mission -> AppDestination.Rovers
+        AppDestination.Favorite -> AppDestination.Favorite
+        AppDestination.Popular -> AppDestination.Popular
+        AppDestination.About -> AppDestination.About
+    }
+}
+
+private val AppDestination.analyticsTag: String
+    get() = when (this) {
+        AppDestination.Rovers -> "rovers"
+        AppDestination.Favorite -> "favorite"
+        AppDestination.Popular -> "popular"
+        AppDestination.About -> "about"
+        else -> "other"
+    }
 
 private val navBackStackConfiguration = SavedStateConfiguration {
     serializersModule = SerializersModule {

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppNavigator.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppNavigator.kt
@@ -19,6 +19,17 @@ class AppNavigator(
         }
     }
 
+    fun selectTopLevel(destination: AppDestination) {
+        while (backStack.size > 1) {
+            backStack.removeLastOrNull()
+        }
+        if (backStack.isEmpty()) {
+            backStack.add(destination)
+        } else {
+            backStack[0] = destination
+        }
+    }
+
     fun goBack(): Boolean {
         if (backStack.size <= 1) {
             return false

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/MarsBottomBar.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/MarsBottomBar.kt
@@ -1,0 +1,132 @@
+package com.sirelon.marsroverphotos.presentation.navigation
+
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbol
+import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbolIcon
+import com.sirelon.marsroverphotos.shared.resources.Res
+import com.sirelon.marsroverphotos.shared.resources.ic_rovers
+import com.sirelon.marsroverphotos.shared.resources.nav_about
+import com.sirelon.marsroverphotos.shared.resources.nav_favorite
+import com.sirelon.marsroverphotos.shared.resources.nav_popular
+import com.sirelon.marsroverphotos.shared.resources.nav_rovers
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+
+public val marsTopLevelDestinations: List<AppDestination> = listOf(
+    AppDestination.Rovers,
+    AppDestination.Favorite,
+    AppDestination.Popular,
+    AppDestination.About,
+)
+
+@Composable
+public fun MarsBottomBar(
+    selectedDestination: AppDestination,
+    onDestinationClick: (AppDestination) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+) {
+    MarsNavigationBar(
+        selectedDestination = selectedDestination,
+        onDestinationClick = onDestinationClick,
+        modifier = modifier,
+        enabled = enabled,
+    )
+}
+
+@Composable
+public fun MarsNavigationBar(
+    selectedDestination: AppDestination,
+    onDestinationClick: (AppDestination) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+) {
+    NavigationBar(modifier = modifier) {
+        marsNavigationItems.forEach { item ->
+            val selected = item.destination == selectedDestination
+            val label = stringResource(item.label)
+
+            NavigationBarItem(
+                selected = selected,
+                enabled = enabled,
+                onClick = { onDestinationClick(item.destination) },
+                icon = {
+                    MarsNavigationIcon(
+                        icon = item.icon,
+                        selected = selected,
+                        contentDescription = label,
+                    )
+                },
+                label = { Text(text = label) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun MarsNavigationIcon(
+    icon: MarsNavigationItemIcon,
+    selected: Boolean,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+) {
+    when (icon) {
+        is MarsNavigationItemIcon.Drawable -> {
+            Icon(
+                painter = painterResource(icon.resource),
+                contentDescription = contentDescription,
+                modifier = modifier,
+            )
+        }
+        is MarsNavigationItemIcon.Symbol -> {
+            MaterialSymbolIcon(
+                symbol = icon.symbol,
+                contentDescription = contentDescription,
+                modifier = modifier,
+                filled = selected,
+            )
+        }
+    }
+}
+
+private data class MarsNavigationItem(
+    val destination: AppDestination,
+    val label: StringResource,
+    val icon: MarsNavigationItemIcon,
+)
+
+private sealed interface MarsNavigationItemIcon {
+    data class Drawable(val resource: DrawableResource) : MarsNavigationItemIcon
+
+    data class Symbol(val symbol: MaterialSymbol) : MarsNavigationItemIcon
+}
+
+private val marsNavigationItems = listOf(
+    MarsNavigationItem(
+        destination = AppDestination.Rovers,
+        label = Res.string.nav_rovers,
+        icon = MarsNavigationItemIcon.Drawable(Res.drawable.ic_rovers),
+    ),
+    MarsNavigationItem(
+        destination = AppDestination.Favorite,
+        label = Res.string.nav_favorite,
+        icon = MarsNavigationItemIcon.Symbol(MaterialSymbol.Favorite),
+    ),
+    MarsNavigationItem(
+        destination = AppDestination.Popular,
+        label = Res.string.nav_popular,
+        icon = MarsNavigationItemIcon.Symbol(MaterialSymbol.LocalFireDepartment),
+    ),
+    MarsNavigationItem(
+        destination = AppDestination.About,
+        label = Res.string.nav_about,
+        icon = MarsNavigationItemIcon.Symbol(MaterialSymbol.Info),
+    ),
+)

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PlaceholderScreens.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PlaceholderScreens.kt
@@ -21,18 +21,6 @@ import androidx.compose.ui.unit.dp
  */
 
 @Composable
-fun RoversScreen(onNavigateToPhotos: (Long) -> Unit) {
-    PlaceholderScreen(
-        title = "Rovers",
-        description = "Browse available Mars rovers\n\n(Screen pending migration)"
-    ) {
-        Button(onClick = { onNavigateToPhotos(5) }) {
-            Text("View Curiosity Photos")
-        }
-    }
-}
-
-@Composable
 fun PhotosScreen(roverId: Long, onNavigateToImages: () -> Unit, onNavigateToMission: (Long) -> Unit) {
     PlaceholderScreen(
         title = "Photos",

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoversScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoversScreen.kt
@@ -1,0 +1,163 @@
+package com.sirelon.marsroverphotos.presentation.screens
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.sirelon.marsroverphotos.domain.models.Rover
+import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbol
+import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbolIcon
+import com.sirelon.marsroverphotos.presentation.ui.painter
+import com.sirelon.marsroverphotos.presentation.viewmodels.RoversViewModel
+import com.sirelon.marsroverphotos.shared.resources.Res
+import com.sirelon.marsroverphotos.shared.resources.label_photos_total
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+fun RoversScreen(
+    onNavigateToPhotos: (Long) -> Unit,
+    onMissionInfoClick: (Long) -> Unit
+) {
+    val viewModel: RoversViewModel = koinViewModel()
+    val rovers by viewModel.rovers.collectAsStateWithLifecycle()
+
+    RoversContent(
+        rovers = rovers,
+        onClick = { rover ->
+            viewModel.onRoverClicked(rover)
+            onNavigateToPhotos(rover.id)
+        },
+        onMissionInfoClick = { rover ->
+            viewModel.onMissionInfoClicked(rover)
+            onMissionInfoClick(rover.id)
+        }
+    )
+}
+
+@Composable
+fun RoversContent(
+    rovers: List<Rover>,
+    onClick: (rover: Rover) -> Unit,
+    onMissionInfoClick: (rover: Rover) -> Unit
+) {
+    LazyColumn {
+        items(rovers, key = { it.id }) { item ->
+            RoverItem(
+                rover = item,
+                onClick = onClick,
+                onMissionInfoClick = onMissionInfoClick
+            )
+            HorizontalDivider()
+        }
+    }
+}
+
+@Composable
+fun RoverItem(
+    rover: Rover,
+    onClick: (rover: Rover) -> Unit,
+    onMissionInfoClick: (rover: Rover) -> Unit
+) {
+    Box {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .padding(8.dp)
+                .clickable(onClick = { onClick(rover) })
+        ) {
+            TitleText(rover.name)
+            InfoText(label = "Status:", text = rover.status)
+
+            val imageHeight = Modifier.height(175.dp)
+            Row(modifier = Modifier.padding(8.dp)) {
+                Image(
+                    contentScale = ContentScale.FillHeight,
+                    painter = rover.painter(),
+                    modifier = imageHeight
+                        .weight(1f)
+                        .clip(shape = MaterialTheme.shapes.large),
+                    contentDescription = rover.name
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Column(
+                    modifier = imageHeight.weight(1f),
+                    verticalArrangement = Arrangement.SpaceAround
+                ) {
+                    InfoText(
+                        label = stringResource(Res.string.label_photos_total),
+                        text = "${rover.totalPhotos}"
+                    )
+                    InfoText(label = "Last photo date:", text = rover.maxDate)
+                    InfoText(label = "Launch date from Earth:", text = rover.launchDate)
+                    InfoText(label = "Landing date on Mars:", text = rover.landingDate)
+                }
+            }
+        }
+        IconButton(
+            onClick = { onMissionInfoClick(rover) },
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(8.dp)
+        ) {
+            MaterialSymbolIcon(
+                symbol = MaterialSymbol.Info,
+                contentDescription = "Mission Info"
+            )
+        }
+    }
+}
+
+@Composable
+private fun TitleText(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.headlineMedium,
+        color = MaterialTheme.colorScheme.tertiary
+    )
+}
+
+@Composable
+private fun InfoText(label: String, text: String) {
+    val typography = MaterialTheme.typography
+    val textToShow = AnnotatedString.Builder().apply {
+        pushStyle(
+            typography.titleMedium.toSpanStyle()
+                .copy(color = MaterialTheme.colorScheme.secondary)
+        )
+        append("$label ")
+        pushStyle(
+            style = typography.titleSmall.toSpanStyle()
+                .copy(color = MaterialTheme.colorScheme.onSurface)
+        )
+        append(text)
+    }
+    Text(
+        text = textToShow.toAnnotatedString(),
+        textAlign = TextAlign.Center,
+        modifier = Modifier.fillMaxWidth()
+    )
+}

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/RoverPainter.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/RoverPainter.kt
@@ -1,0 +1,35 @@
+package com.sirelon.marsroverphotos.presentation.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.painter.Painter
+import com.sirelon.marsroverphotos.domain.models.CURIOSITY_ID
+import com.sirelon.marsroverphotos.domain.models.INSIGHT_ID
+import com.sirelon.marsroverphotos.domain.models.OPPORTUNITY_ID
+import com.sirelon.marsroverphotos.domain.models.PERSEVERANCE_ID
+import com.sirelon.marsroverphotos.domain.models.Rover
+import com.sirelon.marsroverphotos.domain.models.SPIRIT_ID
+import com.sirelon.marsroverphotos.shared.resources.Res
+import com.sirelon.marsroverphotos.shared.resources.img_curiosity
+import com.sirelon.marsroverphotos.shared.resources.img_insight
+import com.sirelon.marsroverphotos.shared.resources.img_opportunity
+import com.sirelon.marsroverphotos.shared.resources.img_perseverance
+import com.sirelon.marsroverphotos.shared.resources.img_placeholder
+import com.sirelon.marsroverphotos.shared.resources.img_spirit
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.painterResource
+
+@Composable
+public fun Rover.painter(): Painter {
+    return painterResource(drawableResource())
+}
+
+private fun Rover.drawableResource(): DrawableResource {
+    return when (id) {
+        PERSEVERANCE_ID -> Res.drawable.img_perseverance
+        INSIGHT_ID -> Res.drawable.img_insight
+        CURIOSITY_ID -> Res.drawable.img_curiosity
+        OPPORTUNITY_ID -> Res.drawable.img_opportunity
+        SPIRIT_ID -> Res.drawable.img_spirit
+        else -> Res.drawable.img_placeholder
+    }
+}

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/RoversViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/RoversViewModel.kt
@@ -1,0 +1,41 @@
+package com.sirelon.marsroverphotos.presentation.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.sirelon.marsroverphotos.domain.models.Rover
+import com.sirelon.marsroverphotos.domain.repositories.RoversRepository
+import com.sirelon.marsroverphotos.platform.Tracker
+import com.sirelon.marsroverphotos.utils.Logger
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.stateIn
+
+class RoversViewModel(
+    roversRepository: RoversRepository,
+    private val tracker: Tracker
+) : ViewModel() {
+
+    val rovers: StateFlow<List<Rover>> = roversRepository.getRovers()
+        .catch { e ->
+            Logger.e("RoversViewModel", e) { "Error loading rovers" }
+            emit(emptyList())
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS),
+            initialValue = emptyList()
+        )
+
+    fun onRoverClicked(rover: Rover) {
+        tracker.trackClick("click_rover_${rover.name}")
+    }
+
+    fun onMissionInfoClicked(rover: Rover) {
+        tracker.trackClick("click_mission_info_${rover.name}")
+    }
+
+    private companion object {
+        const val STOP_TIMEOUT_MILLIS = 5_000L
+    }
+}

--- a/shared/src/desktopMain/kotlin/com/sirelon/marsroverphotos/di/KoinInit.desktop.kt
+++ b/shared/src/desktopMain/kotlin/com/sirelon/marsroverphotos/di/KoinInit.desktop.kt
@@ -1,5 +1,6 @@
 package com.sirelon.marsroverphotos.di
 
+import com.sirelon.marsroverphotos.domain.repositories.RoversRepository
 import com.sirelon.marsroverphotos.platform.BuildInfo
 import org.koin.core.context.startKoin
 
@@ -14,13 +15,15 @@ fun initKoinDesktop() {
         packageName = "com.sirelon.marsroverphotos"
     )
 
-    startKoin {
+    val koinApplication = startKoin {
         modules(
             platformModule,      // Desktop-specific dependencies
             databaseModule,      // Room database and DAOs
             networkModule,       // Ktor and REST API
             repositoryModule,    // Repository implementations
-            viewModelModule      // ViewModels
+            viewModelModule,     // ViewModels
+            navigationModule     // Navigation 3 entries
         )
     }
+    koinApplication.koin.get<RoversRepository>().initialize()
 }

--- a/shared/src/iosMain/kotlin/com/sirelon/marsroverphotos/di/KoinInit.ios.kt
+++ b/shared/src/iosMain/kotlin/com/sirelon/marsroverphotos/di/KoinInit.ios.kt
@@ -1,5 +1,6 @@
 package com.sirelon.marsroverphotos.di
 
+import com.sirelon.marsroverphotos.domain.repositories.RoversRepository
 import com.sirelon.marsroverphotos.platform.BuildInfo
 import org.koin.core.context.startKoin
 import platform.Foundation.NSBundle
@@ -16,13 +17,15 @@ fun initKoinIos() {
         packageName = NSBundle.mainBundle.bundleIdentifier ?: "com.sirelon.marsroverphotos"
     )
 
-    startKoin {
+    val koinApplication = startKoin {
         modules(
             platformModule,      // iOS-specific dependencies
             databaseModule,      // Room database and DAOs
             networkModule,       // Ktor and REST API
             repositoryModule,    // Repository implementations
-            viewModelModule      // ViewModels
+            viewModelModule,     // ViewModels
+            navigationModule     // Navigation 3 entries
         )
     }
+    koinApplication.koin.get<RoversRepository>().initialize()
 }


### PR DESCRIPTION
Migrates Ticket S1 by replacing the shared Rovers placeholder with a real commonMain rover list backed by a new RoversViewModel and CMP rover image resources.
Adds common bottom navigation wiring, top-level selection handling, and mission/photos navigation callbacks while keeping Android-only shell concerns out of shared UI.
Updates desktop and iOS Koin startup so shared navigation entries are available and rover data is initialized, then marks S1 complete in KMP_MIGRATION_PLAN.md with the Material3 NavigationBar note.
Validation: ./gradlew :androidApp:assembleDebug :shared:linkDebugFrameworkIosSimulatorArm64 :shared:testDebugUnitTest detekt and ./gradlew :shared:compileKotlinDesktop.