### PR TITLE
Enable edge-to-edge images and inset handling

### DIFF
--- a/KMP_MIGRATION_PLAN.md
+++ b/KMP_MIGRATION_PLAN.md
@@ -58,6 +58,7 @@ technical reference notes are at the bottom.
 | 6.3 — Xcode project bootstrap | ✅ Done | Checked-in iOS project/workspace that teammates can run |
 | 6.4 — iOS deep links | ✅ Done | `marsrover://` and universal-link handling on iOS |
 | Final cleanup | Pending | Delete legacy `app/`, final smoke tests, CI gate |
+| Edge-to-edge | ✅ Done | Full edge-to-edge support: `isNavigationBarContrastEnforced`, `adjustResize`, ImagesScreen fullscreen |
 
 ---
 
@@ -422,6 +423,30 @@ URLs to `pushDeepLink(urlString:)` (exported from `Main.ios.kt`), which parses t
 Kotlin and feeds the result into a `MutableStateFlow<DeepLink?>` that `MainViewController`
 collects via `collectAsState()` — no UIViewController recreation needed. Universal links
 deferred until the AASA file is hosted on the domain.*
+
+---
+
+---
+
+### Edge-to-Edge ✅
+
+**Goal:** Make the app truly edge-to-edge so content draws behind system bars.
+
+**Done:**
+- ✅ `window.isNavigationBarContrastEnforced = false` in `MainActivity` (API 29+) — prevents unwanted
+  translucent scrim over the nav bar when using M3 `NavigationBar`.
+- ✅ `android:windowSoftInputMode="adjustResize"` added to `MainActivity` in the manifest.
+- ✅ `AppNavigation`: when on `AppDestination.Images`, status-bar insets are removed from the root
+  Column and the bottom chrome (AdSlot + MarsBottomBar) is hidden, giving `ImagesScreen` the full window.
+- ✅ `ImagesScreen`: `TopAppBar` now uses its default window insets (handles status bar itself);
+  overlay controls Box uses `navigationBarsPadding()` so the favorite toggle stays above the nav bar;
+  all `MarsSnackbar` instances in `OnEvent` also use `navigationBarsPadding()`.
+- ✅ `MaterialSymbolIcon`: removed `PlatformTextStyle(includeFontPadding = false)` which was
+  Android-only and broke the iOS framework compile; `platformStyle = null` leaves the Box-centered
+  glyph layout from the prior commit intact.
+
+*Note: The Box-wrapping approach for `MarsImageFavoriteToggle` and `MarsSnackbar` ensures images
+extend behind the nav bar while interactive controls remain tappable above it.*
 
 ---
 

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.AppCompat.DayNight.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/androidApp/src/main/kotlin/com/sirelon/marsroverphotos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/sirelon/marsroverphotos/MainActivity.kt
@@ -2,6 +2,7 @@ package com.sirelon.marsroverphotos
 
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -28,6 +29,11 @@ class MainActivity : ComponentActivity() {
 
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        // Prevent the system from adding a translucent scrim over the NavigationBar —
+        // the app's NavigationBar background provides the necessary contrast.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced = false
+        }
 
         // Handle deep link if present
         handleDeepLink(intent)

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppNavigation.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppNavigation.kt
@@ -45,6 +45,7 @@ fun AppNavigation(
     val entryProvider = koinEntryProvider<NavKey>()
     val tracker: Tracker = koinInject()
     val currentDestination = backStack.lastOrNull() as? AppDestination ?: startDestination
+    val isImages = currentDestination is AppDestination.Images
 
     LaunchedEffect(deepLink) {
         val target = deepLink ?: return@LaunchedEffect
@@ -67,8 +68,11 @@ fun AppNavigation(
     }
 
     CompositionLocalProvider(LocalAppNavigator provides navigator) {
-        Column(modifier = modifier.windowInsetsPadding(WindowInsets.statusBars)) {
-            if (currentDestination !is AppDestination.Ukraine) {
+        // Images screen goes fully edge-to-edge: no status-bar inset, no bottom chrome.
+        Column(
+            modifier = if (isImages) modifier else modifier.windowInsetsPadding(WindowInsets.statusBars)
+        ) {
+            if (!isImages && currentDestination !is AppDestination.Ukraine) {
                 UkraineBanner(
                     modifier = Modifier.fillMaxWidth(),
                     onClick = {
@@ -85,14 +89,16 @@ fun AppNavigation(
                     entryProvider = entryProvider
                 )
             }
-            AdSlot(modifier = Modifier.fillMaxWidth())
-            MarsBottomBar(
-                selectedDestination = currentDestination.topLevelDestination(),
-                onDestinationClick = { destination ->
-                    tracker.trackClick("bottom_${destination.analyticsTag}")
-                    navigator.selectTopLevel(destination)
-                }
-            )
+            if (!isImages) {
+                AdSlot(modifier = Modifier.fillMaxWidth())
+                MarsBottomBar(
+                    selectedDestination = currentDestination.topLevelDestination(),
+                    onDestinationClick = { destination ->
+                        tracker.trackClick("bottom_${destination.analyticsTag}")
+                        navigator.selectTopLevel(destination)
+                    }
+                )
+            }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
@@ -12,9 +12,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
@@ -146,10 +146,9 @@ private fun ImagesPagerContent(
         list.getOrNull(pagerState.currentPage)
     }
 
-    Column {
+    Column(modifier = Modifier.fillMaxSize()) {
         AnimatedVisibility(visible = !hideUi) {
             TopAppBar(
-                windowInsets = WindowInsets(0, 0, 0, 0),
                 title = { Text(text = titleState) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
@@ -192,7 +191,7 @@ private fun ImagesPagerContent(
             }
         }
 
-        Box {
+        Box(modifier = Modifier.weight(1f)) {
             ImagesPager(
                 pagerState = pagerState,
                 images = list,
@@ -236,7 +235,7 @@ private fun BoxScope.OnEvent(uiEvent: UiEvent?) {
 
             MarsSnackbar(
                 snackbarHostState = snackbarHostState,
-                modifier = Modifier.align(Alignment.BottomCenter),
+                modifier = Modifier.align(Alignment.BottomCenter).navigationBarsPadding(),
                 actionClick = {
                     if (!imagePath.isNullOrBlank()) {
                         try {
@@ -264,7 +263,7 @@ private fun BoxScope.OnEvent(uiEvent: UiEvent?) {
             }
             MarsSnackbar(
                 snackbarHostState = snackbarHostState,
-                modifier = Modifier.align(Alignment.BottomCenter),
+                modifier = Modifier.align(Alignment.BottomCenter).navigationBarsPadding(),
                 actionClick = null
             )
         }
@@ -277,7 +276,7 @@ private fun BoxScope.OnEvent(uiEvent: UiEvent?) {
             }
             MarsSnackbar(
                 snackbarHostState = snackbarHostState,
-                modifier = Modifier.align(Alignment.BottomCenter),
+                modifier = Modifier.align(Alignment.BottomCenter).navigationBarsPadding(),
                 actionClick = null
             )
         }
@@ -369,13 +368,20 @@ private fun ImagesPager(
                     showPlaceholder = false,
                 )
 
-                MarsImageFavoriteToggle(
+                // Controls layer — image fills full screen; controls stay above nav bar
+                Box(
                     modifier = Modifier
-                        .size(64.dp)
-                        .align(Alignment.BottomCenter),
-                    checked = marsImage.favorite,
-                    onCheckedChange = { onFavoriteClick(marsImage) }
-                )
+                        .fillMaxSize()
+                        .navigationBarsPadding()
+                ) {
+                    MarsImageFavoriteToggle(
+                        modifier = Modifier
+                            .size(64.dp)
+                            .align(Alignment.BottomCenter),
+                        checked = marsImage.favorite,
+                        onCheckedChange = { onFavoriteClick(marsImage) }
+                    )
+                }
 
                 // Reset zoom when this page scrolls off-screen
                 val isSettled = page == pagerState.settledPage

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/MaterialSymbolIcon.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/MaterialSymbolIcon.kt
@@ -9,7 +9,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -92,7 +91,7 @@ fun MaterialSymbolIcon(
             textAlign = TextAlign.Center,
             maxLines = 1,
             style = LocalTextStyle.current.copy(
-                platformStyle = PlatformTextStyle(includeFontPadding = false)
+                platformStyle = null
             ),
         )
     }


### PR DESCRIPTION
## Summary
This PR implements full edge-to-edge behavior for the image viewer flow and records that work in the migration plan.
On Android, `MainActivity` now disables navigation-bar contrast enforcement on API 29+ and the manifest sets `windowSoftInputMode="adjustResize"`.
In shared UI, `AppNavigation` removes top insets and hides bottom chrome for `AppDestination.Images`, while `ImagesScreen` uses navigation-bar-safe overlay padding for controls/snackbars and keeps content fullscreen.
`MaterialSymbolIcon` drops Android-only `PlatformTextStyle` usage so iOS framework compilation is not broken.

## Validation
Reviewed branch diff against `origin/Sirelon/kmp-migration` and verified the change scope is limited to six files.
