### PR TITLE
Enable KMP Room paging and fix paged image navigation

### DIFF
--- a/KMP_MIGRATION_PLAN.md
+++ b/KMP_MIGRATION_PLAN.md
@@ -86,6 +86,11 @@ and the old placeholders still render before real screens replace them.
 **Notes:**
 - `paging-compose-common` does not exist on Maven Central. The working artifact is
   `androidx.paging:paging-compose:3.4.2`.
+- `androidx.room3:room3-paging:3.0.0-alpha05` ships KMP artifacts for iOS/Desktop (b/339934824
+  fixed). `room-paging` moved to `commonMain`; `@DaoReturnTypeConverters(PagingSourceDaoReturnTypeConverter::class)`
+  added to `AppDataBase`; `loadFavoritePagedSource()` and `loadPopularPagedSource()` restored in
+  `ImagesDao`, `ImagesRepository`, and `ImagesRepositoryImpl`. ViewModels and screens still use
+  the non-paged `Flow<List<MarsImage>>` path — wiring them to `LazyPagingItems` is a follow-up.
 
 ---
 

--- a/KMP_MIGRATION_PLAN.md
+++ b/KMP_MIGRATION_PLAN.md
@@ -235,6 +235,8 @@ interface doesn't expose those Firebase methods. Wire up when `6.1` (Firebase iO
 
 *Note: `IFirebasePhotos.loadPopularPhotos()` is injected directly into `PopularPhotosViewModel` (bypassing the paged Room mediator which is still commented out for KMP-target reasons). Photos load as a `StateFlow<List<MarsImage>>` via a one-shot coroutine with retry. The placeholder `PopularScreen` in `PlaceholderScreens.kt` was removed. `popular_empty_title` string added to `strings.xml`.*
 
