### PR TITLE
Restore GDPR consent flow for Android and iOS

### DIFF
--- a/KMP_MIGRATION_PLAN.md
+++ b/KMP_MIGRATION_PLAN.md
@@ -57,6 +57,7 @@ technical reference notes are at the bottom.
 | 6.2 — iOS image save/share | ✅ Done | Save to Photos and native share sheet |
 | 6.3 — Xcode project bootstrap | ✅ Done | Checked-in iOS project/workspace that teammates can run |
 | 6.4 — iOS deep links | ✅ Done | `marsrover://` and universal-link handling on iOS |
+| S10 — GDPR / Consent | ✅ Done | Android UMP consent flow restored; iOS ATT prompt added |
 | Final cleanup | Pending | Delete legacy `app/`, final smoke tests, CI gate |
 | Edge-to-edge | ✅ Done | Full edge-to-edge support: `isNavigationBarContrastEnforced`, `adjustResize`, ImagesScreen fullscreen |
 
@@ -331,6 +332,34 @@ interface doesn't expose those Firebase methods. Wire up when `6.1` (Firebase iO
 - ✅ Widget can still deep link into the app through `WidgetExtraImageId`.
 
 *Note: `ImagesRepository` and `RestApi` are injected via Koin (`KoinComponent` in `CoroutineWorker`). `Timber` replaced with shared `Logger` (Kermit). Legacy `feature/rovers/*Id` constants replaced with shared `domain.models.*_ID`. `RoversActivity` replaced with `MainActivity`. Added `DeepLink.Image(id: String)` to handle widget photo taps; handled in `MainActivity.handleDeepLink` by checking `WidgetExtraImageId` extra before processing URI deep links. `initialLayout` uses a local placeholder layout — `@layout/glance_default_loading` from the Glance library was not resolvable in this setup.*
+
+---
+
+### ~~Ticket S10 — GDPR / Consent Flow~~ ✅
+
+**Goal:** restore the Google UMP-based GDPR consent flow on Android; add iOS ATT prompt.
+
+**Android work:**
+- Ported `GdprHelper` from legacy `app/` into `androidApp/gdpr/GdprHelper.kt`.
+- Replaced `Timber` with shared `Logger`; replaced `recordException` import with shared platform actual.
+- Wrapped `ConsentDebugSettings` (EEA force) in `if (BuildConfig.DEBUG)`.
+- `gdprHelper.init()` called in `MainActivity.onCreate` after `setContent`.
+- `gdprHelper.acceptGdpr: StateFlow<Boolean>` is ready to wire into `AdSlot` when ads land.
+
+**iOS work:**
+- `NSUserTrackingUsageDescription` added to `Info.plist`.
+- `ATTrackingManager.requestTrackingAuthorization` called from `MarsRoverApp.init()` with a 1 s delay
+  (Apple guideline: show prompt after first frame). No new SPM dependency — system framework.
+
+**Definition of Done:**
+- ✅ `GdprHelper` lives in `androidApp/gdpr/`.
+- ✅ `MainActivity` initialises the consent flow on startup.
+- ✅ iOS `Info.plist` carries `NSUserTrackingUsageDescription`.
+- ✅ iOS ATT authorization is requested on launch.
+- ✅ Android, iOS framework, and unit tests compile.
+
+*Note: ads remain a no-op (`AdSlot.android.kt` placeholder) until a future ticket wires them up.
+GDPR/ATT consent is collected proactively so it is already in place when ads land.*
 
 ---
 

--- a/androidApp/src/main/kotlin/com/sirelon/marsroverphotos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/sirelon/marsroverphotos/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import com.sirelon.marsroverphotos.gdpr.GdprHelper
 import com.sirelon.marsroverphotos.presentation.App
 import com.sirelon.marsroverphotos.presentation.navigation.DeepLink
 import com.sirelon.marsroverphotos.utils.Logger
