### PR TITLE
S8: Migrate Ukraine banner and screen to commonMain KMP

### DIFF
--- a/KMP_MIGRATION_PLAN.md
+++ b/KMP_MIGRATION_PLAN.md
@@ -50,7 +50,7 @@ technical reference notes are at the bottom.
 | S5 — Popular photos | Pending | Shared popular tab backed by Firebase data on Android |
 | S6 — Mission info | ✅ Done | Shared rover mission detail screen |
 | S7 — About/settings | ✅ Done | Shared settings UI: theme, facts, cache, rate app |
-| S8 — Ukraine route decision | Pending | Shared Ukraine banner and Ukraine screen |
+| S8 — Ukraine route decision | ✅ Done | Shared Ukraine banner and Ukraine screen |
 | S9 — Android widget adaptation | Pending | Keep widget Android-only, but wire it to shared repositories/settings/tracker |
 | 6.1 — Firebase iOS | Pending | Popular data, analytics, Crashlytics on iOS |
 | 6.2 — iOS image save/share | Pending | Save to Photos and native share sheet |
@@ -280,7 +280,7 @@ interface doesn't expose those Firebase methods. Wire up when `6.1` (Firebase iO
 
 ---
 
-### Ticket S8 — Ukraine Route Decision
+### ~~Ticket S8 — Ukraine Route Decision~~ ✅
 
 **Goal:** decide and implement the shared Ukraine banner/screen flow.
 
@@ -297,10 +297,12 @@ interface doesn't expose those Firebase methods. Wire up when `6.1` (Firebase iO
 - Existing CMP URI handler for outbound links
 
 **Definition of Done:**
-- Ukraine banner appears in the intended root location.
-- Tapping the banner opens `UkraineScreen`.
-- Outbound links work or degrade safely on all platforms.
-- Android, iOS framework, and Desktop compile.
+- ✅ Ukraine banner appears in the intended root location.
+- ✅ Tapping the banner opens `UkraineScreen`.
+- ✅ Outbound links work or degrade safely on all platforms.
+- ✅ Android, iOS framework, and Desktop compile.
+
+*Note: `UkraineBanner` is inserted into `AppNavigation` between the main content and the ad slot; it is hidden when already on `UkraineScreen` to avoid redundancy. `LocalUriHandler`/`RoverApplication` replaced with `rememberPlatformUriHandler()` and Koin-injected `Tracker`. `UkraineScreen` wraps all links in try/catch with `recordException` so link failures degrade safely on Desktop and iOS.*
 
 ---
 

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/di/NavigationModule.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/di/NavigationModule.kt
@@ -11,6 +11,7 @@ import com.sirelon.marsroverphotos.presentation.screens.RoverMissionInfoScreen
 import com.sirelon.marsroverphotos.presentation.screens.PhotosScreen
 import com.sirelon.marsroverphotos.presentation.screens.PopularScreen
 import com.sirelon.marsroverphotos.presentation.screens.RoversScreen
+import com.sirelon.marsroverphotos.presentation.screens.UkraineScreen
 import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.dsl.module
 import org.koin.dsl.navigation3.navigation