+*Follow-up (2026-05-22): Favorites/Popular now use `LazyPagingItems` + Room paging sources and `PopularRemoteMediator` again. To avoid truncated `ImagesScreen` swiping when opening from a paged list, `AppDestination.Images` now carries an `ImagesSource` enum; the image viewer loads full lists from Room for `FAVORITES`/`POPULAR` and uses explicit `photoIds` only for `DIRECT_IDS` (Photos screen flow).*
+
 ---
 
 ### ~~Ticket S6 — Mission Info~~ ✅

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -104,6 +104,8 @@ kotlin {
 
             // Room KMP (Android, iOS, Desktop only - no WASM support)
             implementation(libs.androidx.room.runtime)
+            // room-paging supports all KMP targets since room3 3.0.0-alpha05 (b/339934824)
+            implementation(libs.androidx.room.paging)
 
             // GitLive Firebase KMP (Firestore supports all platforms)
             implementation(libs.gitlive.firebase.firestore)
@@ -116,9 +118,6 @@ kotlin {
             implementation(libs.koin.android)
             implementation(libs.koin.androidx.compose)
             implementation(libs.lifecycle.viewmodel.navigation3)
-
-            // Room paging (Android-only — confirmed: KSP does not support PagingSource on non-Android targets)
-            implementation(libs.androidx.room.paging)
 
             // Firebase native (Android-only — GitLive wraps these, still needed for Android init)
             implementation(libs.firebase.analytics.versioned)

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -35,6 +35,8 @@
     <string name="favorite_empty_btn">Go to rovers</string>
     <string name="favorite_empty_title">No favorite photos yet.\nYou can save any photos you like.\nJust mark them as "favorite".</string>
     <string name="popular_empty_title">No popular photos available.\nCheck back later!</string>
+    <string name="images_empty_title">No photos available.</string>
+    <string name="images_empty_btn">Go back</string>
 
     <!-- Navigation labels -->
     <string name="nav_rovers">Rovers</string>

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/AppDataBase.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/AppDataBase.kt
@@ -1,10 +1,12 @@
 package com.sirelon.marsroverphotos.data.database
 
 import androidx.room3.ConstructedBy
+import androidx.room3.DaoReturnTypeConverters
 import androidx.room3.Database
 import androidx.room3.RoomDatabase
 import androidx.room3.RoomDatabaseConstructor
 import androidx.room3.migration.Migration
+import androidx.room3.paging.PagingSourceDaoReturnTypeConverter
 import androidx.sqlite.SQLiteConnection
 import androidx.sqlite.execSQL
 import com.sirelon.marsroverphotos.data.database.dao.FactDisplayDao
@@ -28,6 +30,7 @@ expect object AppDataBaseConstructor : RoomDatabaseConstructor<AppDataBase>
     exportSchema = false
 )
 @ConstructedBy(AppDataBaseConstructor::class)
+@DaoReturnTypeConverters(PagingSourceDaoReturnTypeConverter::class)
 abstract class AppDataBase : RoomDatabase() {
 
     abstract fun roversDao(): RoverDao

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/dao/ImagesDao.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/dao/ImagesDao.kt
@@ -45,13 +45,12 @@ interface ImagesDao {
     @Query("SELECT * FROM images WHERE popular = 1 ORDER BY `order` ASC")
     fun loadPopularImages(): Flow<List<MarsImage>>
 
-    // TODO: PagingSource requires room-paging which is Android-only for now.
-    // Confirmed: Room KSP does not support PagingSource return type on non-Android targets.
-    // @Query("SELECT * FROM images WHERE favorite = 1 ORDER BY `order` ASC")
-    // fun loadFavoritePagedSource(): PagingSource<Int, MarsImage>
-    //
-    // @Query("SELECT * FROM images WHERE popular = 1 ORDER BY `order` ASC")
-    // fun loadPopularPagedSource(): PagingSource<Int, MarsImage>
+    // room-paging supports all KMP targets since room3 3.0.0-alpha05 (b/339934824)
+    @Query("SELECT * FROM images WHERE favorite = 1 ORDER BY `order` ASC")
+    fun loadFavoritePagedSource(): PagingSource<Int, MarsImage>
+
+    @Query("SELECT * FROM images WHERE popular = 1 ORDER BY `order` ASC")
+    fun loadPopularPagedSource(): PagingSource<Int, MarsImage>
 
     @Query("DELETE FROM images WHERE popular = 1")
     suspend fun deleteAllPopular()

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/repositories/ImagesRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/repositories/ImagesRepositoryImpl.kt
@@ -33,6 +33,8 @@ class ImagesRepositoryImpl(
 
     override fun loadFavoriteImages(): Flow<List<MarsImage>> = imagesDao.loadFavoriteImages()
 
+    override fun loadPopularImages(): Flow<List<MarsImage>> = imagesDao.loadPopularImages()
+
     override fun loadFavoritePagedSource(): Flow<PagingData<MarsImage>> {
         return Pager(
             config = PagingConfig(pageSize = 10, initialLoadSize = 10, enablePlaceholders = false),

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/repositories/ImagesRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/repositories/ImagesRepositoryImpl.kt
@@ -35,7 +35,7 @@ class ImagesRepositoryImpl(
 
     override fun loadFavoritePagedSource(): Flow<PagingData<MarsImage>> {
         return Pager(
-            config = PagingConfig(pageSize = 10, initialLoadSize = 10),
+            config = PagingConfig(pageSize = 10, initialLoadSize = 10, enablePlaceholders = false),
             pagingSourceFactory = { imagesDao.loadFavoritePagedSource() }
         ).flow
     }
@@ -63,7 +63,7 @@ class ImagesRepositoryImpl(
     @OptIn(ExperimentalPagingApi::class)
     override fun loadPopularPagedSource(): Flow<PagingData<MarsImage>> {
         return Pager(
-            config = PagingConfig(pageSize = 20, initialLoadSize = 20),
+            config = PagingConfig(pageSize = 20, initialLoadSize = 20, enablePlaceholders = false),
             pagingSourceFactory = { imagesDao.loadPopularPagedSource() },
             remoteMediator = PopularRemoteMediator(firebasePhotos, imagesDao)
         ).flow

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/repositories/ImagesRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/repositories/ImagesRepositoryImpl.kt
@@ -33,13 +33,12 @@ class ImagesRepositoryImpl(
 
     override fun loadFavoriteImages(): Flow<List<MarsImage>> = imagesDao.loadFavoriteImages()
 
-    // TODO: Re-enable when room-paging supports all KMP targets
-    // override fun loadFavoritePagedSource(): Flow<PagingData<MarsImage>> {
-    //     return Pager(
-    //         config = PagingConfig(pageSize = 10, initialLoadSize = 10),
-    //         pagingSourceFactory = { imagesDao.loadFavoritePagedSource() }
-    //     ).flow
-    // }
+    override fun loadFavoritePagedSource(): Flow<PagingData<MarsImage>> {
+        return Pager(
+            config = PagingConfig(pageSize = 10, initialLoadSize = 10),
+            pagingSourceFactory = { imagesDao.loadFavoritePagedSource() }
+        ).flow
+    }
 
     override suspend fun updateFavForImage(item: MarsImage) {
         supervisorScope {
@@ -61,13 +60,12 @@ class ImagesRepositoryImpl(
         }
     }
 
-    // TODO: Re-enable when room-paging supports all KMP targets
-    // @OptIn(ExperimentalPagingApi::class)
-    // override fun loadPopularPagedSource(): Flow<PagingData<MarsImage>> {
-    //     return Pager(
-    //         config = PagingConfig(pageSize = 20, initialLoadSize = 20),
-    //         pagingSourceFactory = { imagesDao.loadPopularPagedSource() },
-    //         remoteMediator = PopularRemoteMediator(firebasePhotos, imagesDao)
-    //     ).flow
-    // }
+    @OptIn(ExperimentalPagingApi::class)
+    override fun loadPopularPagedSource(): Flow<PagingData<MarsImage>> {
+        return Pager(
+            config = PagingConfig(pageSize = 20, initialLoadSize = 20),
+            pagingSourceFactory = { imagesDao.loadPopularPagedSource() },
+            remoteMediator = PopularRemoteMediator(firebasePhotos, imagesDao)
+        ).flow
+    }
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/di/NavigationModule.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/di/NavigationModule.kt
@@ -38,7 +38,8 @@ val navigationModule = module {
                 navigator.navigate(
                     AppDestination.Images(
                         photoIds = listOf(photoId),
-                        selectedId = photoId
+                        selectedId = photoId,
+                        source = AppDestination.ImagesSource.DIRECT_IDS,
                     )
                 )
             },
@@ -54,6 +55,7 @@ val navigationModule = module {
         ImagesScreen(
             photoIds = destination.photoIds,
             selectedId = destination.selectedId,
+            source = destination.source,
             onBack = { navigator.goBack() }
         )
     }
@@ -61,11 +63,11 @@ val navigationModule = module {
     navigation<AppDestination.Favorite> {
         val navigator = LocalAppNavigator.current
         FavoriteScreen(
-            onNavigateToImages = { image, allImages ->
+            onNavigateToImages = { image ->
                 navigator.navigate(
                     AppDestination.Images(
-                        photoIds = allImages.map { it.id },
-                        selectedId = image.id
+                        selectedId = image.id,
+                        source = AppDestination.ImagesSource.FAVORITES,
                     )
                 )
             },
@@ -76,11 +78,11 @@ val navigationModule = module {
     navigation<AppDestination.Popular> {
         val navigator = LocalAppNavigator.current
         PopularScreen(
-            onNavigateToImages = { image, allImages ->
+            onNavigateToImages = { image ->
                 navigator.navigate(
                     AppDestination.Images(
-                        photoIds = allImages.map { it.id },
-                        selectedId = image.id
+                        selectedId = image.id,
+                        source = AppDestination.ImagesSource.POPULAR,
                     )
                 )
             }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/domain/repositories/ImagesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/domain/repositories/ImagesRepository.kt
@@ -29,6 +29,12 @@ interface ImagesRepository {
     fun loadFavoriteImages(): Flow<List<MarsImage>>
 
     /**
+     * Load popular images.
+     * @return Flow of popular images
+     */
+    fun loadPopularImages(): Flow<List<MarsImage>>
+
+    /**
      * Load favorite images with paging support.
      * @return Flow of paged favorite images
      */

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/domain/repositories/ImagesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/domain/repositories/ImagesRepository.kt
@@ -28,12 +28,11 @@ interface ImagesRepository {
      */
     fun loadFavoriteImages(): Flow<List<MarsImage>>
 
-    // TODO: Re-enable when room-paging supports all KMP targets
-    // /**
-    //  * Load favorite images with paging support.
-    //  * @return Flow of paged favorite images
-    //  */
-    // fun loadFavoritePagedSource(): Flow<PagingData<MarsImage>>
+    /**
+     * Load favorite images with paging support.
+     * @return Flow of paged favorite images
+     */
+    fun loadFavoritePagedSource(): Flow<PagingData<MarsImage>>
 
     /**
      * Toggle favorite status for an image.
@@ -41,10 +40,9 @@ interface ImagesRepository {
      */
     suspend fun updateFavForImage(item: MarsImage)
 
-    // TODO: Re-enable when room-paging supports all KMP targets
-    // /**
-    //  * Load popular images with paging support.
-    //  * @return Flow of paged popular images
-    //  */
-    // fun loadPopularPagedSource(): Flow<PagingData<MarsImage>>
+    /**
+     * Load popular images with paging support.
+     * @return Flow of paged popular images
+     */
+    fun loadPopularPagedSource(): Flow<PagingData<MarsImage>>
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppDestinations.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppDestinations.kt
@@ -9,6 +9,13 @@ import kotlinx.serialization.Serializable
 @Serializable
 sealed interface AppDestination : NavKey {
     @Serializable
+    enum class ImagesSource {
+        DIRECT_IDS,
+        FAVORITES,
+        POPULAR,
+    }
+
+    @Serializable
     data object Rovers : AppDestination
 
     @Serializable
@@ -17,7 +24,8 @@ sealed interface AppDestination : NavKey {
     @Serializable
     data class Images(
         val photoIds: List<String> = emptyList(),
-        val selectedId: String? = null
+        val selectedId: String? = null,
+        val source: ImagesSource = ImagesSource.DIRECT_IDS,
     ) : AppDestination
 
     @Serializable

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/FavoriteScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/FavoriteScreen.kt
@@ -2,6 +2,7 @@ package com.sirelon.marsroverphotos.presentation.screens
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -36,10 +37,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
+import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
+import androidx.paging.compose.itemContentType
+import androidx.paging.compose.itemKey
 import com.sirelon.marsroverphotos.data.database.entities.MarsImage
 import com.sirelon.marsroverphotos.domain.settings.AppSettings
 import com.sirelon.marsroverphotos.presentation.ui.CenteredColumn
-import com.sirelon.marsroverphotos.presentation.ui.CenteredProgress
 import com.sirelon.marsroverphotos.presentation.ui.MarsImageComposable
 import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbol
 import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbolIcon
@@ -49,9 +54,6 @@ import com.sirelon.marsroverphotos.shared.resources.alien_icon
 import com.sirelon.marsroverphotos.shared.resources.favorite_empty_btn
 import com.sirelon.marsroverphotos.shared.resources.favorite_empty_title
 import com.sirelon.marsroverphotos.shared.resources.favorite_title
-import com.sirelon.marsroverphotos.shared.resources.img_placeholder
-import kotlin.uuid.ExperimentalUuidApi
-import kotlin.uuid.Uuid
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
@@ -59,7 +61,7 @@ import org.koin.compose.viewmodel.koinViewModel
 
 /**
  * Favorite images screen.
- * Displays the user's favorite Mars photos.
+ * Displays the user's favorite Mars photos with paging support backed by Room.
  *
  * Created on 01.03.2021 22:32 for Mars-Rover-Photos.
  * Ported to Compose Multiplatform (KMP).
@@ -72,15 +74,18 @@ fun FavoriteScreen(
     viewModel: FavoriteImagesViewModel = koinViewModel()
 ) {
     val appSettings: AppSettings = koinInject()
-    val items by viewModel.favoriteImagesFlow.collectAsState(initial = emptyList())
+    val lazyPagingItems = viewModel.favoritePagedFlow.collectAsLazyPagingItems()
 
     FavoritePhotosContent(
         modifier = modifier,
         title = stringResource(Res.string.favorite_title),
-        items = items,
+        lazyPagingItems = lazyPagingItems,
         appSettings = appSettings,
         onFavoriteClick = { viewModel.updateFavForImage(it) },
-        onItemClick = { image -> onNavigateToImages(image, items) },
+        onItemClick = { image ->
+            val loadedItems = (0 until lazyPagingItems.itemCount).mapNotNull { lazyPagingItems.peek(it) }
+            onNavigateToImages(image, loadedItems)
+        },
         emptyContent = {
             FavoriteEmptyContent(
                 title = stringResource(Res.string.favorite_empty_title),
@@ -94,12 +99,12 @@ fun FavoriteScreen(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalUuidApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun FavoritePhotosContent(
     modifier: Modifier,
     title: String,
-    items: List<MarsImage>,
+    lazyPagingItems: LazyPagingItems<MarsImage>,
     appSettings: AppSettings,
     onItemClick: (image: MarsImage) -> Unit,
     onFavoriteClick: (image: MarsImage) -> Unit,
@@ -114,7 +119,7 @@ private fun FavoritePhotosContent(
             title = { Text(text = title) },
             windowInsets = WindowInsets(0, 0, 0, 0),
             actions = {
-                if (items.isNotEmpty()) {
+                if (lazyPagingItems.itemCount > 0) {
                     IconButton(
                         onClick = {
                             gridView = !gridView
@@ -138,38 +143,52 @@ private fun FavoritePhotosContent(
             scrollBehavior = scrollBehavior,
         )
 
-        if (items.isEmpty()) {
-            emptyContent()
-        } else {
-            val spacedBy = Arrangement.spacedBy(8.dp)
-            LazyVerticalStaggeredGrid(
-                modifier = modifier
-                    .weight(1f)
-                    .nestedScroll(scrollBehavior.nestedScrollConnection),
-                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
-                columns = if (gridView) {
-                    StaggeredGridCells.Adaptive(minSize = 180.dp)
-                } else {
-                    StaggeredGridCells.Fixed(1)
-                },
-                verticalItemSpacing = 8.dp,
-                horizontalArrangement = spacedBy,
-                content = {
-                    items(
-                        count = items.size,
-                        key = { items[it].id.ifEmpty { Uuid.random().toString() } },
-                        contentType = { "MarsImageComposable" }
-                    ) { index ->
-                        val image = items[index]
-                        MarsImageComposable(
-                            modifier = Modifier,
-                            marsImage = image,
-                            onClick = { onItemClick(image) },
-                            onFavoriteClick = { onFavoriteClick(image) }
-                        )
-                    }
+        when {
+            lazyPagingItems.loadState.refresh is LoadState.Loading && lazyPagingItems.itemCount == 0 -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
                 }
-            )
+            }
+
+            lazyPagingItems.itemCount == 0 -> {
+                emptyContent()
+            }
+
+            else -> {
+                LazyVerticalStaggeredGrid(
+                    modifier = modifier
+                        .weight(1f)
+                        .nestedScroll(scrollBehavior.nestedScrollConnection),
+                    contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
+                    columns = if (gridView) {
+                        StaggeredGridCells.Adaptive(minSize = 180.dp)
+                    } else {
+                        StaggeredGridCells.Fixed(1)
+                    },
+                    verticalItemSpacing = 8.dp,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    content = {
+                        items(
+                            count = lazyPagingItems.itemCount,
+                            key = lazyPagingItems.itemKey { it.id },
+                            contentType = lazyPagingItems.itemContentType { "MarsImageComposable" }
+                        ) { index ->
+                            val image = lazyPagingItems[index] ?: return@items
+                            MarsImageComposable(
+                                modifier = Modifier,
+                                marsImage = image,
+                                onClick = { onItemClick(image) },
+                                onFavoriteClick = { onFavoriteClick(image) }
+                            )
+                        }
+                        if (lazyPagingItems.loadState.append is LoadState.Loading) {
+                            item(span = StaggeredGridItemSpan.FullLine) {
+                                LoadingMoreItem()
+                            }
+                        }
+                    }
+                )
+            }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/FavoriteScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/FavoriteScreen.kt
@@ -68,7 +68,7 @@ import org.koin.compose.viewmodel.koinViewModel
  */
 @Composable
 fun FavoriteScreen(
-    onNavigateToImages: (selected: MarsImage, all: List<MarsImage>) -> Unit,
+    onNavigateToImages: (selected: MarsImage) -> Unit,
     onNavigateToRovers: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: FavoriteImagesViewModel = koinViewModel()
@@ -82,10 +82,7 @@ fun FavoriteScreen(
         lazyPagingItems = lazyPagingItems,
         appSettings = appSettings,
         onFavoriteClick = { viewModel.updateFavForImage(it) },
-        onItemClick = { image ->
-            val loadedItems = (0 until lazyPagingItems.itemCount).mapNotNull { lazyPagingItems.peek(it) }
-            onNavigateToImages(image, loadedItems)
-        },
+        onItemClick = onNavigateToImages,
         emptyContent = {
             FavoriteEmptyContent(
                 title = stringResource(Res.string.favorite_empty_title),

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sirelon.marsroverphotos.data.database.entities.MarsImage
+import com.sirelon.marsroverphotos.presentation.navigation.AppDestination
 import com.sirelon.marsroverphotos.presentation.ui.CenteredProgress
 import com.sirelon.marsroverphotos.presentation.ui.MarsImageFavoriteToggle
 import com.sirelon.marsroverphotos.presentation.ui.MarsSnackbar
@@ -71,40 +72,48 @@ import org.koin.compose.viewmodel.koinViewModel
  *
  * @param photoIds    Ordered list of image IDs to show in the pager.
  * @param selectedId  Which ID to land on initially (null → first page).
+ * @param source      Defines where images should be loaded from.
  * @param onBack      Navigate back (e.g. pop to Photos screen).
  */
 @Composable
 fun ImagesScreen(
     photoIds: List<String>,
     selectedId: String?,
+    source: AppDestination.ImagesSource,
     onBack: () -> Unit,
     viewModel: ImageViewModel = koinViewModel(),
 ) {
     // Guard: nothing to show → pop immediately instead of hanging on the loader.
-    if (photoIds.isEmpty()) {
+    if (source == AppDestination.ImagesSource.DIRECT_IDS && photoIds.isEmpty()) {
         LaunchedEffect(Unit) { onBack() }
         return
     }
 
-    LaunchedEffect(photoIds) {
-        viewModel.setIdsToShow(photoIds)
+    LaunchedEffect(photoIds, source) {
+        viewModel.setImageSource(source = source, ids = photoIds)
     }
 
     DisposableEffect(photoIds) {
         onDispose { /* nothing to clean up */ }
     }
 
-    val initialPage = remember(photoIds, selectedId) {
-        selectedId?.let { photoIds.indexOf(it).takeIf { i -> i >= 0 } } ?: 0
-    }
-
     val screenState by viewModel.screenState.collectAsStateWithLifecycle()
     val images = screenState.images
 
     val pagerState = rememberPagerState(
-        initialPage = initialPage,
+        initialPage = 0,
         pageCount = { images.size },
     )
+
+    LaunchedEffect(images, selectedId) {
+        val index = selectedId?.let { targetId ->
+            images.indexOfFirst { it.id == targetId }.takeIf { it >= 0 }
+        } ?: return@LaunchedEffect
+
+        if (pagerState.currentPage != index && index < pagerState.pageCount) {
+            pagerState.scrollToPage(index)
+        }
+    }
 
     Crossfade(targetState = images.isEmpty(), label = "Images") { isEmpty ->
         if (isEmpty) {

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
@@ -12,8 +12,10 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -21,6 +23,7 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -61,8 +64,12 @@ import com.sirelon.marsroverphotos.presentation.ui.rememberZoomableState
 import com.sirelon.marsroverphotos.presentation.ui.zoomable
 import com.sirelon.marsroverphotos.presentation.viewmodels.ImageViewModel
 import com.sirelon.marsroverphotos.presentation.viewmodels.UiEvent
+import com.sirelon.marsroverphotos.shared.resources.Res
+import com.sirelon.marsroverphotos.shared.resources.images_empty_btn
+import com.sirelon.marsroverphotos.shared.resources.images_empty_title
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 
 /**
@@ -104,20 +111,47 @@ fun ImagesScreen(
         initialPage = 0,
         pageCount = { images.size },
     )
+    var isInitialPositionApplied by remember(source, selectedId) { mutableStateOf(false) }
+    var hasRenderedImages by remember(source) { mutableStateOf(false) }
 
-    LaunchedEffect(images, selectedId) {
-        val index = selectedId?.let { targetId ->
-            images.indexOfFirst { it.id == targetId }.takeIf { it >= 0 }
-        } ?: return@LaunchedEffect
-
-        if (pagerState.currentPage != index && index < pagerState.pageCount) {
-            pagerState.scrollToPage(index)
+    if (images.isNotEmpty() && !hasRenderedImages) {
+        SideEffect {
+            hasRenderedImages = true
         }
+    }
+
+    LaunchedEffect(images, selectedId, isInitialPositionApplied) {
+        if (isInitialPositionApplied) return@LaunchedEffect
+
+        if (selectedId == null) {
+            isInitialPositionApplied = true
+            return@LaunchedEffect
+        }
+
+        if (images.isEmpty()) {
+            return@LaunchedEffect
+        }
+
+        val index = selectedId.let { targetId ->
+            images.indexOfFirst { it.id == targetId }.takeIf { it >= 0 }
+        }
+
+        if (index != null && index < pagerState.pageCount) {
+            if (pagerState.currentPage != index) {
+                pagerState.scrollToPage(index)
+            }
+        }
+
+        isInitialPositionApplied = true
     }
 
     Crossfade(targetState = images.isEmpty(), label = "Images") { isEmpty ->
         if (isEmpty) {
-            CenteredProgress()
+            if (source != AppDestination.ImagesSource.DIRECT_IDS && hasRenderedImages) {
+                ImagesEmptyState(onBack = onBack)
+            } else {
+                CenteredProgress()
+            }
         } else {
             ImagesPagerContent(
                 viewModel = viewModel,
@@ -126,6 +160,25 @@ fun ImagesScreen(
                 hideUi = screenState.hideUi,
                 onBack = onBack,
             )
+        }
+    }
+}
+
+@Composable
+private fun ImagesEmptyState(onBack: () -> Unit) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = stringResource(Res.string.images_empty_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Button(onClick = onBack) {
+                Text(text = stringResource(Res.string.images_empty_btn))
+            }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PopularScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PopularScreen.kt
@@ -57,7 +57,7 @@ import org.koin.compose.viewmodel.koinViewModel
  */
 @Composable
 fun PopularScreen(
-    onNavigateToImages: (selected: MarsImage, all: List<MarsImage>) -> Unit,
+    onNavigateToImages: (selected: MarsImage) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: PopularPhotosViewModel = koinViewModel(),
 ) {
@@ -70,10 +70,7 @@ fun PopularScreen(
         lazyPagingItems = lazyPagingItems,
         appSettings = appSettings,
         onFavoriteClick = { viewModel.updateFavorite(it) },
-        onItemClick = { image ->
-            val loadedItems = (0 until lazyPagingItems.itemCount).mapNotNull { lazyPagingItems.peek(it) }
-            onNavigateToImages(image, loadedItems)
-        },
+        onItemClick = onNavigateToImages,
     )
 }
 

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PopularScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PopularScreen.kt
@@ -8,9 +8,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
+import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
@@ -28,6 +28,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
+import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
+import androidx.paging.compose.itemContentType
+import androidx.paging.compose.itemKey
 import com.sirelon.marsroverphotos.data.database.entities.MarsImage
 import com.sirelon.marsroverphotos.domain.settings.AppSettings
 import com.sirelon.marsroverphotos.presentation.ui.CenteredColumn
@@ -38,8 +43,6 @@ import com.sirelon.marsroverphotos.presentation.viewmodels.PopularPhotosViewMode
 import com.sirelon.marsroverphotos.shared.resources.Res
 import com.sirelon.marsroverphotos.shared.resources.popular_empty_title
 import com.sirelon.marsroverphotos.shared.resources.popular_title
-import kotlin.uuid.ExperimentalUuidApi
-import kotlin.uuid.Uuid
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
@@ -47,8 +50,8 @@ import org.koin.compose.viewmodel.koinViewModel
 /**
  * Popular photos screen.
  * Displays the most popular Mars photos ranked by community engagement.
- * On Android, shows real Firebase data. On iOS and Desktop, degrades to an empty state
- * until platform Firebase support is fully active.
+ * Data is fetched from Firebase via [PopularRemoteMediator] and cached in Room,
+ * then surfaced to the UI as paged items — works on Android, iOS, and Desktop.
  *
  * Created for KMP migration — Ticket S5.
  */
@@ -59,32 +62,30 @@ fun PopularScreen(
     viewModel: PopularPhotosViewModel = koinViewModel(),
 ) {
     val appSettings: AppSettings = koinInject()
-    val items by viewModel.popularPhotos.collectAsState()
-    val isLoading by viewModel.isLoading.collectAsState()
+    val lazyPagingItems = viewModel.popularPagedFlow.collectAsLazyPagingItems()
 
     PopularPhotosContent(
         modifier = modifier,
         title = stringResource(Res.string.popular_title),
-        items = items,
-        isLoading = isLoading,
+        lazyPagingItems = lazyPagingItems,
         appSettings = appSettings,
         onFavoriteClick = { viewModel.updateFavorite(it) },
-        onItemClick = { image -> onNavigateToImages(image, items) },
-        onRetry = { viewModel.loadPopularPhotos() },
+        onItemClick = { image ->
+            val loadedItems = (0 until lazyPagingItems.itemCount).mapNotNull { lazyPagingItems.peek(it) }
+            onNavigateToImages(image, loadedItems)
+        },
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalUuidApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun PopularPhotosContent(
     modifier: Modifier,
     title: String,
-    items: List<MarsImage>,
-    isLoading: Boolean,
+    lazyPagingItems: LazyPagingItems<MarsImage>,
     appSettings: AppSettings,
     onItemClick: (image: MarsImage) -> Unit,
     onFavoriteClick: (image: MarsImage) -> Unit,
-    onRetry: () -> Unit,
 ) {
     val gridViewState by appSettings.gridViewFlow.collectAsState()
     var gridView by rememberSaveable { mutableStateOf(gridViewState) }
@@ -118,21 +119,27 @@ private fun PopularPhotosContent(
         )
 
         when {
-            isLoading && items.isEmpty() -> {
+            lazyPagingItems.loadState.refresh is LoadState.Loading && lazyPagingItems.itemCount == 0 -> {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     CircularProgressIndicator()
                 }
             }
 
-            items.isEmpty() -> {
+            lazyPagingItems.loadState.refresh is LoadState.Error && lazyPagingItems.itemCount == 0 -> {
                 PopularEmptyContent(
                     title = stringResource(Res.string.popular_empty_title),
-                    onRetry = onRetry,
+                    onRetry = { lazyPagingItems.retry() },
+                )
+            }
+
+            lazyPagingItems.itemCount == 0 -> {
+                PopularEmptyContent(
+                    title = stringResource(Res.string.popular_empty_title),
+                    onRetry = { lazyPagingItems.refresh() },
                 )
             }
 
             else -> {
-                val spacedBy = Arrangement.spacedBy(8.dp)
                 LazyVerticalStaggeredGrid(
                     modifier = modifier
                         .weight(1f)
@@ -144,14 +151,14 @@ private fun PopularPhotosContent(
                         StaggeredGridCells.Fixed(1)
                     },
                     verticalItemSpacing = 8.dp,
-                    horizontalArrangement = spacedBy,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
                     content = {
                         items(
-                            count = items.size,
-                            key = { items[it].id.ifEmpty { Uuid.random().toString() } },
-                            contentType = { "MarsImageComposable" }
+                            count = lazyPagingItems.itemCount,
+                            key = lazyPagingItems.itemKey { it.id },
+                            contentType = lazyPagingItems.itemContentType { "MarsImageComposable" }
                         ) { index ->
-                            val image = items[index]
+                            val image = lazyPagingItems[index] ?: return@items
                             MarsImageComposable(
                                 modifier = Modifier,
                                 marsImage = image,
@@ -179,7 +186,7 @@ private fun PopularEmptyContent(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         Spacer(modifier = Modifier.height(16.dp))
-        androidx.compose.material3.Button(onClick = onRetry) {
+        Button(onClick = onRetry) {
             Text(text = "Retry")
         }
     }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/FavoriteImagesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/FavoriteImagesViewModel.kt
@@ -2,6 +2,8 @@ package com.sirelon.marsroverphotos.presentation.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
 import com.sirelon.marsroverphotos.data.database.entities.MarsImage
 import com.sirelon.marsroverphotos.domain.repositories.ImagesRepository
 import com.sirelon.marsroverphotos.platform.Tracker
@@ -11,7 +13,7 @@ import kotlinx.coroutines.launch
 
 /**
  * ViewModel for the favorite images screen.
- * Loads user's favorite images.
+ * Loads user's favorite images with paging support.
  *
  * Created on 25.08.2020 12:13 for Mars-Rover-Photos.
  */
@@ -21,9 +23,11 @@ class FavoriteImagesViewModel(
 ) : ViewModel() {
 
     /**
-     * Flow of favorite images.
+     * Paged flow of favorite images, cached in [viewModelScope].
      */
-    val favoriteImagesFlow: Flow<List<MarsImage>> = imagesRepository.loadFavoriteImages()
+    val favoritePagedFlow: Flow<PagingData<MarsImage>> = imagesRepository
+        .loadFavoritePagedSource()
+        .cachedIn(viewModelScope)
 
     /**
      * Track an analytics event.
@@ -35,6 +39,7 @@ class FavoriteImagesViewModel(
 
     /**
      * Toggle favorite status for an image.
+     * Room invalidates the PagingSource automatically after the DB write.
      * @param image The image to update
      */
     fun updateFavForImage(image: MarsImage) {

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/ImageViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/ImageViewModel.kt
@@ -6,6 +6,7 @@ import com.sirelon.marsroverphotos.data.database.entities.MarsImage
 import com.sirelon.marsroverphotos.domain.repositories.ImagesRepository
 import com.sirelon.marsroverphotos.platform.ImageOperationResult
 import com.sirelon.marsroverphotos.platform.ImageOperations
+import com.sirelon.marsroverphotos.presentation.navigation.AppDestination
 import com.sirelon.marsroverphotos.utils.Logger
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -37,6 +38,7 @@ class ImageViewModel(
 ) : ViewModel() {
 
     private val idsEmitter = MutableStateFlow<List<String>>(emptyList())
+    private val sourceEmitter = MutableStateFlow(AppDestination.ImagesSource.DIRECT_IDS)
     private val uiEventEmitter = Channel<UiEvent>(capacity = Channel.BUFFERED)
     private val hideUiEmitter = MutableStateFlow(false)
 
@@ -50,16 +52,25 @@ class ImageViewModel(
      */
     var shouldTrack = true
 
-    private val imagesFlow: Flow<ImmutableList<MarsImage>> = idsEmitter
-        .flatMapLatest { ids ->
-            if (ids.isEmpty()) {
-                flowOf(emptyList())
-            } else {
-                imagesRepository.loadImages(ids)
+    private val imagesFlow: Flow<ImmutableList<MarsImage>> = combine(idsEmitter, sourceEmitter) { ids, source ->
+        ids to source
+    }
+        .flatMapLatest { (ids, source) ->
+            when (source) {
+                AppDestination.ImagesSource.DIRECT_IDS -> {
+                    if (ids.isEmpty()) {
+                        flowOf(emptyList())
+                    } else {
+                        imagesRepository.loadImages(ids)
+                    }
+                }
+
+                AppDestination.ImagesSource.FAVORITES -> imagesRepository.loadFavoriteImages()
+                AppDestination.ImagesSource.POPULAR -> imagesRepository.loadPopularImages()
             }
         }
         .flatMapLatest { images ->
-            if (images.isEmpty() && idsEmitter.value.isNotEmpty()) {
+            if (images.isEmpty() && idsEmitter.value.isNotEmpty() && sourceEmitter.value == AppDestination.ImagesSource.DIRECT_IDS) {
                 // Retry once if database is empty but we have IDs
                 Logger.e("ImageViewModel", null) { "Images flow returned empty, retrying" }
                 delay(500)
@@ -84,7 +95,8 @@ class ImageViewModel(
      * Set the list of image IDs to display.
      * @param ids List of image IDs
      */
-    fun setIdsToShow(ids: List<String>) {
+    fun setImageSource(source: AppDestination.ImagesSource, ids: List<String>) {
+        sourceEmitter.value = source
         idsEmitter.value = ids
     }
 

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/PopularPhotosViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/PopularPhotosViewModel.kt
@@ -2,73 +2,47 @@ package com.sirelon.marsroverphotos.presentation.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
 import com.sirelon.marsroverphotos.data.database.entities.MarsImage
-import com.sirelon.marsroverphotos.domain.models.toFirebasePhoto
 import com.sirelon.marsroverphotos.domain.repositories.ImagesRepository
-import com.sirelon.marsroverphotos.platform.IFirebasePhotos
 import com.sirelon.marsroverphotos.utils.Logger
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 
 /**
  * ViewModel for the popular photos screen.
- * Loads popular photos from Firebase and allows toggling favorites.
+ * Loads popular photos via Room + [PopularRemoteMediator] (Firebase remote source).
+ * Room invalidates the PagingSource automatically when the mediator refreshes data.
  *
  * Created on 31.08.2020 21:59 for Mars-Rover-Photos.
  */
 class PopularPhotosViewModel(
     private val imagesRepository: ImagesRepository,
-    private val firebasePhotos: IFirebasePhotos,
 ) : ViewModel() {
 
-    private val _popularPhotos = MutableStateFlow<List<MarsImage>>(emptyList())
-    val popularPhotos: StateFlow<List<MarsImage>> = _popularPhotos.asStateFlow()
-
-    private val _isLoading = MutableStateFlow(false)
-    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
-
-    init {
-        loadPopularPhotos()
-    }
-
-    fun loadPopularPhotos() {
-        viewModelScope.launch {
-            _isLoading.value = true
-            try {
-                val photos = firebasePhotos.loadPopularPhotos(count = 50)
-                val mappedPhotos = photos.mapIndexed { index, fp -> fp.toMarsImage(index) }
-                imagesRepository.saveImages(mappedPhotos)
-                _popularPhotos.value = mappedPhotos
-            } catch (e: Exception) {
-                Logger.e("PopularPhotosViewModel", e) { "Error loading popular photos" }
-                _popularPhotos.value = emptyList()
-            } finally {
-                _isLoading.value = false
-            }
-        }
-    }
+    /**
+     * Paged flow of popular images, cached in [viewModelScope].
+     * The [PopularRemoteMediator] fetches from Firebase and writes to Room on first load
+     * and on subsequent page requests.
+     */
+    val popularPagedFlow: Flow<PagingData<MarsImage>> = imagesRepository
+        .loadPopularPagedSource()
+        .cachedIn(viewModelScope)
 
     /**
      * Toggle favorite status for an image.
+     * Room invalidates the PagingSource automatically after the DB write.
      * @param image The image to update
      */
     fun updateFavorite(image: MarsImage) {
         viewModelScope.launch {
-            val updatedFavorite = !image.favorite
-            _popularPhotos.value = _popularPhotos.value.map { current ->
-                if (current.id == image.id) current.copy(favorite = updatedFavorite) else current
-            }
             try {
                 imagesRepository.updateFavForImage(image)
                 Logger.d("PopularPhotosViewModel") {
-                    "Updated favorite for image ${image.id}: $updatedFavorite"
+                    "Updated favorite for image ${image.id}: ${!image.favorite}"
                 }
             } catch (e: Exception) {
-                _popularPhotos.value = _popularPhotos.value.map { current ->
-                    if (current.id == image.id) current.copy(favorite = image.favorite) else current
-                }
                 Logger.e("PopularPhotosViewModel", e) {
                     "Error updating favorite for image ${image.id}"
                 }


### PR DESCRIPTION
## Summary
This PR completes the Favorites/Popular paging migration on KMP by enabling Room paging in `commonMain`, restoring paged DAO/repository APIs, and wiring `FavoriteImagesViewModel`/`PopularPhotosViewModel` + screens to `LazyPagingItems` with proper loading and error states. It also updates Room database configuration with `@DaoReturnTypeConverters(PagingSourceDaoReturnTypeConverter::class)` so PagingSource return types work across Android/iOS/Desktop targets. The image viewer navigation path was fixed to avoid truncated swipe sets from paged lists by introducing `AppDestination.ImagesSource` and loading full Favorites/Popular streams in `ImageViewModel`, while keeping direct-ID behavior for Photos flow. `KMP_MIGRATION_PLAN.md` was updated with additive notes reflecting the room-paging enablement and the follow-up navigation fix.

## Validation
- `./gradlew :androidApp:assembleDebug :shared:linkDebugFrameworkIosSimulatorArm64 :shared:testDebugUnitTest detekt`