@@ -22,6 +23,7 @@ import com.sirelon.marsroverphotos.widget.WidgetExtraImageId
  */
 class MainActivity : ComponentActivity() {
     private var pendingDeepLink: DeepLink? by mutableStateOf(null)
+    private val gdprHelper = GdprHelper(this)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         // Install Android 12+ splash screen
@@ -46,6 +48,11 @@ class MainActivity : ComponentActivity() {
                 appVersion = BuildConfig.VERSION_NAME
             )
         }
+
+        // Initialise GDPR/UMP consent flow. For EEA users this may show a consent form;
+        // for everyone else it completes silently. gdprHelper.acceptGdpr can be wired into
+        // AdSlot when ads are re-enabled.
+        gdprHelper.init()
     }
 
     private fun openStoreListing() {

--- a/androidApp/src/main/kotlin/com/sirelon/marsroverphotos/gdpr/GdprHelper.kt
+++ b/androidApp/src/main/kotlin/com/sirelon/marsroverphotos/gdpr/GdprHelper.kt
@@ -47,7 +47,7 @@ class GdprHelper(private val activity: Activity) {
                 if (consentInformation.isConsentFormAvailable) {
                     loadForm()
                 } else {
-                    acceptGdpr.value = true
+                    updateAcceptanceFromConsentState()
                 }
             },
             ::onError
@@ -57,8 +57,7 @@ class GdprHelper(private val activity: Activity) {
     private fun onError(error: FormError) {
         Logger.w(TAG) { "UMP error ${error.errorCode}: ${error.message}" }
         recordException(RuntimeException("UMP ${error.errorCode}: ${error.message}"))
-        // Treat errors as consent not required so the app remains functional.
-        acceptGdpr.value = true
+        updateAcceptanceFromConsentState()
     }
 
     private fun loadForm() {
@@ -72,14 +71,23 @@ class GdprHelper(private val activity: Activity) {
     private fun showConsentForm(consentForm: ConsentForm) {
         Logger.d(TAG) { "showConsentForm status=${consentInformation.consentStatus}" }
         if (consentInformation.consentStatus == ConsentInformation.ConsentStatus.REQUIRED) {
-            consentForm.show(activity) {
+            consentForm.show(activity) { formError ->
+                if (formError != null) {
+                    Logger.w(TAG) { "Consent form dismissed with error ${formError.errorCode}: ${formError.message}" }
+                    recordException(RuntimeException("UMP form dismiss ${formError.errorCode}: ${formError.message}"))
+                }
                 // Reload form after dismissal so it is ready for future re-requests.
                 loadForm()
-                acceptGdpr.value = true
+                updateAcceptanceFromConsentState()
             }
         } else {
-            acceptGdpr.value = true
+            updateAcceptanceFromConsentState()
         }
+    }
+
+    private fun updateAcceptanceFromConsentState() {
+        // UMP source of truth: only true when ad requests are currently allowed.
+        acceptGdpr.value = consentInformation.canRequestAds()
     }
 
     private companion object {

--- a/androidApp/src/main/kotlin/com/sirelon/marsroverphotos/gdpr/GdprHelper.kt
+++ b/androidApp/src/main/kotlin/com/sirelon/marsroverphotos/gdpr/GdprHelper.kt
@@ -1,0 +1,88 @@
+package com.sirelon.marsroverphotos.gdpr
+
+import android.app.Activity
+import com.google.android.ump.ConsentDebugSettings
+import com.google.android.ump.ConsentForm
+import com.google.android.ump.ConsentInformation
+import com.google.android.ump.ConsentRequestParameters
+import com.google.android.ump.FormError
+import com.google.android.ump.UserMessagingPlatform
+import com.sirelon.marsroverphotos.BuildConfig
+import com.sirelon.marsroverphotos.platform.recordException
+import com.sirelon.marsroverphotos.utils.Logger
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * Helper for Google User Messaging Platform (UMP) GDPR consent.
+ * Shows a consent form for EEA users when personalized ads are in use.
+ * For non-EEA users or when consent is not required, [acceptGdpr] emits `true` silently.
+ */
+class GdprHelper(private val activity: Activity) {
+
+    private val consentInformation by lazy {
+        UserMessagingPlatform.getConsentInformation(activity)
+    }
+
+    /** Emits `true` once consent has been obtained or is not required. */
+    val acceptGdpr = MutableStateFlow(false)
+
+    fun init() {
+        val paramsBuilder = ConsentRequestParameters.Builder()
+            .setTagForUnderAgeOfConsent(false)
+
+        if (BuildConfig.DEBUG) {
+            // In debug builds, force EEA geography so the consent form is always testable.
+            val debugSettings = ConsentDebugSettings.Builder(activity)
+                .setDebugGeography(ConsentDebugSettings.DebugGeography.DEBUG_GEOGRAPHY_EEA)
+                .addTestDeviceHashedId("62FB47CDEF3CE930EF49BB808381622F")
+                .build()
+            paramsBuilder.setConsentDebugSettings(debugSettings)
+        }
+
+        consentInformation.requestConsentInfoUpdate(
+            activity,
+            paramsBuilder.build(),
+            {
+                Logger.d(TAG) { "Consent info updated: $consentInformation" }
+                if (consentInformation.isConsentFormAvailable) {
+                    loadForm()
+                } else {
+                    acceptGdpr.value = true
+                }
+            },
+            ::onError
+        )
+    }
+
+    private fun onError(error: FormError) {
+        Logger.w(TAG) { "UMP error ${error.errorCode}: ${error.message}" }
+        recordException(RuntimeException("UMP ${error.errorCode}: ${error.message}"))
+        // Treat errors as consent not required so the app remains functional.
+        acceptGdpr.value = true
+    }
+
+    private fun loadForm() {
+        UserMessagingPlatform.loadConsentForm(
+            activity,
+            ::showConsentForm,
+            ::onError
+        )
+    }
+
+    private fun showConsentForm(consentForm: ConsentForm) {
+        Logger.d(TAG) { "showConsentForm status=${consentInformation.consentStatus}" }
+        if (consentInformation.consentStatus == ConsentInformation.ConsentStatus.REQUIRED) {
+            consentForm.show(activity) {
+                // Reload form after dismissal so it is ready for future re-requests.
+                loadForm()
+                acceptGdpr.value = true
+            }
+        } else {
+            acceptGdpr.value = true
+        }
+    }
+
+    private companion object {
+        private const val TAG = "GdprHelper"
+    }
+}

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -31,6 +31,8 @@
 	<true/>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Mars Rover Photos needs access to save rover photos to your Photos library.</string>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>We use this to show you relevant ads and improve the app experience.</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/iosApp/iosApp/MarsRoverApp.swift
+++ b/iosApp/iosApp/MarsRoverApp.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import shared
 import FirebaseCore
+import AppTrackingTransparency
 
 @main
 struct MarsRoverApp: App {
@@ -9,6 +10,19 @@ struct MarsRoverApp: App {
         FirebaseApp.configure()
         // Initialize Koin dependency injection from shared module
         IosApp.shared.start()
+
+        // Request App Tracking Transparency authorization (iOS 14+).
+        // The prompt is deferred by 1 s so it appears after the app's first frame is rendered,
+        // which is required by Apple's HIG. The status is used when ads are added in the future.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            ATTrackingManager.requestTrackingAuthorization { status in
+                // .authorized  — user allowed tracking; use personalized ads
+                // .denied / .restricted — non-personalized ads only
+                // .notDetermined — authorization not yet requested (should not happen here)
+                // Wire into Google Mobile Ads SDK initialization when ads land on iOS.
+                _ = status
+            }
+        }
     }
 
     var body: some Scene {


### PR DESCRIPTION
## Summary
- Restores Android GDPR consent flow by adding `GdprHelper` in `androidApp`, initializing UMP from `MainActivity`, and keeping debug-only EEA forcing for testability.
- Adds iOS ATT support by adding `NSUserTrackingUsageDescription` to `Info.plist` and requesting authorization from `MarsRoverApp` after app startup.
- Updates `KMP_MIGRATION_PLAN.md` to mark Ticket S10 complete and record the delivered Android/iOS consent work.

## Validation
- Not rerun in this publish step; this PR publishes the current workspace state.
