### PR TITLE
S3: Migrate image gallery and photo info sheet to KMP

### DIFF
--- a/KMP_MIGRATION_PLAN.md
+++ b/KMP_MIGRATION_PLAN.md
@@ -418,7 +418,7 @@ dialog and earth-date picker working on both platforms.
 
 ---
 
-### Ticket S3 — Image gallery + photo info sheet
+### ~~Ticket S3 — Image gallery + photo info sheet~~ ✅
 
 **Files:**
 - `feature/images/ImagesScreen.kt` → `presentation/screens/ImagesScreen.kt`.
@@ -429,17 +429,26 @@ dialog and earth-date picker working on both platforms.
 **Blockers:**
 | Blocker | Replacement |
 |---|---|
-| `net.engawapg.lib.zoomable` (`rememberZoomState`, `Modifier.zoomable`) | Custom `Modifier.zoomable(state)` shipped in S0 |
-| `BuildConfig.DEBUG` | `BuildInfo.isDebug` (S0) |
-| `Intent.ACTION_VIEW` to open saved image | `openLocalImage(uri)` expect (S0) |
-| `LocalHapticFeedback` | Works in CMP — keep |
+| `net.engawapg.lib.zoomable` (`rememberZoomState`, `Modifier.zoomable`) | ✅ `Zoomable.kt` redesigned in S3 with proper `ZoomableState` (observable `scale`, `reset()`). |
+| `BuildConfig.DEBUG` | ✅ `BuildInfo.isDebug` |
+| `Intent.ACTION_VIEW` to open saved image | ✅ `LocalUriHandler.current.openUri(uri)` (CMP-native, works on Android content URIs) |
+| `LocalHapticFeedback` | ✅ Works in CMP — kept |
 
 **iOS gap unblocked here:** `IosImageOperations.saveImage` / `shareImage` must be
 implemented before this screen is useful on iOS — see §6.2. Until then the screen still
 renders and pages through images on iOS, but Save/Share show an error snackbar.
 
