### PR TITLE
S2: Migrate PhotosScreen to commonMain KMP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ Do not move these into `commonMain` as-is: `Application`, `Activity`, `Component
 
 Use common-safe replacements instead: KMP `ViewModel`, injected repositories/settings, Compose Multiplatform resources, common interfaces with platform actuals or callbacks, Koin core/Compose/ViewModel APIs in common, Kermit for logging, Ktor core in common with engines in platform source sets, and Room runtime only for the enabled Android/iOS/Desktop targets.
 
+Prefer existing KMP-compatible components and libraries over platform-specific mirrors. Use `expect`/`actual` only for real platform gaps; do not introduce platform-specific abstractions when Compose Multiplatform or another KMP dependency already provides the component in shared code. For example, use the shared Material3/Compose Multiplatform `DatePicker` instead of native platform date pickers unless there is a proven blocker.
+
 ## Build, Test, and Development Commands
 - `./gradlew assembleDebug` — build the debuggable APK with the repository Compose compiler flags.
 - `./gradlew testDebugUnitTest` — run JVM unit tests; execute before every commit.

--- a/KMP_MIGRATION_PLAN.md
+++ b/KMP_MIGRATION_PLAN.md
@@ -394,7 +394,7 @@ exposing `StateFlow<List<Rover>>` via `roversRepository.loadAllRovers()`. Bind i
 
 ---
 
-### Ticket S2 — Rover photos (grid)
+### ~~Ticket S2 — Rover photos (grid)~~ ✅
 
 **Files to port:**
 - `feature/photos/RoverPhotosScreen.kt` →
@@ -413,8 +413,12 @@ exposing `StateFlow<List<Rover>>` via `roversRepository.loadAllRovers()`. Bind i
 | `androidx.compose.material3.DatePicker` directly | Use `PlatformDatePickerDialog` (already in `presentation/ui`). |
 | `rememberSaveable { mutableStateOf(false) }` | OK in CMP — keep. |
 
-**DoD:** `PhotosScreen(roverId, …)` shows real photos for the rover, with the sol slider
+**DoD:** ✅ `PhotosScreen(roverId, …)` shows real photos for the rover, with the sol slider
 dialog and earth-date picker working on both platforms.
+
+*Note: S2 uses the shared Compose Multiplatform Material3 date picker wrapper, not native
+platform pickers. `Mapper.kt` was not duplicated because shared `data/network/Mappers.kt`
+already covers the migrated network-to-UI mapping.*
 
 ---
 

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -19,6 +19,17 @@
     <string name="action_rate">Rate this app</string>
     <string name="label_photos_total">Total photos: </string>
     <string name="sol_description">The term sol is used by planetary astronomers to refer to the duration of a solar day on Mars.\nA mean Martian solar day is 24 hours, 39 minutes, and 35.244 seconds.</string>
+    <string name="sol_date_fmt">Sol date: \n%d</string>
+    <string name="earth_date_fmt">Earth date: \n%s</string>
+    <string name="sol_label">Sol: </string>
+    <string name="sol_max_error_fmt">The max sol for this rover is %d</string>
+    <string name="select_date">Select date</string>
+    <string name="choose">Choose</string>
+    <string name="select">Select</string>
+    <string name="cancel">Cancel</string>
+    <string name="photo_refresh">Refresh photos</string>
+    <string name="educational_fact">Educational fact</string>
+    <string name="did_you_know">Did You Know?</string>
     <string name="tap_to_retry">Tap to retry</string>
     <string name="no_photos_title">The rover didn\'t take any photos on this date.</string>
     <string name="favorite_empty_btn">Go to rovers</string>

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/di/NavigationModule.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/di/NavigationModule.kt
@@ -29,11 +29,8 @@ val navigationModule = module {
         val navigator = LocalAppNavigator.current
         PhotosScreen(
             roverId = destination.roverId,
-            onNavigateToImages = {
-                navigator.navigate(AppDestination.Images())
-            },
-            onNavigateToMission = { roverId ->
-                navigator.navigate(AppDestination.Mission(roverId))
+            onNavigateToImages = { photoId ->
+                navigator.navigate(AppDestination.Images(photoId))
             }
         )
     }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
@@ -1,0 +1,444 @@
+package com.sirelon.marsroverphotos.presentation.screens
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.sirelon.marsroverphotos.data.database.entities.MarsImage
+import com.sirelon.marsroverphotos.domain.models.EducationalFact
+import com.sirelon.marsroverphotos.presentation.models.GridItem
+import com.sirelon.marsroverphotos.presentation.ui.CenteredColumn
+import com.sirelon.marsroverphotos.presentation.ui.CenteredProgress
+import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbol
+import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbolIcon
+import com.sirelon.marsroverphotos.presentation.ui.NetworkImage
+import com.sirelon.marsroverphotos.presentation.ui.PlatformDatePickerDialog
+import com.sirelon.marsroverphotos.presentation.ui.adaptiveGridCells
+import com.sirelon.marsroverphotos.presentation.viewmodels.PhotosViewModel
+import com.sirelon.marsroverphotos.shared.resources.Res
+import com.sirelon.marsroverphotos.shared.resources.alien_icon
+import com.sirelon.marsroverphotos.shared.resources.cancel
+import com.sirelon.marsroverphotos.shared.resources.choose
+import com.sirelon.marsroverphotos.shared.resources.did_you_know
+import com.sirelon.marsroverphotos.shared.resources.earth_date_fmt
+import com.sirelon.marsroverphotos.shared.resources.educational_fact
+import com.sirelon.marsroverphotos.shared.resources.no_photos_title
+import com.sirelon.marsroverphotos.shared.resources.photo_refresh
+import com.sirelon.marsroverphotos.shared.resources.select
+import com.sirelon.marsroverphotos.shared.resources.select_date
+import com.sirelon.marsroverphotos.shared.resources.sol_date_fmt
+import com.sirelon.marsroverphotos.shared.resources.sol_description
+import com.sirelon.marsroverphotos.shared.resources.sol_label
+import com.sirelon.marsroverphotos.shared.resources.sol_max_error_fmt
+import com.sirelon.marsroverphotos.shared.resources.tap_to_retry
+import kotlin.time.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.toLocalDateTime
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+fun PhotosScreen(
+    roverId: Long,
+    onNavigateToImages: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: PhotosViewModel = koinViewModel()
+) {
+    var maxSol by remember { mutableLongStateOf(1L) }
+
+    LaunchedEffect(roverId) {
+        viewModel.setRoverId(roverId)
+        maxSol = viewModel.maxSol().coerceAtLeast(1L)
+    }
+
+    val gridItems by viewModel.gridItemsFlow.collectAsState(initial = null)
+    val photos = remember(gridItems) {
+        gridItems?.mapNotNull { item ->
+            (item as? GridItem.PhotoItem)?.image
+        }.orEmpty()
+    }
+    val sol by viewModel.solFlow.collectAsState(initial = 0L)
+
+    var openSolDialog by rememberSaveable { mutableStateOf(false) }
+    var openEarthDateDialog by rememberSaveable { mutableStateOf(false) }
+
+    SolDialog(
+        maxSol = maxSol,
+        openDialog = openSolDialog,
+        sol = sol,
+        onClose = { openSolDialog = false },
+        onChoose = {
+            viewModel.loadBySol(it)
+            openSolDialog = false
+        }
+    )
+
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            Row(modifier = Modifier.height(52.dp)) {
+                HeaderButton(stringResource(Res.string.sol_date_fmt, sol)) {
+                    openSolDialog = true
+                }
+                HorizontalDivider(
+                    modifier = Modifier
+                        .width(1.dp)
+                        .fillMaxHeight()
+                )
+                HeaderButton(stringResource(Res.string.earth_date_fmt, viewModel.earthDateStr(sol))) {
+                    openEarthDateDialog = true
+                }
+            }
+
+            if (openEarthDateDialog) {
+                PlatformDatePickerDialog(
+                    selectedDate = millisToUtcLocalDate(viewModel.dateFromSol()),
+                    minDate = millisToUtcLocalDate(viewModel.minDate()),
+                    maxDate = millisToUtcLocalDate(viewModel.maxDate()),
+                    onDateSelected = { selectedDate ->
+                        viewModel.setEarthTime(selectedDate.toUtcMillis())
+                        openEarthDateDialog = false
+                    },
+                    onDismissRequest = { openEarthDateDialog = false },
+                    title = stringResource(Res.string.select_date),
+                    confirmText = stringResource(Res.string.select),
+                    dismissText = stringResource(Res.string.cancel)
+                )
+            }
+
+            Crossfade(targetState = gridItems, label = "[Anim]:PhotosProgress") { items ->
+                when {
+                    items == null -> CenteredProgress()
+                    items.isEmpty() -> {
+                        EmptyPhotos(
+                            title = stringResource(Res.string.no_photos_title),
+                            btnTitle = stringResource(Res.string.tap_to_retry),
+                            callback = { viewModel.randomize() }
+                        )
+                    }
+                    else -> {
+                        PhotosList(items) { image ->
+                            viewModel.onPhotoClick()
+                            onNavigateToImages(image.id)
+                        }
+                    }
+                }
+            }
+        }
+
+        RefreshButton(
+            visible = photos.isNotEmpty(),
+            modifier = Modifier.align(Alignment.BottomEnd),
+            onClick = { viewModel.goToLatest() }
+        )
+    }
+}
+
+@Composable
+private fun RefreshButton(
+    visible: Boolean,
+    modifier: Modifier,
+    onClick: () -> Unit,
+) {
+    AnimatedVisibility(
+        visible = visible,
+        modifier = modifier.padding(16.dp),
+        enter = fadeIn(),
+        exit = fadeOut()
+    ) {
+        FloatingActionButton(onClick = onClick) {
+            MaterialSymbolIcon(
+                symbol = MaterialSymbol.Autorenew,
+                contentDescription = stringResource(Res.string.photo_refresh)
+            )
+        }
+    }
+}
+
+@Composable
+private fun PhotosList(
+    gridItems: List<GridItem>,
+    onPhotoClick: (image: MarsImage) -> Unit
+) {
+    LazyVerticalGrid(
+        columns = adaptiveGridCells(minColumnWidth = 160.dp),
+        modifier = Modifier.fillMaxSize()
+    ) {
+        items(
+            items = gridItems,
+            key = { item ->
+                when (item) {
+                    is GridItem.PhotoItem -> item.id
+                    is GridItem.FactItem -> item.id
+                }
+            },
+            contentType = { item ->
+                when (item) {
+                    is GridItem.PhotoItem -> "MarsPhotoContentType"
+                    is GridItem.FactItem -> "FactCardContentType"
+                }
+            },
+            span = { item ->
+                when (item) {
+                    is GridItem.PhotoItem -> GridItemSpan(1)
+                    is GridItem.FactItem -> GridItemSpan(maxLineSpan)
+                }
+            }
+        ) { item ->
+            when (item) {
+                is GridItem.PhotoItem -> PhotoCard(image = item.image, onPhotoClick = onPhotoClick)
+                is GridItem.FactItem -> FactCard(fact = item.fact)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PhotoCard(
+    image: MarsImage,
+    onPhotoClick: (image: MarsImage) -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .padding(8.dp)
+            .fillMaxWidth()
+            .clickable { onPhotoClick(image) },
+        shape = MaterialTheme.shapes.large
+    ) {
+        Column(verticalArrangement = Arrangement.SpaceBetween) {
+            NetworkImage(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(1F),
+                imageUrl = image.imageUrl
+            )
+            Text(
+                text = image.name.orEmpty(),
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(4.dp).fillMaxWidth(),
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+@Composable
+private fun SolDialog(
+    openDialog: Boolean,
+    maxSol: Long,
+    sol: Long,
+    onClose: () -> Unit,
+    onChoose: (sol: Long) -> Unit
+) {
+    if (openDialog) {
+        var selectedSol: Long? by remember(sol) { mutableStateOf(sol) }
+        var errorMessage by remember { mutableStateOf<String?>(null) }
+
+        AlertDialog(
+            onDismissRequest = onClose,
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val resolvedSol = selectedSol
+                        if (resolvedSol != null) {
+                            onChoose(resolvedSol)
+                        } else {
+                            onClose()
+                        }
+                    }
+                ) {
+                    Text(stringResource(Res.string.choose))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = onClose) {
+                    Text(stringResource(Res.string.cancel))
+                }
+            },
+            title = { Text(text = stringResource(Res.string.sol_description)) },
+            text = {
+                val maxSolError = stringResource(Res.string.sol_max_error_fmt, maxSol)
+                SolChanger(selectedSol, maxSol, errorMessage) { nextSol ->
+                    if ((nextSol ?: 0L) > maxSol) {
+                        selectedSol = maxSol
+                        errorMessage = maxSolError
+                    } else {
+                        selectedSol = nextSol
+                        errorMessage = null
+                    }
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun SolChanger(
+    sol: Long?,
+    maxSol: Long,
+    errorMessage: String?,
+    onSolChanged: (sol: Long?) -> Unit
+) {
+    val sliderMax = maxSol.coerceAtLeast(1L)
+    Column {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = stringResource(Res.string.sol_label),
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.titleLarge
+            )
+            OutlinedTextField(
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                value = sol?.toString().orEmpty(),
+                modifier = Modifier.weight(1f),
+                singleLine = true,
+                onValueChange = { onSolChanged(it.toLongOrNull()) }
+            )
+        }
+        Slider(
+            value = (sol ?: 0L).coerceIn(0L, sliderMax).toFloat(),
+            valueRange = 0f..sliderMax.toFloat(),
+            onValueChange = { onSolChanged(it.toLong()) }
+        )
+        if (!errorMessage.isNullOrBlank()) {
+            Text(
+                text = errorMessage,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(top = 8.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun RowScope.HeaderButton(text: String, onClick: () -> Unit) {
+    TextButton(
+        modifier = Modifier
+            .weight(1f)
+            .animateContentSize(),
+        onClick = onClick
+    ) {
+        Text(
+            text = text,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun EmptyPhotos(title: String, btnTitle: String, callback: () -> Unit) {
+    CenteredColumn(
+        modifier = Modifier
+            .clickable(onClick = callback)
+            .padding(32.dp)
+    ) {
+        Image(painter = painterResource(Res.drawable.alien_icon), contentDescription = null)
+        Spacer(modifier = Modifier.size(8.dp))
+        Text(text = title, style = MaterialTheme.typography.headlineSmall, textAlign = TextAlign.Center)
+        Spacer(modifier = Modifier.size(8.dp))
+        Text(text = btnTitle, style = MaterialTheme.typography.headlineMedium)
+    }
+}
+
+@Composable
+private fun FactCard(
+    fact: EducationalFact,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 12.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                MaterialSymbolIcon(
+                    symbol = MaterialSymbol.Info,
+                    contentDescription = stringResource(Res.string.educational_fact),
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                    modifier = Modifier.size(24.dp)
+                )
+                Text(
+                    text = stringResource(Res.string.did_you_know),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+            }
+
+            Text(
+                text = fact.text,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+    }
+}
+
+private fun millisToUtcLocalDate(timeMillis: Long): LocalDate =
+    Instant.fromEpochMilliseconds(timeMillis).toLocalDateTime(TimeZone.UTC).date
+
+private fun LocalDate.toUtcMillis(): Long =
+    atStartOfDayIn(TimeZone.UTC).toEpochMilliseconds()

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PlaceholderScreens.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PlaceholderScreens.kt
@@ -33,22 +33,6 @@ fun RoversScreen(onNavigateToPhotos: (Long) -> Unit) {
 }
 
 @Composable
-fun PhotosScreen(roverId: Long, onNavigateToImages: () -> Unit, onNavigateToMission: (Long) -> Unit) {
-    PlaceholderScreen(
-        title = "Photos",
-        description = "Rover ID: $roverId\nBrowse rover photos by sol and camera\n\n(Screen pending migration)"
-    ) {
-        Button(onClick = onNavigateToImages) {
-            Text("View Image Gallery")
-        }
-        Spacer(modifier = Modifier.height(8.dp))
-        Button(onClick = { onNavigateToMission(roverId) }) {
-            Text("View Mission Info")
-        }
-    }
-}
-
-@Composable
 fun ImagesScreen(photoId: String?, onBack: () -> Unit) {
     PlaceholderScreen(
         title = "Images",


### PR DESCRIPTION
Ports the Rover photos grid screen (S2) from the legacy `app/` module to `shared/src/commonMain`.

- Adds `PhotosScreen.kt` with sol/earth-date pickers, adaptive grid, fact cards, and empty-state — all using CMP and existing shared ViewModels
- Removes the `PhotosScreen` placeholder from `PlaceholderScreens.kt` and updates `NavigationModule` to pass `photoId` when navigating to the Images destination
- Ports missing string resources (sol/date picker labels, fact card strings) to `composeResources/values/strings.xml`
- Adds AGENTS.md note to prefer CMP components over platform-specific pickers, and marks S2 ✅ in `KMP_MIGRATION_PLAN.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)