### PR TITLE
Complete iOS deep links and universal-link parsing

### DIFF
--- a/KMP_MIGRATION_PLAN.md
+++ b/KMP_MIGRATION_PLAN.md
@@ -55,7 +55,7 @@ technical reference notes are at the bottom.
 | 6.1 — Firebase iOS | ✅ Done | Popular data, analytics, Crashlytics on iOS |
 | 6.2 — iOS image save/share | Pending | Save to Photos and native share sheet |
 | 6.3 — Xcode project bootstrap | ✅ Done | Checked-in iOS project/workspace that teammates can run |
-| 6.4 — iOS deep links | Pending | `marsrover://` and universal-link handling on iOS |
+| 6.4 — iOS deep links | ✅ Done | `marsrover://` and universal-link handling on iOS |
 | Final cleanup | Pending | Delete legacy `app/`, final smoke tests, CI gate |
 
 ---
@@ -391,7 +391,7 @@ file must be provided locally. `IosTracker` now mirrors `AndroidTracker` using `
 
 ---
 
-### 6.4 — iOS Deep Links
+### ~~6.4 — iOS Deep Links~~ ✅
 
 **Goal:** match Android deep-link behavior on iOS.
 
@@ -402,8 +402,14 @@ file must be provided locally. `IosTracker` now mirrors `AndroidTracker` using `
 - Pass the pending deep link into `MainViewController`.
 
 **Definition of Done:**
-- Opening `marsrover://rover/5` on iOS navigates to Curiosity photos.
+- ✅ Opening `marsrover://rover/5` on iOS navigates to Curiosity photos.
 - Universal links work once domain setup is available.
+
+*Note: `marsrover://` URL scheme registered in `Info.plist`. `MarsRoverApp.swift` forwards
+URLs to `pushDeepLink(urlString:)` (exported from `Main.ios.kt`), which parses the path in
+Kotlin and feeds the result into a `MutableStateFlow<DeepLink?>` that `MainViewController`
+collects via `collectAsState()` — no UIViewController recreation needed. Universal links
+deferred until the AASA file is hosted on the domain.*
 
 ---
 

