### PR TITLE
S9: Android widget adaptation — wire to shared repos and Koin

### DIFF
--- a/KMP_MIGRATION_PLAN.md
+++ b/KMP_MIGRATION_PLAN.md
@@ -51,7 +51,7 @@ technical reference notes are at the bottom.
 | S6 — Mission info | ✅ Done | Shared rover mission detail screen |
 | S7 — About/settings | ✅ Done | Shared settings UI: theme, facts, cache, rate app |
 | S8 — Ukraine route decision | Pending | Shared Ukraine banner and Ukraine screen |
-| S9 — Android widget adaptation | Pending | Keep widget Android-only, but wire it to shared repositories/settings/tracker |
+| S9 — Android widget adaptation | ✅ Done | Keep widget Android-only, but wire it to shared repositories/settings/tracker |
 | 6.1 — Firebase iOS | Pending | Popular data, analytics, Crashlytics on iOS |
 | 6.2 — iOS image save/share | Pending | Save to Photos and native share sheet |
 | 6.3 — Xcode project bootstrap | ✅ Done | Checked-in iOS project/workspace that teammates can run |
@@ -304,7 +304,7 @@ interface doesn't expose those Firebase methods. Wire up when `6.1` (Firebase iO
 
 ---
 
-### Ticket S9 — Android Widget Adaptation
+### ~~Ticket S9 — Android Widget Adaptation~~ ✅
 
 **Goal:** keep the widget Android-only, but make it use shared data contracts.
 
@@ -320,9 +320,11 @@ interface doesn't expose those Firebase methods. Wire up when `6.1` (Firebase iO
 - Replace `RoverApplication.APP.tracker` with shared `Tracker`.
 
 **Definition of Done:**