@@ -81,5 +82,9 @@ val navigationModule = module {
 
     navigation<AppDestination.About> {
         AboutScreen()
+    }
+
+    navigation<AppDestination.Ukraine> {
+        UkraineScreen()
     }
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppDestinations.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppDestinations.kt
@@ -31,4 +31,7 @@ sealed interface AppDestination : NavKey {
 
     @Serializable
     data object About : AppDestination
+
+    @Serializable
+    data object Ukraine : AppDestination
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppNavigation.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppNavigation.kt
@@ -14,6 +14,7 @@ import androidx.navigation3.ui.NavDisplay
 import androidx.savedstate.serialization.SavedStateConfiguration
 import com.sirelon.marsroverphotos.platform.Tracker
 import com.sirelon.marsroverphotos.presentation.ui.AdSlot
+import com.sirelon.marsroverphotos.presentation.ui.UkraineBanner
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.modules.subclass
@@ -66,6 +67,15 @@ fun AppNavigation(
                     entryProvider = entryProvider
                 )
             }
+            if (currentDestination !is AppDestination.Ukraine) {
+                UkraineBanner(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = {
+                        tracker.trackClick("UkraineBanner_Root")
+                        navigator.navigate(AppDestination.Ukraine)
+                    },
+                )
+            }
             AdSlot(modifier = Modifier.fillMaxWidth())
             MarsBottomBar(
                 selectedDestination = currentDestination.topLevelDestination(),
@@ -83,7 +93,8 @@ private fun AppDestination.topLevelDestination(): AppDestination {
         AppDestination.Rovers,
         is AppDestination.Photos,
         is AppDestination.Images,
-        is AppDestination.Mission -> AppDestination.Rovers
+        is AppDestination.Mission,
+        AppDestination.Ukraine -> AppDestination.Rovers
         AppDestination.Favorite -> AppDestination.Favorite
         AppDestination.Popular -> AppDestination.Popular
         AppDestination.About -> AppDestination.About
@@ -96,6 +107,7 @@ private val AppDestination.analyticsTag: String
         AppDestination.Favorite -> "favorite"
         AppDestination.Popular -> "popular"
         AppDestination.About -> "about"
+        AppDestination.Ukraine -> "ukraine"
         else -> "other"
     }
 
@@ -109,6 +121,7 @@ private val navBackStackConfiguration = SavedStateConfiguration {
             subclass(AppDestination.Popular::class, AppDestination.Popular.serializer())
             subclass(AppDestination.Mission::class, AppDestination.Mission.serializer())
             subclass(AppDestination.About::class, AppDestination.About.serializer())
+            subclass(AppDestination.Ukraine::class, AppDestination.Ukraine.serializer())
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/UkraineScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/UkraineScreen.kt
@@ -1,0 +1,144 @@
+package com.sirelon.marsroverphotos.presentation.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.sirelon.marsroverphotos.platform.Tracker
+import com.sirelon.marsroverphotos.platform.recordException
+import com.sirelon.marsroverphotos.presentation.ui.UkraineBanner
+import com.sirelon.marsroverphotos.presentation.ui.rememberPlatformUriHandler
+import org.koin.compose.koinInject
+
+/**
+ * Full-screen Ukraine info screen. Describes the current situation in Ukraine and
+ * provides outbound links to external resources.
+ */
+@Composable
+fun UkraineScreen() {
+    val uriHandler = rememberPlatformUriHandler()
+    val tracker: Tracker = koinInject()
+
+    fun openUri(uri: String) {
+        try {
+            uriHandler.openUri(uri)
+        } catch (e: Throwable) {
+            recordException(e)
+        }
+    }
+
+    Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+        CompositionLocalProvider(
+            LocalTextStyle provides MaterialTheme.typography.titleMedium.copy(
+                textAlign = TextAlign.Center,
+            ),
+        ) {
+            UkraineInfoContent(
+                onTrackClick = { event -> tracker.trackClick(event) },
+                onOpenUri = ::openUri,
+            )
+        }
+
+        UkraineBanner(
+            modifier = Modifier.fillMaxWidth(),
+            title = "Glory to Ukraine",
+            onClick = {
+                tracker.trackClick("UkraineBanner_Bottom")
+                openUri("https://twitter.com/search?q=%23StandWithUkraine")
+            },
+        )
+    }
+}
+
+@Composable
+private fun UkraineInfoContent(
+    onTrackClick: (String) -> Unit,
+    onOpenUri: (String) -> Unit,
+) {
+    Column(
+        modifier = Modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = "Hello, I'm Oleksandr, a proud Ukrainian",
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.titleSmall,
+        )
+        Text(
+            text = "As you may be aware, Ukraine is currently facing a severe and merciless war. " +
+                "Countless lives have been lost, and our cities endure daily missile strikes, " +
+                "with some territories occupied and the true extent of casualties unknown.",
+        )
+        Text(
+            text = "In a world where Russia, without a shred of decency, prioritizes war over " +
+                "science, engages in daily violence, and propagates hatred, it has even spawned " +
+                "a new form of fascism called",
+        )
+        TextButton(
+            onClick = {
+                onTrackClick("Ukraine_wiki")
+                onOpenUri("https://en.wikipedia.org/wiki/Rashism")
+            },
+        ) {
+            Text(text = "rashism.")
+        }
+        Text(
+            text = "The sheer brutality of it is unfathomable in the 21st century. Yet, Ukraine " +
+                "persists against this evil, despite being outgunned and outmanned by Russia. " +
+                "We're not just surviving; we're fighting tooth and nail to liberate our territory " +
+                "and people.",
+        )
+        Text(
+            text = "This struggle is nothing short of incredible, fueled by the support of " +
+                "compassionate individuals worldwide. Massive thanks to those who stand with us " +
+                "in this desperate battle for survival.",
+        )
+        Text(
+            text = "Thank you!",
+            color = Color.Red,
+            style = MaterialTheme.typography.titleSmall,
+        )
+        Text(
+            text = "Don't just scroll past this. Remember us. We need your unwavering support as " +
+                "the war rages on. We're fighting for democracy, for our lives, and for a better " +
+                "future for everyone.",
+        )
+        Text(text = "For more gritty details and stories of resilience from Ukrainian heroes, check out")
+        TextButton(
+            onClick = {
+                onTrackClick("Ukraine_site")
+                onOpenUri("https://war.ukraine.ua/")
+            },
+        ) {
+            Text(text = "https://war.ukraine.ua/")
+        }
+        Text(text = "If you have any questions, reach me via email")
+        TextButton(
+            onClick = {
+                onTrackClick("Ukraine_mail")
+                onOpenUri("mailto:sasha.sirelon@gmail.com")
+            },
+        ) {
+            Text(text = "sasha.sirelon@gmail.com")
+        }
+        Text(
+            text = "Thanks a bunch – we're all in this together!",
+            color = Color.Red,
+            style = MaterialTheme.typography.titleSmall,
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/UkraineBanner.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/UkraineBanner.kt
@@ -1,0 +1,62 @@
+package com.sirelon.marsroverphotos.presentation.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+/**
+ * A banner composable that displays the Ukrainian flag colors and a title.
+ * Tapping the banner invokes [onClick].
+ */
+@Composable
+fun UkraineBanner(
+    modifier: Modifier = Modifier,
+    title: String = "#Stand with Ukraine",
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .drawBehind {
+                val halfHeight = size.height / 2
+                val alpha = 0.5f
+                drawRect(
+                    color = Color.Blue.copy(alpha = alpha),
+                    size = size.copy(height = halfHeight),
+                )
+                drawRect(
+                    color = Color.Yellow.copy(alpha = alpha),
+                    size = size.copy(height = halfHeight),
+                    topLeft = Offset(x = 0f, y = halfHeight),
+                )
+            },
+    ) {
+        Text(
+            text = title,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp),
+            textAlign = TextAlign.Center,
+            color = Color.White,
+            style = MaterialTheme.typography.titleLarge.copy(
+                shadow = Shadow(
+                    color = Color.Black,
+                    offset = Offset(2f, 2f),
+                    blurRadius = 2f,
+                ),
+            ),
+        )
+    }
+}


### PR DESCRIPTION
Implements ticket S8 from the KMP migration plan. Adds `UkraineBanner` (Ukrainian-flag-colored clickable banner) and `UkraineScreen` (full info screen with outbound links) to `commonMain`. A new `AppDestination.Ukraine` route is wired into the Navigation 3 back stack, and the banner is embedded in the root `AppNavigation` layout so it appears on all tabs — tapping it navigates to `UkraineScreen`. Platform-specific APIs replaced: `LocalUriHandler` → `rememberPlatformUriHandler()`, `RoverApplication.APP.dataManger.trackClick` → Koin-injected `Tracker`, link failures wrapped in `try/catch` + `recordException` for safe degradation on iOS/Desktop. Android APK, iOS Simulator framework, unit tests, and detekt all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)