--- a/iosApp/README.md
+++ b/iosApp/README.md
@@ -53,11 +53,32 @@ iosApp/
     └── Info.plist
 ```
 
+## Deep links (ticket 6.4 ✅)
+
+The `marsrover://` URL scheme is registered in `Info.plist`. When iOS delivers a URL,
+`MarsRoverApp.swift` forwards it to `Main_iosKt.pushDeepLink(urlString:)` which parses
+it in Kotlin and injects the result into the running Compose content via a `MutableStateFlow`.
+
+Supported URLs:
+| URL | Effect |
+|---|---|
+| `marsrover://rover/5` | Navigate to rover 5 (Curiosity) photos |
+| `marsrover://photo/123` | Open photo 123 in the gallery |
+
+Test from terminal (simulator must be running):
+```bash
+xcrun simctl openurl booted "marsrover://rover/5"
+xcrun simctl openurl booted "marsrover://photo/123"
+```
+
+Universal links (`https://marsroverphotos.app/…`) work once the AASA file is hosted on the domain.
+
 ## Architecture
 
 ```
 MarsRoverApp.swift  →  FirebaseApp.configure()
                     →  initKoinIos()
+                    →  .onOpenURL → Main_iosKt.pushDeepLink()  (ticket 6.4)
 ContentView.swift   →  Main_iosKt.MainViewController()
                     →  shared.framework (Compose Multiplatform)
                     →  App.kt (commonMain)

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -38,8 +38,9 @@
 /* Begin PBXFileReference section */
 		9E2B4A212B8F3D0100C4A5E2 /* MarsRoverApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarsRoverApp.swift; sourceTree = "<group>"; };
 		9E2B4A222B8F3D0100C4A5E2 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
-		9E2B4A232B8F3D0100C4A5E2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		9E2B4A242B8F3D0100C4A5E2 /* shared.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = shared.framework; path = ../shared/build/bin/iosSimulatorArm64/debugFramework/shared.framework; sourceTree = SOURCE_ROOT; };
+			9E2B4A232B8F3D0100C4A5E2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+			726B44A0A95A4F0F9D5E8B75 /* iosApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = iosApp.entitlements; sourceTree = "<group>"; };
+			9E2B4A242B8F3D0100C4A5E2 /* shared.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = shared.framework; path = ../shared/build/bin/iosSimulatorArm64/debugFramework/shared.framework; sourceTree = SOURCE_ROOT; };
 		9E2B4A252B8F3D0100C4A5E2 /* iosApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iosApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9E2B4A352B8F3D0100C4A5E2 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -85,9 +86,10 @@
 			children = (
 				9E2B4A212B8F3D0100C4A5E2 /* MarsRoverApp.swift */,
 				9E2B4A222B8F3D0100C4A5E2 /* ContentView.swift */,
-				9E2B4A232B8F3D0100C4A5E2 /* Info.plist */,
-				9E2B4A352B8F3D0100C4A5E2 /* GoogleService-Info.plist */,
-			);
+					9E2B4A232B8F3D0100C4A5E2 /* Info.plist */,
+					726B44A0A95A4F0F9D5E8B75 /* iosApp.entitlements */,
+					9E2B4A352B8F3D0100C4A5E2 /* GoogleService-Info.plist */,
+				);
 			path = iosApp;
 			sourceTree = "<group>";
 		};
@@ -327,8 +329,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+					CODE_SIGN_STYLE = Automatic;
+					CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
+					CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 5MF89WU7WQ;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SRCROOT)/../shared/build/bin/iosSimulatorArm64/debugFramework",
@@ -357,8 +360,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+					CODE_SIGN_STYLE = Automatic;
+					CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
+					CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 5MF89WU7WQ;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SRCROOT)/../shared/build/bin/iosSimulatorArm64/releaseFramework",

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -29,6 +29,17 @@
 	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.sirelon.marsroverphotos</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>marsrover</string>
+			</array>
+		</dict>
+	</array>
 	<key>UILaunchScreen</key>
 	<dict/>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/iosApp/iosApp/MarsRoverApp.swift
+++ b/iosApp/iosApp/MarsRoverApp.swift
@@ -14,6 +14,11 @@ struct MarsRoverApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                // Deep link handling (ticket 6.4)
+                // Forwards marsrover:// URLs to Kotlin for parsing and navigation.
+                .onOpenURL { url in
+                    Main_iosKt.pushDeepLink(urlString: url.absoluteString)
+                }
         }
     }
 }

--- a/iosApp/iosApp/iosApp.entitlements
+++ b/iosApp/iosApp/iosApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:marsroverphotos.app</string>
+	</array>
+</dict>
+</plist>

--- a/shared/src/iosMain/kotlin/Main.ios.kt
+++ b/shared/src/iosMain/kotlin/Main.ios.kt
@@ -20,9 +20,17 @@ private val pendingDeepLink = MutableStateFlow<DeepLink?>(null)
  *   marsrover://photo/{photoId}   — navigate directly to a photo in the gallery
  */
 fun pushDeepLink(urlString: String) {
-    if (!urlString.startsWith("marsrover://")) return
-    val path = urlString.removePrefix("marsrover://")
-    val parts = path.split("/")
+    val parts = when {
+        urlString.startsWith("marsrover://") -> {
+            urlString.removePrefix("marsrover://").split("/")
+        }
+
+        urlString.startsWith("https://marsroverphotos.app/") -> {
+            urlString.removePrefix("https://marsroverphotos.app/").split("/")
+        }
+
+        else -> return
+    }
     if (parts.size < 2) return
     val host = parts[0]
     val idStr = parts[1]

--- a/shared/src/iosMain/kotlin/Main.ios.kt
+++ b/shared/src/iosMain/kotlin/Main.ios.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.window.ComposeUIViewController
 import com.sirelon.marsroverphotos.presentation.App
 import com.sirelon.marsroverphotos.presentation.navigation.DeepLink
 import kotlinx.coroutines.flow.MutableStateFlow
+import platform.Foundation.NSURL
 import platform.UIKit.UIViewController
 
 /**
@@ -20,21 +21,24 @@ private val pendingDeepLink = MutableStateFlow<DeepLink?>(null)
  *   marsrover://photo/{photoId}   — navigate directly to a photo in the gallery
  */
 fun pushDeepLink(urlString: String) {
-    val parts = when {
-        urlString.startsWith("marsrover://") -> {
-            urlString.removePrefix("marsrover://").split("/")
+    val url = NSURL.URLWithString(urlString) ?: return
+    val host = url.host ?: return
+    val pathSegments = url.pathComponents
+        ?.mapNotNull { it as? String }
+        ?.filter { it != "/" && it.isNotBlank() }
+        .orEmpty()
+    if (pathSegments.isEmpty()) return
+
+    val (kind, idStr) = when (host.lowercase()) {
+        "marsroverphotos.app" -> {
+            if (pathSegments.size < 2) return
+            pathSegments[0] to pathSegments[1]
         }
 
-        urlString.startsWith("https://marsroverphotos.app/") -> {
-            urlString.removePrefix("https://marsroverphotos.app/").split("/")
-        }
-
+        "rover", "photo" -> host.lowercase() to pathSegments[0]
         else -> return
     }
-    if (parts.size < 2) return
-    val host = parts[0]
-    val idStr = parts[1]
-    val deepLink = when (host) {
+    val deepLink = when (kind) {
         "rover" -> idStr.toLongOrNull()?.let { DeepLink.Rover(it) }
         "photo" -> idStr.toLongOrNull()?.let { DeepLink.Photo(it) }
         else -> null

--- a/shared/src/iosMain/kotlin/Main.ios.kt
+++ b/shared/src/iosMain/kotlin/Main.ios.kt
@@ -1,6 +1,38 @@
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.window.ComposeUIViewController
 import com.sirelon.marsroverphotos.presentation.App
+import com.sirelon.marsroverphotos.presentation.navigation.DeepLink
+import kotlinx.coroutines.flow.MutableStateFlow
 import platform.UIKit.UIViewController
+
+/**
+ * Internal bus so the iOS app shell can push deep links into the running Compose content
+ * without recreating the UIViewController.
+ */
+private val pendingDeepLink = MutableStateFlow<DeepLink?>(null)
+
+/**
+ * Called by the iOS app shell (MarsRoverApp.swift) when the OS delivers a deep-link URL.
+ *
+ * Supported schemes:
+ *   marsrover://rover/{roverId}   — navigate to a rover's photo grid
+ *   marsrover://photo/{photoId}   — navigate directly to a photo in the gallery
+ */
+fun pushDeepLink(urlString: String) {
+    if (!urlString.startsWith("marsrover://")) return
+    val path = urlString.removePrefix("marsrover://")
+    val parts = path.split("/")
+    if (parts.size < 2) return
+    val host = parts[0]
+    val idStr = parts[1]
+    val deepLink = when (host) {
+        "rover" -> idStr.toLongOrNull()?.let { DeepLink.Rover(it) }
+        "photo" -> idStr.toLongOrNull()?.let { DeepLink.Photo(it) }
+        else -> null
+    } ?: return
+    pendingDeepLink.value = deepLink
+}
 
 /**
  * Main entry point for iOS app.
@@ -8,6 +40,11 @@ import platform.UIKit.UIViewController
  */
 fun MainViewController(): UIViewController {
     return ComposeUIViewController {
-        App(rateAppUrl = "https://apps.apple.com/app/mars-rover-photos")
+        val deepLink by pendingDeepLink.collectAsState()
+        App(
+            deepLink = deepLink,
+            onDeepLinkConsumed = { pendingDeepLink.value = null },
+            rateAppUrl = "https://apps.apple.com/app/mars-rover-photos"
+        )
     }
 }


### PR DESCRIPTION
This PR completes ticket 6.4 by wiring iOS deep links end-to-end: registering the `marsrover` URL scheme in `Info.plist`, forwarding incoming URLs from `MarsRoverApp.swift`, and handling them in `Main.ios.kt` without recreating the Compose controller. It also updates the iOS README and `KMP_MIGRATION_PLAN.md` to mark 6.4 as done and document supported deep-link formats and testing commands. A follow-up fix was included because the initial iOS parser only accepted `marsrover://...` and dropped universal-link URLs; `Main.ios.kt` now also parses `https://marsroverphotos.app/rover/{id}` and `/photo/{id}` paths. This keeps iOS behavior aligned with Android once associated domains/AASA are enabled.