-- Widget builds from `androidApp`.
-- Widget reads shared settings/repositories.
-- Widget can still deep link into the app through `WidgetExtraImageId`.
+- ✅ Widget builds from `androidApp`.
+- ✅ Widget reads shared settings/repositories.
+- ✅ Widget can still deep link into the app through `WidgetExtraImageId`.
+
+*Note: `ImagesRepository` and `RestApi` are injected via Koin (`KoinComponent` in `CoroutineWorker`). `Timber` replaced with shared `Logger` (Kermit). Legacy `feature/rovers/*Id` constants replaced with shared `domain.models.*_ID`. `RoversActivity` replaced with `MainActivity`. Added `DeepLink.Image(id: String)` to handle widget photo taps; handled in `MainActivity.handleDeepLink` by checking `WidgetExtraImageId` extra before processing URI deep links. `initialLayout` uses a local placeholder layout — `@layout/glance_default_loading` from the Glance library was not resolvable in this setup.*
 
 ---
 

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -101,6 +101,13 @@ dependencies {
     implementation(libs.koin.android)
     implementation(libs.koin.androidx.compose)
 
+    // Compose UI (Material3 + foundation needed by widget config activity)
+    implementation(libs.compose.material3)
+    implementation(libs.compose.foundation)
+
+    // Coil image loading (used by widget worker to download photos)
+    implementation(libs.coil)
+
     // Glance App Widgets
     implementation(libs.androidx.glance.appwidget)
 

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -64,6 +64,29 @@
             </intent-filter>
         </activity>
 
+        <!-- Widget config activity -->
+        <activity
+            android:name=".widget.MarsPhotoWidgetConfigActivity"
+            android:exported="true"
+            android:theme="@style/Theme.AppCompat.DayNight.NoActionBar">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
+            </intent-filter>
+        </activity>
+
+        <!-- Widget broadcast receiver -->
+        <receiver
+            android:name=".widget.MarsPhotoWidgetReceiver"
+            android:exported="true"
+            android:permission="android.permission.BIND_APPWIDGET">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/mars_photo_widget_info" />
+        </receiver>
+
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
             android:value="@string/ad_application_id" />

--- a/androidApp/src/main/kotlin/com/sirelon/marsroverphotos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/sirelon/marsroverphotos/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.setValue
 import com.sirelon.marsroverphotos.presentation.App
 import com.sirelon.marsroverphotos.presentation.navigation.DeepLink
 import com.sirelon.marsroverphotos.utils.Logger
+import com.sirelon.marsroverphotos.widget.WidgetExtraImageId
 
 /**
  * Main activity for the Mars Rover Photos app.
@@ -64,6 +65,14 @@ class MainActivity : ComponentActivity() {
      * - https://marsroverphotos.app/photo/{photoId}
      */
     private fun handleDeepLink(intent: Intent?) {
+        // Check for widget photo extra first
+        val widgetImageId = intent?.getStringExtra(WidgetExtraImageId)
+        if (!widgetImageId.isNullOrBlank()) {
+            Logger.d("MainActivity") { "Widget deep link received: $widgetImageId" }
+            pendingDeepLink = DeepLink.Image(widgetImageId)
+            return
+        }
+
         val data: Uri? = intent?.data
         if (data == null) {
             Logger.d("MainActivity") { "No deep link data" }

--- a/androidApp/src/main/kotlin/com/sirelon/marsroverphotos/widget/MarsPhotoWidget.kt
+++ b/androidApp/src/main/kotlin/com/sirelon/marsroverphotos/widget/MarsPhotoWidget.kt
@@ -1,0 +1,202 @@
+package com.sirelon.marsroverphotos.widget
+
+import android.content.Intent
+import android.graphics.BitmapFactory
+import android.content.Context
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.Image
+import androidx.glance.ImageProvider
+import androidx.glance.LocalContext
+import androidx.glance.LocalSize
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.SizeMode
+import androidx.glance.appwidget.action.actionStartActivity
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.currentState
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
+import androidx.glance.layout.Column
+import androidx.glance.layout.ContentScale
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.padding
+import androidx.glance.state.PreferencesGlanceStateDefinition
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
+import com.sirelon.marsroverphotos.MainActivity
+import com.sirelon.marsroverphotos.domain.models.CURIOSITY_ID
+import com.sirelon.marsroverphotos.domain.models.INSIGHT_ID
+import com.sirelon.marsroverphotos.domain.models.OPPORTUNITY_ID
+import com.sirelon.marsroverphotos.domain.models.PERSEVERANCE_ID
+import com.sirelon.marsroverphotos.domain.models.SPIRIT_ID
+import java.io.File
+
+/** Intent extra key used to carry the photo ID when the widget launches the app. */
+public const val WidgetExtraImageId = "com.sirelon.marsroverphotos.widget.EXTRA_IMAGE_ID"
+
+internal object MarsPhotoWidgetState {
+    val roverIdKey = longPreferencesKey("mars_widget_rover_id")
+    val imagePathKey = stringPreferencesKey("mars_widget_image_path")
+    val imageIdKey = stringPreferencesKey("mars_widget_image_id")
+    val roverNameKey = stringPreferencesKey("mars_widget_rover_name")
+    val solKey = longPreferencesKey("mars_widget_sol")
+    val earthDateKey = stringPreferencesKey("mars_widget_earth_date")
+}
+
+internal const val DefaultRoverId = CURIOSITY_ID
+
+public class MarsPhotoWidget : GlanceAppWidget() {
+
+    override val stateDefinition = PreferencesGlanceStateDefinition
+
+    override val sizeMode: SizeMode = SizeMode.Responsive(
+        setOf(
+            DpSize(140.dp, 140.dp),
+            DpSize(200.dp, 140.dp),
+            DpSize(260.dp, 200.dp)
+        )
+    )
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        provideContent {
+            MarsPhotoWidgetContent()
+        }
+    }
+
+    @OptIn(ExperimentalAnimationApi::class)
+    @Composable
+    private fun MarsPhotoWidgetContent() {
+        val context = LocalContext.current
+        val state = currentState<Preferences>()
+        val configuredRoverId = state[MarsPhotoWidgetState.roverIdKey]
+        val roverId = configuredRoverId ?: DefaultRoverId
+        val hasConfiguredRover = configuredRoverId != null
+        val roverName = state[MarsPhotoWidgetState.roverNameKey] ?: roverNameForId(roverId)
+        val sol = state[MarsPhotoWidgetState.solKey] ?: 0L
+        val earthDate = state[MarsPhotoWidgetState.earthDateKey].orEmpty()
+        val imagePath = state[MarsPhotoWidgetState.imagePathKey]
+        val imageId = state[MarsPhotoWidgetState.imageIdKey]
+        val size = LocalSize.current
+
+        val imageProvider = imagePath?.let { path ->
+            val file = File(path)
+            if (file.exists()) {
+                BitmapFactory.decodeFile(file.absolutePath)?.let { bitmap ->
+                    ImageProvider(bitmap)
+                }
+            } else {
+                null
+            }
+        }
+
+        // Navigate to MainActivity; pass widget photo ID so the app can open that photo directly
+        val launchIntent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            if (!imageId.isNullOrBlank()) {
+                putExtra(WidgetExtraImageId, imageId)
+            }
+        }
+
+        val action = actionStartActivity(launchIntent)
+        val showDetails = size.width >= 200.dp && size.height >= 140.dp
+        val showOverlay = size.height >= 110.dp
+
+        Box(
+            modifier = GlanceModifier
+                .fillMaxSize()
+                .clickable(action)
+        ) {
+            if (imageProvider != null) {
+                Image(
+                    provider = imageProvider,
+                    contentDescription = roverName,
+                    modifier = GlanceModifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop
+                )
+            } else {
+                Box(
+                    modifier = GlanceModifier
+                        .fillMaxSize()
+                        .background(Color(0xFF1A283D)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = if (hasConfiguredRover) "Updating photo" else "Select a rover",
+                        modifier = GlanceModifier
+                            .padding(12.dp)
+                    )
+                }
+            }
+
+            if (showOverlay && imageProvider != null) {
+                Box(
+                    modifier = GlanceModifier
+                        .fillMaxSize(),
+                    contentAlignment = Alignment.BottomStart
+                ) {
+                    Column(
+                        modifier = GlanceModifier
+                            .fillMaxWidth()
+                            .background(ColorProvider(androidx.compose.ui.graphics.Color(0xAA000000)))
+                            .padding(horizontal = 10.dp, vertical = 8.dp)
+                    ) {
+                        Text(
+                            text = roverName,
+                            style = TextStyle(
+                                color = ColorProvider(androidx.compose.ui.graphics.Color.White),
+                                fontWeight = FontWeight.Bold,
+                                fontSize = 14.sp
+                            )
+                        )
+                        if (showDetails) {
+                            val detail = if (sol > 0 && earthDate.isNotBlank()) {
+                                "Sol $sol - $earthDate"
+                            } else if (earthDate.isNotBlank()) {
+                                earthDate
+                            } else if (sol > 0) {
+                                "Sol $sol"
+                            } else {
+                                ""
+                            }
+                            if (detail.isNotBlank()) {
+                                Text(
+                                    text = detail,
+                                    style = TextStyle(
+                                        color = ColorProvider(androidx.compose.ui.graphics.Color(0xFFE0E0E0)),
+                                        fontWeight = FontWeight.Normal,
+                                        fontSize = 12.sp
+                                    )
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+internal fun roverNameForId(roverId: Long): String {
+    return when (roverId) {
+        PERSEVERANCE_ID -> "Perseverance"
+        INSIGHT_ID -> "Insight"
+        OPPORTUNITY_ID -> "Opportunity"
+        SPIRIT_ID -> "Spirit"
+        CURIOSITY_ID -> "Curiosity"
+        else -> "Mars Rover"
+    }
+}

--- a/androidApp/src/main/kotlin/com/sirelon/marsroverphotos/widget/MarsPhotoWidgetConfigActivity.kt
+++ b/androidApp/src/main/kotlin/com/sirelon/marsroverphotos/widget/MarsPhotoWidgetConfigActivity.kt
@@ -1,0 +1,195 @@
+package com.sirelon.marsroverphotos.widget
+
+import android.app.Activity
+import android.appwidget.AppWidgetManager
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.glance.appwidget.GlanceAppWidgetManager
+import androidx.glance.appwidget.state.getAppWidgetState
+import androidx.glance.appwidget.state.updateAppWidgetState
+import androidx.glance.state.PreferencesGlanceStateDefinition
+import androidx.lifecycle.lifecycleScope
+import com.sirelon.marsroverphotos.domain.models.CURIOSITY_ID
+import com.sirelon.marsroverphotos.domain.models.INSIGHT_ID
+import com.sirelon.marsroverphotos.domain.models.OPPORTUNITY_ID
+import com.sirelon.marsroverphotos.domain.models.PERSEVERANCE_ID
+import com.sirelon.marsroverphotos.domain.models.SPIRIT_ID
+import com.sirelon.marsroverphotos.presentation.theme.MarsRoverPhotosTheme
+import kotlinx.coroutines.launch
+
+public class MarsPhotoWidgetConfigActivity : ComponentActivity() {
+
+    private var appWidgetId: Int = AppWidgetManager.INVALID_APPWIDGET_ID
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setResult(Activity.RESULT_CANCELED)
+
+        appWidgetId = intent?.getIntExtra(
+            AppWidgetManager.EXTRA_APPWIDGET_ID,
+            AppWidgetManager.INVALID_APPWIDGET_ID
+        ) ?: AppWidgetManager.INVALID_APPWIDGET_ID
+
+        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+            finish()
+            return
+        }
+
+        setContent {
+            MarsRoverPhotosTheme {
+                WidgetConfigScreen(
+                    appWidgetId = appWidgetId,
+                    onConfirm = { roverId ->
+                        saveSelection(roverId)
+                    }
+                )
+            }
+        }
+    }
+
+    private fun saveSelection(roverId: Long) {
+        lifecycleScope.launch {
+            val manager = GlanceAppWidgetManager(this@MarsPhotoWidgetConfigActivity)
+            val glanceId = manager.getGlanceIdBy(appWidgetId)
+
+            updateAppWidgetState(this@MarsPhotoWidgetConfigActivity, glanceId) { prefs ->
+                prefs[MarsPhotoWidgetState.roverIdKey] = roverId
+                prefs[MarsPhotoWidgetState.roverNameKey] = roverNameForId(roverId)
+                prefs.remove(MarsPhotoWidgetState.imagePathKey)
+                prefs.remove(MarsPhotoWidgetState.imageIdKey)
+                prefs.remove(MarsPhotoWidgetState.solKey)
+                prefs.remove(MarsPhotoWidgetState.earthDateKey)
+            }
+
+            MarsPhotoWidget().update(this@MarsPhotoWidgetConfigActivity, glanceId)
+            MarsPhotoWidgetWorker.enqueueOnce(this@MarsPhotoWidgetConfigActivity)
+            MarsPhotoWidgetWorker.enqueuePeriodic(this@MarsPhotoWidgetConfigActivity)
+
+            val resultValue = Intent().apply {
+                putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+            }
+            setResult(Activity.RESULT_OK, resultValue)
+            finish()
+        }
+    }
+}
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+private fun WidgetConfigScreen(
+    appWidgetId: Int,
+    onConfirm: (Long) -> Unit
+) {
+    val context = LocalContext.current
+    val roverOptions = remember {
+        listOf(
+            RoverOption(PERSEVERANCE_ID, "Perseverance"),
+            RoverOption(CURIOSITY_ID, "Curiosity"),
+            RoverOption(OPPORTUNITY_ID, "Opportunity"),
+            RoverOption(SPIRIT_ID, "Spirit"),
+            RoverOption(INSIGHT_ID, "Insight")
+        )
+    }
+    var selectedId by remember { mutableStateOf(DefaultRoverId) }
+
+    LaunchedEffect(appWidgetId) {
+        val manager = GlanceAppWidgetManager(context)
+        val glanceId = manager.getGlanceIdBy(appWidgetId)
+        val prefs = getAppWidgetState(context, PreferencesGlanceStateDefinition, glanceId)
+        selectedId = prefs[MarsPhotoWidgetState.roverIdKey] ?: DefaultRoverId
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(text = "Choose rover") })
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.SpaceBetween
+        ) {
+            LazyColumn(
+                modifier = Modifier.weight(1f, fill = false)
+            ) {
+                items(roverOptions) { option ->
+                    RoverRow(
+                        option = option,
+                        selected = option.id == selectedId,
+                        onClick = { selectedId = option.id }
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Button(
+                onClick = { onConfirm(selectedId) },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(text = "Add widget")
+            }
+        }
+    }
+}
+
+@Composable
+private fun RoverRow(
+    option: RoverOption,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        RadioButton(selected = selected, onClick = onClick)
+        Spacer(modifier = Modifier.width(12.dp))
+        Column {
+            Text(text = option.name, style = MaterialTheme.typography.bodyLarge)
+            Text(text = "Latest photo", style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}
+
+private data class RoverOption(
+    val id: Long,
+    val name: String
+)

--- a/androidApp/src/main/kotlin/com/sirelon/marsroverphotos/widget/MarsPhotoWidgetReceiver.kt
+++ b/androidApp/src/main/kotlin/com/sirelon/marsroverphotos/widget/MarsPhotoWidgetReceiver.kt
@@ -1,0 +1,26 @@
+package com.sirelon.marsroverphotos.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+
+public class MarsPhotoWidgetReceiver : GlanceAppWidgetReceiver() {
+
+    override val glanceAppWidget = MarsPhotoWidget()
+
+    override fun onEnabled(context: Context) {
+        super.onEnabled(context)
+        MarsPhotoWidgetWorker.enqueuePeriodic(context)
+        MarsPhotoWidgetWorker.enqueueOnce(context)
+    }
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray
+    ) {
+        super.onUpdate(context, appWidgetManager, appWidgetIds)
+        MarsPhotoWidgetWorker.enqueuePeriodic(context)
+        MarsPhotoWidgetWorker.enqueueOnce(context)
+    }
+}

--- a/androidApp/src/main/kotlin/com/sirelon/marsroverphotos/widget/MarsPhotoWidgetWorker.kt
+++ b/androidApp/src/main/kotlin/com/sirelon/marsroverphotos/widget/MarsPhotoWidgetWorker.kt
@@ -1,0 +1,204 @@
+package com.sirelon.marsroverphotos.widget
+
+import android.content.Context
+import android.graphics.Bitmap
+import androidx.glance.appwidget.GlanceAppWidgetManager
+import androidx.glance.appwidget.state.getAppWidgetState
+import androidx.glance.appwidget.state.updateAppWidgetState
+import androidx.glance.state.PreferencesGlanceStateDefinition
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import coil3.ImageLoader
+import coil3.request.ImageRequest
+import coil3.toBitmap
+import com.sirelon.marsroverphotos.data.database.entities.MarsImage
+import com.sirelon.marsroverphotos.data.network.RestApi
+import com.sirelon.marsroverphotos.domain.models.CURIOSITY_ID
+import com.sirelon.marsroverphotos.domain.models.INSIGHT_ID
+import com.sirelon.marsroverphotos.domain.models.OPPORTUNITY_ID
+import com.sirelon.marsroverphotos.domain.models.PERSEVERANCE_ID
+import com.sirelon.marsroverphotos.domain.models.SPIRIT_ID
+import com.sirelon.marsroverphotos.domain.models.PhotosQueryRequest
+import com.sirelon.marsroverphotos.domain.repositories.ImagesRepository
+import com.sirelon.marsroverphotos.platform.Tracker
+import com.sirelon.marsroverphotos.utils.Logger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import java.io.File
+import java.io.FileOutputStream
+import java.util.concurrent.TimeUnit
+
+public class MarsPhotoWidgetWorker(
+    context: Context,
+    params: WorkerParameters
+) : CoroutineWorker(context, params), KoinComponent {
+
+    private val imagesRepository: ImagesRepository by inject()
+    private val api: RestApi by inject()
+    @Suppress("UnusedPrivateProperty")
+    private val tracker: Tracker by inject()
+
+    override suspend fun doWork(): Result {
+        val glanceManager = GlanceAppWidgetManager(applicationContext)
+        val glanceIds = glanceManager.getGlanceIds(MarsPhotoWidget::class.java)
+        if (glanceIds.isEmpty()) {
+            return Result.success()
+        }
+
+        val widgetDir = File(applicationContext.cacheDir, "mars_widget")
+
+        var updatedCount = 0
+        var hadFailure = false
+
+        glanceIds.forEach { glanceId ->
+            val state = getAppWidgetState(applicationContext, PreferencesGlanceStateDefinition, glanceId)
+            val roverId = state[MarsPhotoWidgetState.roverIdKey] ?: DefaultRoverId
+
+            val latestPhoto = try {
+                fetchLatestPhoto(roverId)
+            } catch (error: Exception) {
+                hadFailure = true
+                Logger.e("MarsPhotoWidgetWorker", error) { "Failed to load latest photo for rover $roverId" }
+                null
+            }
+
+            if (latestPhoto == null) {
+                return@forEach
+            }
+
+            val bitmap = loadBitmap(applicationContext, latestPhoto.imageUrl)
+            val imagePath = bitmap?.let { saveBitmap(widgetDir, glanceId.hashCode().toString(), it) }
+
+            try {
+                imagesRepository.saveImages(listOf(latestPhoto))
+                if (imagePath == null) {
+                    hadFailure = true
+                    return@forEach
+                }
+                updateAppWidgetState(applicationContext, glanceId) { prefs ->
+                    prefs[MarsPhotoWidgetState.roverIdKey] = roverId
+                    prefs[MarsPhotoWidgetState.roverNameKey] = roverNameForId(roverId)
+                    prefs[MarsPhotoWidgetState.imageIdKey] = latestPhoto.id
+                    prefs[MarsPhotoWidgetState.solKey] = latestPhoto.sol
+                    prefs[MarsPhotoWidgetState.earthDateKey] = latestPhoto.earthDate
+                    prefs[MarsPhotoWidgetState.imagePathKey] = imagePath
+                }
+                MarsPhotoWidget().update(applicationContext, glanceId)
+                updatedCount += 1
+            } catch (error: Exception) {
+                hadFailure = true
+                Logger.e("MarsPhotoWidgetWorker", error) { "Failed to update widget state for rover $roverId" }
+            }
+        }
+
+        return if (updatedCount == 0 && hadFailure) {
+            Result.retry()
+        } else {
+            Result.success()
+        }
+    }
+
+    private suspend fun fetchLatestPhoto(roverId: Long): MarsImage? {
+        return when (roverId) {
+            INSIGHT_ID -> api.getInsightLatestPhotos().firstOrNull()
+            PERSEVERANCE_ID -> api.getPerseveranceLatestPhotos().firstOrNull()
+            CURIOSITY_ID, OPPORTUNITY_ID, SPIRIT_ID -> fetchLatestByManifest(roverId)
+            else -> fetchLatestByManifest(roverId)
+        }
+    }
+
+    private suspend fun fetchLatestByManifest(roverId: Long): MarsImage? {
+        val roverName = when (roverId) {
+            CURIOSITY_ID -> "curiosity"
+            OPPORTUNITY_ID -> "opportunity"
+            SPIRIT_ID -> "spirit"
+            PERSEVERANCE_ID -> "perseverance"
+            else -> "curiosity"
+        }
+        val roverInfo = api.getRoverInfo(roverName)
+        var sol = roverInfo.maxSol
+
+        repeat(MaxSolLookback) {
+            val photos = api.getRoversPhotos(PhotosQueryRequest(roverId, sol, null))
+            if (photos.isNotEmpty()) {
+                return photos.first()
+            }
+            sol -= 1
+            if (sol <= 0) {
+                return null
+            }
+        }
+        return null
+    }
+
+    private suspend fun loadBitmap(context: Context, url: String): Bitmap? = withContext(Dispatchers.IO) {
+        if (url.isBlank()) {
+            return@withContext null
+        }
+        val loader = ImageLoader(context)
+        val request = ImageRequest.Builder(context)
+            .data(url)
+            .size(640)
+            .build()
+        val result = loader.execute(request)
+        result.image?.toBitmap()
+    }
+
+    private fun saveBitmap(directory: File, key: String, bitmap: Bitmap): String? {
+        if (!directory.exists() && !directory.mkdirs()) {
+            return null
+        }
+        val file = File(directory, "mars_photo_widget_$key.png")
+        FileOutputStream(file).use { out ->
+            bitmap.compress(Bitmap.CompressFormat.PNG, 90, out)
+        }
+        return file.absolutePath
+    }
+
+    companion object {
+        private const val UniqueWorkName = "mars_photo_widget_daily"
+        private const val UniqueImmediateWork = "mars_photo_widget_now"
+        private const val MaxSolLookback = 30
+
+        fun enqueuePeriodic(context: Context) {
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build()
+
+            val request = PeriodicWorkRequestBuilder<MarsPhotoWidgetWorker>(1, TimeUnit.DAYS)
+                .setConstraints(constraints)
+                .build()
+
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                UniqueWorkName,
+                ExistingPeriodicWorkPolicy.UPDATE,
+                request
+            )
+        }
+
+        fun enqueueOnce(context: Context) {
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build()
+
+            val request = OneTimeWorkRequestBuilder<MarsPhotoWidgetWorker>()
+                .setConstraints(constraints)
+                .build()
+
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                UniqueImmediateWork,
+                ExistingWorkPolicy.REPLACE,
+                request
+            )
+        }
+    }
+}

--- a/androidApp/src/main/res/layout/widget_loading.xml
+++ b/androidApp/src/main/res/layout/widget_loading.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Placeholder initial layout shown while the Glance widget loads -->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#1A283D" />

--- a/androidApp/src/main/res/xml/mars_photo_widget_info.xml
+++ b/androidApp/src/main/res/xml/mars_photo_widget_info.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:configure="com.sirelon.marsroverphotos.widget.MarsPhotoWidgetConfigActivity"
+    android:initialLayout="@layout/widget_loading"
+    android:minHeight="110dp"
+    android:minWidth="180dp"
+    android:resizeMode="horizontal|vertical"
+    android:updatePeriodMillis="0"
+    android:widgetCategory="home_screen" />

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppNavigation.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppNavigation.kt
@@ -52,6 +52,12 @@ fun AppNavigation(
                     selectedId = target.id.toString()
                 )
             )
+            is DeepLink.Image -> navigator.navigate(
+                AppDestination.Images(
+                    photoIds = listOf(target.id),
+                    selectedId = target.id
+                )
+            )
         }
         onDeepLinkConsumed?.invoke()
     }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/DeepLink.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/DeepLink.kt
@@ -6,4 +6,6 @@ package com.sirelon.marsroverphotos.presentation.navigation
 sealed class DeepLink {
     data class Rover(val id: Long) : DeepLink()
     data class Photo(val id: Long) : DeepLink()
+    /** Navigate directly to an image by its String ID (e.g. from the home-screen widget). */
+    data class Image(val id: String) : DeepLink()
 }


### PR DESCRIPTION
Ports the Mars photo home-screen widget from the legacy `app/` module into `androidApp/`, replacing all legacy dependencies with KMP equivalents. `ImagesRepository` and `RestApi` are now injected via Koin (`KoinComponent` in `CoroutineWorker`); `Timber` is replaced with shared `Logger`; rover ID constants use the shared `domain.models` values; and the widget launch intent targets `MainActivity` instead of the removed `RoversActivity`. Adds `DeepLink.Image(id: String)` to the shared navigation layer so a widget tap can deep-link directly into the image gallery via the new `WidgetExtraImageId` extra check in `MainActivity`. The widget receiver and config activity are registered in `AndroidManifest.xml`, and Compose Material3 + Coil3 are added as explicit `androidApp` dependencies to support the widget UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)