-**DoD:** Fullscreen swipeable gallery with zoom and tap-to-toggle UI works on both
-platforms. Share works on Android via `UIActivityViewController` on iOS (after §6.2).
+**DoD:**
+- ✅ `ImagesScreen.kt` and `PhotoInfoBottomSheet.kt` in `commonMain`, zero Android-only imports.
+- ✅ `AppDestination.Images` updated to carry `photoIds: List<String>` + `selectedId: String?`.
+- ✅ Horizontal pager with pinch-to-zoom and tap-to-toggle works; zoom resets on page change.
+- ✅ Save/share/info toolbar actions wired through `ImageViewModel`.
+- ✅ `UiEvent.ShareError` handled in the common screen (addition over legacy).
+- ✅ `String.format("%.1fK")` replaced with KMP-safe `formatStatValue()` in `PhotoInfoBottomSheet`.
+- ✅ `:androidApp:assembleDebug` and `:shared:linkDebugFrameworkIosSimulatorArm64` pass.
+
+*Note: `makePopular`/`removePopular` debug buttons are present but are no-ops — `ImagesRepository`
+common interface doesn't expose those Firebase methods. Wire them up when §6.1 (Firebase iOS) lands.*
 
 ---
 

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/di/NavigationModule.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/di/NavigationModule.kt
@@ -41,7 +41,8 @@ val navigationModule = module {
     navigation<AppDestination.Images> { destination ->
         val navigator = LocalAppNavigator.current
         ImagesScreen(
-            photoId = destination.photoId,
+            photoIds = destination.photoIds,
+            selectedId = destination.selectedId,
             onBack = { navigator.goBack() }
         )
     }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppDestinations.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppDestinations.kt
@@ -15,7 +15,10 @@ sealed interface AppDestination : NavKey {
     data class Photos(val roverId: Long) : AppDestination
 
     @Serializable
-    data class Images(val photoId: String? = null) : AppDestination
+    data class Images(
+        val photoIds: List<String> = emptyList(),
+        val selectedId: String? = null
+    ) : AppDestination
 
     @Serializable
     data object Favorite : AppDestination

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppNavigation.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppNavigation.kt
@@ -46,7 +46,12 @@ fun AppNavigation(
         val target = deepLink ?: return@LaunchedEffect
         when (target) {
             is DeepLink.Rover -> navigator.navigate(AppDestination.Photos(target.id))
-            is DeepLink.Photo -> navigator.navigate(AppDestination.Images(selectedId = target.id.toString()))
+            is DeepLink.Photo -> navigator.navigate(
+                AppDestination.Images(
+                    photoIds = listOf(target.id.toString()),
+                    selectedId = target.id.toString()
+                )
+            )
         }
         onDeepLinkConsumed?.invoke()
     }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppNavigation.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppNavigation.kt
@@ -38,7 +38,7 @@ fun AppNavigation(
         val target = deepLink ?: return@LaunchedEffect
         when (target) {
             is DeepLink.Rover -> navigator.navigate(AppDestination.Photos(target.id))
-            is DeepLink.Photo -> navigator.navigate(AppDestination.Images(target.id.toString()))
+            is DeepLink.Photo -> navigator.navigate(AppDestination.Images(selectedId = target.id.toString()))
         }
         onDeepLinkConsumed?.invoke()
     }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
@@ -79,6 +79,12 @@ fun ImagesScreen(
     onBack: () -> Unit,
     viewModel: ImageViewModel = koinViewModel(),
 ) {
+    // Guard: nothing to show → pop immediately instead of hanging on the loader.
+    if (photoIds.isEmpty()) {
+        LaunchedEffect(Unit) { onBack() }
+        return
+    }
+
     LaunchedEffect(photoIds) {
         viewModel.setIdsToShow(photoIds)
     }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
@@ -1,0 +1,382 @@
+package com.sirelon.marsroverphotos.presentation.screens
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.sirelon.marsroverphotos.data.database.entities.MarsImage
+import com.sirelon.marsroverphotos.platform.BuildInfo
+import com.sirelon.marsroverphotos.presentation.ui.CenteredProgress
+import com.sirelon.marsroverphotos.presentation.ui.MarsImageFavoriteToggle
+import com.sirelon.marsroverphotos.presentation.ui.MarsSnackbar
+import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbol
+import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbolIcon
+import com.sirelon.marsroverphotos.presentation.ui.NetworkImage
+import com.sirelon.marsroverphotos.presentation.ui.NoScrollEffect
+import com.sirelon.marsroverphotos.presentation.ui.rememberZoomableState
+import com.sirelon.marsroverphotos.presentation.ui.zoomable
+import com.sirelon.marsroverphotos.presentation.viewmodels.ImageViewModel
+import com.sirelon.marsroverphotos.presentation.viewmodels.UiEvent
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * Fullscreen image viewer — horizontal pager with pinch-to-zoom, save, share, info sheet.
+ *
+ * Ported from `app/.../feature/images/ImagesScreen.kt` to Compose Multiplatform.
+ *
+ * @param photoIds    Ordered list of image IDs to show in the pager.
+ * @param selectedId  Which ID to land on initially (null → first page).
+ * @param onBack      Navigate back (e.g. pop to Photos screen).
+ */
+@Composable
+fun ImagesScreen(
+    photoIds: List<String>,
+    selectedId: String?,
+    onBack: () -> Unit,
+    viewModel: ImageViewModel = koinViewModel(),
+) {
+    LaunchedEffect(photoIds) {
+        viewModel.setIdsToShow(photoIds)
+    }
+
+    DisposableEffect(photoIds) {
+        onDispose { /* nothing to clean up */ }
+    }
+
+    val initialPage = remember(photoIds, selectedId) {
+        selectedId?.let { photoIds.indexOf(it).takeIf { i -> i >= 0 } } ?: 0
+    }
+
+    val screenState by viewModel.screenState.collectAsStateWithLifecycle()
+    val images = screenState.images
+
+    val pagerState = rememberPagerState(
+        initialPage = initialPage,
+        pageCount = { images.size },
+    )
+
+    Crossfade(targetState = images.isEmpty(), label = "Images") { isEmpty ->
+        if (isEmpty) {
+            CenteredProgress()
+        } else {
+            ImagesPagerContent(
+                viewModel = viewModel,
+                list = images,
+                pagerState = pagerState,
+                hideUi = screenState.hideUi,
+                onBack = onBack,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ImagesPagerContent(
+    viewModel: ImageViewModel,
+    list: List<MarsImage>,
+    pagerState: PagerState,
+    hideUi: Boolean,
+    onBack: () -> Unit,
+) {
+    var titleState by remember { mutableStateOf("Mars Rover Photos") }
+    var showInfoSheet by remember { mutableStateOf(false) }
+
+    LaunchedEffect(pagerState) {
+        snapshotFlow { pagerState.currentPage }.collect { page ->
+            if (list.isNotEmpty() && page < list.size) {
+                val marsPhoto = list[page]
+                viewModel.onShown(marsPhoto, page)
+                titleState = "Mars image ID: ${marsPhoto.id}"
+            }
+        }
+    }
+
+    val currentImage = remember(pagerState.currentPage, list) {
+        list.getOrNull(pagerState.currentPage)
+    }
+
+    Column {
+        AnimatedVisibility(visible = !hideUi) {
+            TopAppBar(
+                windowInsets = WindowInsets(0, 0, 0, 0),
+                title = { Text(text = titleState) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        MaterialSymbolIcon(
+                            symbol = MaterialSymbol.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                actions = {
+                    if (currentImage != null) {
+                        SaveIcon(onClick = {
+                            viewModel.saveImage(currentImage)
+                        })
+                        ShareIcon(onClick = {
+                            viewModel.shareMarsImage(currentImage)
+                        })
+                        InfoIcon(onClick = {
+                            showInfoSheet = true
+                        })
+                    }
+                },
+            )
+        }
+
+        // Debug buttons — shown only on debug builds
+        if (BuildInfo.isDebug) {
+            AnimatedVisibility(visible = !hideUi) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceAround
+                ) {
+                    Button(onClick = { /* makePopular — requires repo extension; noop in shared */ }) {
+                        Text(text = "Mark as popular")
+                    }
+                    Button(onClick = { /* removePopular — noop in shared */ }) {
+                        Text(text = "Remove from popular")
+                    }
+                }
+            }
+        }
+
+        Box {
+            ImagesPager(
+                pagerState = pagerState,
+                images = list,
+                onTap = { viewModel.onTap() },
+                onFavoriteClick = { marsImage -> viewModel.updateFavorite(marsImage) },
+            )
+
+            val uiEvent by viewModel.uiEvent.collectAsStateWithLifecycle(initialValue = null)
+            OnEvent(uiEvent = uiEvent)
+        }
+    }
+
+    // Photo info bottom sheet
+    if (showInfoSheet && currentImage != null) {
+        PhotoInfoBottomSheet(
+            image = currentImage,
+            onDismiss = { showInfoSheet = false }
+        )
+    }
+}
+
+@Composable
+private fun BoxScope.OnEvent(uiEvent: UiEvent?) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val haptic = LocalHapticFeedback.current
+    val uriHandler = LocalUriHandler.current
+    var showCheckmark by remember { mutableStateOf(false) }
+
+    when (uiEvent) {
+        is UiEvent.PhotoSaved -> {
+            val imagePath = uiEvent.imagePath
+
+            LaunchedEffect(uiEvent) {
+                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                showCheckmark = true
+                delay(1500)
+                showCheckmark = false
+            }
+
+            SaveSuccessOverlay(visible = showCheckmark)
+
+            MarsSnackbar(
+                snackbarHostState = snackbarHostState,
+                modifier = Modifier.align(Alignment.BottomCenter),
+                actionClick = {
+                    if (!imagePath.isNullOrBlank()) {
+                        try {
+                            uriHandler.openUri(imagePath)
+                        } catch (_: Exception) {
+                            // URI may not be openable on all platforms — silently ignore
+                        }
+                    }
+                }
+            )
+            LaunchedEffect(uiEvent) {
+                snackbarHostState.showSnackbar(
+                    message = "Image saved successfully",
+                    actionLabel = if (imagePath != null) "Open" else null
+                )
+            }
+        }
+
+        is UiEvent.PhotoSaveError -> {
+            LaunchedEffect(uiEvent) {
+                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                snackbarHostState.showSnackbar(
+                    message = "Failed to save image: ${uiEvent.errorMessage}"
+                )
+            }
+            MarsSnackbar(
+                snackbarHostState = snackbarHostState,
+                modifier = Modifier.align(Alignment.BottomCenter),
+                actionClick = null
+            )
+        }
+
+        is UiEvent.ShareError -> {
+            LaunchedEffect(uiEvent) {
+                snackbarHostState.showSnackbar(
+                    message = "Failed to share image: ${uiEvent.errorMessage}"
+                )
+            }
+            MarsSnackbar(
+                snackbarHostState = snackbarHostState,
+                modifier = Modifier.align(Alignment.BottomCenter),
+                actionClick = null
+            )
+        }
+
+        null -> { /* idle */ }
+    }
+}
+
+@Composable
+private fun BoxScope.SaveSuccessOverlay(visible: Boolean) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(animationSpec = tween(durationMillis = 300)),
+        exit = fadeOut(animationSpec = tween(durationMillis = 300)),
+        modifier = Modifier.align(Alignment.TopEnd)
+    ) {
+        MaterialSymbolIcon(
+            symbol = MaterialSymbol.CheckCircle,
+            contentDescription = "Saved",
+            modifier = Modifier.padding(16.dp),
+            tint = MaterialTheme.colorScheme.primary,
+            size = 48.dp,
+            filled = true
+        )
+    }
+}
+
+// ─── Icon buttons ────────────────────────────────────────────────────────────
+
+@Composable
+private fun SaveIcon(onClick: () -> Unit) {
+    IconButton(onClick = onClick) {
+        MaterialSymbolIcon(symbol = MaterialSymbol.Save, contentDescription = "Save")
+    }
+}
+
+@Composable
+private fun ShareIcon(onClick: () -> Unit) {
+    IconButton(onClick = onClick) {
+        MaterialSymbolIcon(symbol = MaterialSymbol.Share, contentDescription = "Share")
+    }
+}
+
+@Composable
+private fun InfoIcon(onClick: () -> Unit) {
+    IconButton(onClick = onClick) {
+        MaterialSymbolIcon(symbol = MaterialSymbol.Info, contentDescription = "Photo information")
+    }
+}
+
+// ─── Pager ───────────────────────────────────────────────────────────────────
+
+@Composable
+private fun ImagesPager(
+    pagerState: PagerState,
+    images: List<MarsImage>,
+    onTap: () -> Unit,
+    onFavoriteClick: (MarsImage) -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+
+    NoScrollEffect {
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background),
+        ) { page ->
+            val marsImage = images[page]
+            val zoomState = rememberZoomableState()
+
+            Box(modifier = Modifier.fillMaxSize()) {
+                NetworkImage(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .zoomable(state = zoomState)
+                        .pointerInput(zoomState) {
+                            detectTapGestures(
+                                onTap = { onTap() },
+                                onDoubleTap = {
+                                    if (zoomState.scale > 1f) {
+                                        scope.launch { zoomState.reset() }
+                                    }
+                                },
+                            )
+                        },
+                    contentScale = ContentScale.FillWidth,
+                    imageUrl = marsImage.imageUrl,
+                    showPlaceholder = false,
+                )
+
+                MarsImageFavoriteToggle(
+                    modifier = Modifier
+                        .size(64.dp)
+                        .align(Alignment.BottomCenter),
+                    checked = marsImage.favorite,
+                    onCheckedChange = { onFavoriteClick(marsImage) }
+                )
+
+                // Reset zoom when this page scrolls off-screen
+                val isSettled = page == pagerState.settledPage
+                LaunchedEffect(isSettled) {
+                    if (!isSettled) zoomState.reset()
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotoInfoBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotoInfoBottomSheet.kt
@@ -1,0 +1,151 @@
+package com.sirelon.marsroverphotos.presentation.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.sirelon.marsroverphotos.data.database.entities.MarsImage
+
+/**
+ * Bottom sheet displaying detailed information about a Mars rover photo.
+ *
+ * Shows:
+ * - Description (Perseverance only)
+ * - Credit (Perseverance only)
+ * - Camera information
+ * - Sol and Earth date
+ * - Usage statistics
+ *
+ * Ported from `app/.../feature/images/PhotoInfoBottomSheet.kt` to Compose Multiplatform.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PhotoInfoBottomSheet(
+    image: MarsImage,
+    onDismiss: () -> Unit
+) {
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            // Title
+            Text(
+                text = "Photo Information",
+                style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+
+            // Description section (Perseverance only)
+            image.description?.takeIf { it.isNotBlank() }?.let { description ->
+                InfoSection(title = "Description", content = description)
+            }
+
+            // Credit section (Perseverance only)
+            image.credit?.takeIf { it.isNotBlank() }?.let { credit ->
+                InfoSection(title = "Credit", content = credit)
+            }
+
+            // Camera information
+            image.camera?.let { camera ->
+                InfoSection(
+                    title = "Camera",
+                    content = "${camera.fullName} (${camera.name})"
+                )
+            }
+
+            // Sol and Earth Date
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    InfoSection(title = "Sol", content = image.sol.toString())
+                }
+                Column(modifier = Modifier.weight(1f)) {
+                    InfoSection(title = "Earth Date", content = image.earthDate)
+                }
+            }
+
+            // Statistics
+            Text(
+                text = "Statistics",
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(top = 8.dp)
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                StatItem("Views", image.stats.see)
+                StatItem("Scales", image.stats.scale)
+                StatItem("Saves", image.stats.save)
+                StatItem("Shares", image.stats.share)
+                StatItem("Favorites", image.stats.favorite)
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun InfoSection(title: String, content: String) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = content,
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
+}
+
+@Composable
+private fun StatItem(label: String, value: Long) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Text(
+            text = formatStatValue(value),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.primary
+        )
+        Text(
+            text = label.lowercase(),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+/**
+ * KMP-safe compact number formatter.
+ * Replaces `String.format("%.1fK", value / 1000.0)` which is JVM-only.
+ *
+ * Examples: 0 → "0", 999 → "999", 1000 → "1.0K", 1500 → "1.5K", 12345 → "12.3K"
+ */
+private fun formatStatValue(value: Long): String {
+    if (value < 1000) return value.toString()
+    val thousands = value / 1000
+    val tenths = (value % 1000) / 100
+    return "${thousands}.${tenths}K"
+}

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PlaceholderScreens.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PlaceholderScreens.kt
@@ -49,24 +49,6 @@ fun PhotosScreen(roverId: Long, onNavigateToImages: () -> Unit, onNavigateToMiss
 }
 
 @Composable
-fun ImagesScreen(photoId: String?, onBack: () -> Unit) {
-    PlaceholderScreen(
-        title = "Images",
-        description = buildString {
-            append("Fullscreen image viewer with zoom\n")
-            if (photoId != null) {
-                append("Photo ID: $photoId\n")
-            }
-            append("\n(Screen pending migration)")
-        }
-    ) {
-        Button(onClick = onBack) {
-            Text("Back to Photos")
-        }
-    }
-}
-
-@Composable
 fun FavoriteScreen() {
     PlaceholderScreen(
         title = "Favorite Photos",

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/Zoomable.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/Zoomable.kt
@@ -1,6 +1,5 @@
 package com.sirelon.marsroverphotos.presentation.ui
 
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -9,58 +8,60 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 
-data class ZoomableState(
-    val scale: Float = 1f,
-    val offset: Offset = Offset.Zero
-)
+/**
+ * Mutable state for [Modifier.zoomable].
+ *
+ * Holds the current scale and pan offset; read these in your layout to react to zoom changes.
+ * Call [reset] to animate/snap back to 1× (e.g. when the current page leaves the viewport).
+ */
+class ZoomableState {
+    var scale by mutableFloatStateOf(1f)
+        internal set
+    var offset by mutableStateOf(Offset.Zero)
+        internal set
 
-@Composable
-fun rememberZoomableState(): ZoomableState {
-    // State is managed internally by Modifier.zoomable via composed {}
-    // This function is kept for API compatibility with callers
-    return ZoomableState()
+    /** Snap scale back to 1× and pan back to zero. */
+    fun reset() {
+        scale = 1f
+        offset = Offset.Zero
+    }
 }
 
+/** Remember a [ZoomableState] across recompositions. */
+@Composable
+fun rememberZoomableState(): ZoomableState = remember { ZoomableState() }
+
+/**
+ * Adds pinch-to-zoom and one-finger-pan support to any composable.
+ *
+ * The [state] is updated on every pointer event; reading [ZoomableState.scale] or
+ * [ZoomableState.offset] outside this modifier will reflect the current value.
+ * Double-tap reset is NOT handled here — add a separate `pointerInput { detectTapGestures
+ * (onDoubleTap = { state.reset() }) }` on the same modifier chain if you need it.
+ *
+ * @param state     The [ZoomableState] driving scale and translation.
+ * @param minScale  Minimum zoom level (default 1×).
+ * @param maxScale  Maximum zoom level (default 5×).
+ */
 fun Modifier.zoomable(
+    state: ZoomableState,
     minScale: Float = 1f,
     maxScale: Float = 5f,
-    onScaleChanged: ((Float) -> Unit)? = null
-): Modifier = composed {
-    var scale by remember { mutableFloatStateOf(1f) }
-    var offset by remember { mutableStateOf(Offset.Zero) }
-
-    this
-        .pointerInput(Unit) {
-            detectTransformGestures { _, pan, zoom, _ ->
-                val newScale = (scale * zoom).coerceIn(minScale, maxScale)
-                scale = newScale
-                onScaleChanged?.invoke(newScale)
-                // Only pan when zoomed in; reset offset when back at min scale
-                if (scale > minScale) {
-                    offset += pan
-                } else {
-                    offset = Offset.Zero
-                }
-            }
+): Modifier = this
+    .pointerInput(state) {
+        detectTransformGestures { _, pan, zoom, _ ->
+            val newScale = (state.scale * zoom).coerceIn(minScale, maxScale)
+            state.scale = newScale
+            state.offset = if (newScale > minScale) state.offset + pan else Offset.Zero
         }
-        .pointerInput(Unit) {
-            detectTapGestures(
-                onDoubleTap = {
-                    scale = minScale
-                    offset = Offset.Zero
-                    onScaleChanged?.invoke(minScale)
-                }
-            )
-        }
-        .graphicsLayer(
-            scaleX = scale,
-            scaleY = scale,
-            translationX = offset.x,
-            translationY = offset.y
-        )
-}
+    }
+    .graphicsLayer {
+        scaleX = state.scale
+        scaleY = state.scale
+        translationX = state.offset.x
+        translationY = state.offset.y
+    }


### PR DESCRIPTION
Ports the fullscreen image viewer (`ImagesScreen`) and `PhotoInfoBottomSheet` to `commonMain` as part of the KMP migration. Replaces `net.engawapg.lib.zoomable` with a redesigned `ZoomableState` (observable `scale` + `reset()`), swaps `BuildConfig.DEBUG` / `Intent.ACTION_VIEW` / `LocalContext` for their CMP-native equivalents, and replaces the JVM-only `String.format` in the bottom sheet with a KMP-safe formatter. `AppDestination.Images` is updated to carry `photoIds: List<String>` + `selectedId` (was a single nullable ID), and the placeholder `ImagesScreen` is removed. All three verification targets pass: `:androidApp:assembleDebug`, `:shared:linkDebugFrameworkIosSimulatorArm64`, and `detekt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)