### PR TITLE
Compose patterns pass for shared KMP screens

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -23,7 +23,7 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     namespace = "com.sirelon.marsroverphotos"
-    compileSdk = 36
+    compileSdk = 37
 
     signingConfigs {
         create("release") {

--- a/app/src/main/java/com/sirelon/marsroverphotos/feature/rovers/RoversActivity.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/feature/rovers/RoversActivity.kt
@@ -274,7 +274,7 @@ class RoversActivity : FragmentActivity() {
                 )
 
                 val layoutType =
-                    if (hideUI && navAlpha <= 0.01f) NavigationSuiteType.None else navSuiteType
+                    if (hideUI && !navTransition.isRunning) NavigationSuiteType.None else navSuiteType
 
                 Box(modifier = Modifier.fillMaxSize()) {
                     NavigationSuiteScaffold(

--- a/app/src/main/java/com/sirelon/marsroverphotos/feature/settings/AboutAppScreen.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/feature/settings/AboutAppScreen.kt
@@ -131,15 +131,14 @@ private fun ThemeChanger() {
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
-                RadioButtonText(text = "White", selected = currentTheme == Theme.WHITE) {
-                    changeColor(Theme.WHITE)
+                RadioButtonText(selected = currentTheme == Theme.WHITE, onClick = { changeColor(Theme.WHITE) }) {
+                    Text(text = "White")
                 }
-                RadioButtonText(text = "Dark", selected = currentTheme == Theme.DARK) {
-                    changeColor(Theme.DARK)
+                RadioButtonText(selected = currentTheme == Theme.DARK, onClick = { changeColor(Theme.DARK) }) {
+                    Text(text = "Dark")
                 }
-
-                RadioButtonText(text = "System", selected = currentTheme == Theme.SYSTEM) {
-                    changeColor(Theme.SYSTEM)
+                RadioButtonText(selected = currentTheme == Theme.SYSTEM, onClick = { changeColor(Theme.SYSTEM) }) {
+                    Text(text = "System")
                 }
             }
         }
@@ -176,11 +175,11 @@ private fun FactsToggle() {
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceEvenly
             ) {
-                RadioButtonText(text = "Show Facts", selected = showFacts) {
-                    toggleFacts(true)
+                RadioButtonText(selected = showFacts, onClick = { toggleFacts(true) }) {
+                    Text(text = "Show Facts")
                 }
-                RadioButtonText(text = "Hide Facts", selected = !showFacts) {
-                    toggleFacts(false)
+                RadioButtonText(selected = !showFacts, onClick = { toggleFacts(false) }) {
+                    Text(text = "Hide Facts")
                 }
             }
         }

--- a/app/src/main/java/com/sirelon/marsroverphotos/ui/widgets.kt
+++ b/app/src/main/java/com/sirelon/marsroverphotos/ui/widgets.kt
@@ -53,10 +53,10 @@ fun MarsSnackbar(
 
 @Composable
 fun RadioButtonText(
-    text: String,
     selected: Boolean,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    onClick: () -> Unit
+    labelContent: @Composable () -> Unit,
 ) {
     Column(
         modifier = modifier
@@ -69,7 +69,7 @@ fun RadioButtonText(
             selected = selected,
             onClick = null
         )
-        Text(text = text)
+        labelContent()
     }
 }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -179,7 +179,7 @@ compose.resources {
 
 android {
     namespace = "com.sirelon.marsroverphotos.shared"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 23

--- a/shared/src/androidMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/Theme.android.kt
+++ b/shared/src/androidMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/Theme.android.kt
@@ -6,12 +6,14 @@ import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.platform.LocalContext
 
 /**
  * Android implementation: Use system dark theme preference.
  */
 @Composable
+@ReadOnlyComposable
 actual fun isSystemInDarkTheme(): Boolean {
     return androidIsSystemInDarkTheme()
 }
@@ -20,6 +22,7 @@ actual fun isSystemInDarkTheme(): Boolean {
  * Android implementation: Dynamic colors supported on Android 12+ (API 31+).
  */
 @Composable
+@ReadOnlyComposable
 actual fun supportsDynamicColor(): Boolean {
     return Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
 }
@@ -28,6 +31,7 @@ actual fun supportsDynamicColor(): Boolean {
  * Android implementation: Get dynamic dark color scheme from system.
  */
 @Composable
+@ReadOnlyComposable
 actual fun getDynamicDarkColorScheme(): ColorScheme {
     val context = LocalContext.current
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -41,6 +45,7 @@ actual fun getDynamicDarkColorScheme(): ColorScheme {
  * Android implementation: Get dynamic light color scheme from system.
  */
 @Composable
+@ReadOnlyComposable
 actual fun getDynamicLightColorScheme(): ColorScheme {
     val context = LocalContext.current
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/App.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/App.kt
@@ -5,8 +5,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Modifier
 import com.sirelon.marsroverphotos.domain.settings.AppSettings
 import com.sirelon.marsroverphotos.domain.settings.Theme
@@ -32,7 +32,7 @@ fun App(
     rateAppUrl: String = ""
 ) {
     val appSettings: AppSettings = koinInject()
-    val theme by appSettings.themeFlow.collectAsState()
+    val theme by appSettings.themeFlow.collectAsStateWithLifecycle()
     val systemDarkTheme = isSystemInDarkTheme()
     val dynamicColor = supportsDynamicColor()
 

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/AboutScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/AboutScreen.kt
@@ -120,8 +120,10 @@ private fun AboutContent(
                 }
             }
 
-            ThemeChanger(viewModel)
-            FactsToggle(viewModel)
+            val currentTheme by viewModel.themeFlow.collectAsState()
+            val showFacts by viewModel.showFactsFlow.collectAsState()
+            ThemeChanger(currentTheme = currentTheme, onThemeChange = viewModel::setTheme)
+            FactsToggle(showFacts = showFacts, onFactsToggle = viewModel::toggleFacts)
 
             OutlinedButton(onClick = {
                 onClearCache()
@@ -165,8 +167,7 @@ private fun AboutContent(
 }
 
 @Composable
-private fun ThemeChanger(viewModel: AboutViewModel) {
-    val currentTheme by viewModel.themeFlow.collectAsState()
+private fun ThemeChanger(currentTheme: Theme, onThemeChange: (Theme) -> Unit) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -187,13 +188,13 @@ private fun ThemeChanger(viewModel: AboutViewModel) {
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 RadioButtonText(text = "White", selected = currentTheme == Theme.WHITE) {
-                    viewModel.setTheme(Theme.WHITE)
+                    onThemeChange(Theme.WHITE)
                 }
                 RadioButtonText(text = "Dark", selected = currentTheme == Theme.DARK) {
-                    viewModel.setTheme(Theme.DARK)
+                    onThemeChange(Theme.DARK)
                 }
                 RadioButtonText(text = "System", selected = currentTheme == Theme.SYSTEM) {
-                    viewModel.setTheme(Theme.SYSTEM)
+                    onThemeChange(Theme.SYSTEM)
                 }
             }
         }
@@ -201,8 +202,7 @@ private fun ThemeChanger(viewModel: AboutViewModel) {
 }
 
 @Composable
-private fun FactsToggle(viewModel: AboutViewModel) {
-    val showFacts by viewModel.showFactsFlow.collectAsState()
+private fun FactsToggle(showFacts: Boolean, onFactsToggle: (Boolean) -> Unit) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -227,7 +227,7 @@ private fun FactsToggle(viewModel: AboutViewModel) {
             }
             Switch(
                 checked = showFacts,
-                onCheckedChange = { viewModel.toggleFacts(it) }
+                onCheckedChange = onFactsToggle
             )
         }
     }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/AboutScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/AboutScreen.kt
@@ -21,10 +21,10 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
@@ -120,8 +120,8 @@ private fun AboutContent(
                 }
             }
 
-            val currentTheme by viewModel.themeFlow.collectAsState()
-            val showFacts by viewModel.showFactsFlow.collectAsState()
+            val currentTheme by viewModel.themeFlow.collectAsStateWithLifecycle()
+            val showFacts by viewModel.showFactsFlow.collectAsStateWithLifecycle()
             ThemeChanger(currentTheme = currentTheme, onThemeChange = viewModel::setTheme)
             FactsToggle(showFacts = showFacts, onFactsToggle = viewModel::toggleFacts)
 

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/AboutScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/AboutScreen.kt
@@ -187,14 +187,14 @@ private fun ThemeChanger(currentTheme: Theme, onThemeChange: (Theme) -> Unit) {
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
-                RadioButtonText(text = "White", selected = currentTheme == Theme.WHITE) {
-                    onThemeChange(Theme.WHITE)
+                RadioButtonText(selected = currentTheme == Theme.WHITE, onClick = { onThemeChange(Theme.WHITE) }) {
+                    Text("White")
                 }
-                RadioButtonText(text = "Dark", selected = currentTheme == Theme.DARK) {
-                    onThemeChange(Theme.DARK)
+                RadioButtonText(selected = currentTheme == Theme.DARK, onClick = { onThemeChange(Theme.DARK) }) {
+                    Text("Dark")
                 }
-                RadioButtonText(text = "System", selected = currentTheme == Theme.SYSTEM) {
-                    onThemeChange(Theme.SYSTEM)
+                RadioButtonText(selected = currentTheme == Theme.SYSTEM, onClick = { onThemeChange(Theme.SYSTEM) }) {
+                    Text("System")
                 }
             }
         }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/FavoriteScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/FavoriteScreen.kt
@@ -28,8 +28,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -69,7 +69,7 @@ fun FavoriteScreen(
     viewModel: FavoriteImagesViewModel = koinViewModel()
 ) {
     val lazyPagingItems = viewModel.favoritePagedFlow.collectAsLazyPagingItems()
-    val gridView by viewModel.gridViewState.collectAsState()
+    val gridView by viewModel.gridViewState.collectAsStateWithLifecycle()
 
     FavoritePhotosContent(
         modifier = modifier,

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/FavoriteScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/FavoriteScreen.kt
@@ -97,7 +97,7 @@ fun FavoriteScreen(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun FavoritePhotosContent(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     title: String,
     lazyPagingItems: LazyPagingItems<MarsImage>,
     gridView: Boolean,
@@ -108,7 +108,7 @@ private fun FavoritePhotosContent(
 ) {
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             TopAppBar(
                 title = { Text(text = title) },
@@ -149,7 +149,7 @@ private fun FavoritePhotosContent(
 
             else -> {
                 LazyVerticalStaggeredGrid(
-                    modifier = modifier.fillMaxSize(),
+                    modifier = Modifier.fillMaxSize(),
                     contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
                     columns = if (gridView) {
                         StaggeredGridCells.Adaptive(minSize = 180.dp)

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
@@ -80,6 +80,7 @@ import com.sirelon.marsroverphotos.presentation.viewmodels.UiEvent
 import com.sirelon.marsroverphotos.shared.resources.Res
 import com.sirelon.marsroverphotos.shared.resources.images_empty_btn
 import com.sirelon.marsroverphotos.shared.resources.images_empty_title
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
@@ -205,7 +206,7 @@ private fun ImagesEmptyState(onBack: () -> Unit) {
 @Composable
 private fun ImagesPagerContent(
     viewModel: ImageViewModel,
-    list: List<MarsImage>,
+    list: ImmutableList<MarsImage>,
     pagerState: PagerState,
     hideUi: Boolean,
     onBack: () -> Unit,
@@ -439,7 +440,7 @@ private fun InfoIcon(onClick: () -> Unit) {
 @Composable
 private fun ImagesPager(
     pagerState: PagerState,
-    images: List<MarsImage>,
+    images: ImmutableList<MarsImage>,
     hideUi: Boolean,
     onTap: () -> Unit,
     onFavoriteClick: (MarsImage) -> Unit,

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
@@ -82,9 +82,11 @@ import com.sirelon.marsroverphotos.shared.resources.Res
 import com.sirelon.marsroverphotos.shared.resources.images_empty_btn
 import com.sirelon.marsroverphotos.shared.resources.images_empty_title
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
 
 /**
@@ -126,6 +128,8 @@ fun ImagesScreen(
 
     val screenState by viewModel.screenState.collectAsStateWithLifecycle()
     val images = screenState.images
+
+    val uiEvent by viewModel.uiEvent.collectAsStateWithLifecycle(initialValue = null)
 
     val pagerState = rememberPagerState(
         initialPage = 0,
@@ -174,11 +178,16 @@ fun ImagesScreen(
             }
         } else {
             ImagesPagerContent(
-                viewModel = viewModel,
+                uiEvent = uiEvent,
                 list = images,
                 pagerState = pagerState,
                 hideUi = screenState.hideUi,
                 onBack = onBack,
+                onShown = viewModel::onShown,
+                onTap = viewModel::onTap,
+                onFavoriteClick = viewModel::updateFavorite,
+                onSaveClick = viewModel::saveImage,
+                onShareClick = viewModel::shareMarsImage,
             )
         }
     }
@@ -206,11 +215,16 @@ private fun ImagesEmptyState(onBack: () -> Unit) {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ImagesPagerContent(
-    viewModel: ImageViewModel,
+    uiEvent: UiEvent?,
     list: ImmutableList<MarsImage>,
     pagerState: PagerState,
     hideUi: Boolean,
     onBack: () -> Unit,
+    onShown: (MarsImage, Int) -> Unit,
+    onTap: () -> Unit,
+    onFavoriteClick: (MarsImage) -> Unit,
+    onSaveClick: (MarsImage) -> Unit,
+    onShareClick: (MarsImage) -> Unit,
 ) {
     var titleState by remember { mutableStateOf("Mars Rover Photos") }
     var showInfoSheet by remember { mutableStateOf(false) }
@@ -230,7 +244,7 @@ private fun ImagesPagerContent(
             val currentList = latestList
             if (currentList.isNotEmpty() && page < currentList.size) {
                 val marsPhoto = currentList[page]
-                viewModel.onShown(marsPhoto, page)
+                onShown(marsPhoto, page)
                 titleState = buildString {
                     append("Sol ")
                     append(marsPhoto.sol)
@@ -264,14 +278,13 @@ private fun ImagesPagerContent(
             pagerState = pagerState,
             images = list,
             hideUi = hideUi,
-            onTap = { viewModel.onTap() },
-            onFavoriteClick = { marsImage -> viewModel.updateFavorite(marsImage) },
+            onTap = onTap,
+            onFavoriteClick = onFavoriteClick,
             onBack = onBack,
             dismissOffsetY = dismissOffsetY,
             dismissThresholdPx = dismissThresholdPx,
         )
 
-        val uiEvent by viewModel.uiEvent.collectAsStateWithLifecycle(initialValue = null)
         OnEvent(uiEvent = uiEvent)
 
         // Translucent TopAppBar overlay + (debug-only) action row.
@@ -305,10 +318,10 @@ private fun ImagesPagerContent(
                     actions = {
                         if (currentImage != null) {
                             SaveIcon(onClick = {
-                                viewModel.saveImage(currentImage)
+                                onSaveClick(currentImage)
                             })
                             ShareIcon(onClick = {
-                                viewModel.shareMarsImage(currentImage)
+                                onShareClick(currentImage)
                             })
                             InfoIcon(onClick = {
                                 showInfoSheet = true
@@ -594,5 +607,46 @@ private fun ImagesPager(
                 }
             }
         }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview
+@Composable
+private fun ImagesPagerContentPreview() {
+    val sampleImage = MarsImage(
+        id = "preview_1",
+        order = 0,
+        sol = 3200L,
+        name = "Curiosity: FHAZ",
+        imageUrl = "https://mars.nasa.gov/msl-raw-images/sample.jpg",
+        earthDate = "2015-08-05",
+        camera = com.sirelon.marsroverphotos.domain.models.RoverCamera(
+            id = 1,
+            name = "FHAZ",
+            fullName = "Front Hazard Avoidance Camera"
+        ),
+        favorite = false,
+        popular = false,
+        stats = MarsImage.Stats(see = 42, scale = 0, save = 2, share = 1, favorite = 5),
+    )
+    val sampleImages = persistentListOf(
+        sampleImage,
+        sampleImage.copy(id = "preview_2", sol = 3201L, name = "Curiosity: MAST"),
+    )
+    val pagerState = rememberPagerState(pageCount = { sampleImages.size })
+    MaterialTheme {
+        ImagesPagerContent(
+            uiEvent = null,
+            list = sampleImages,
+            pagerState = pagerState,
+            hideUi = false,
+            onBack = {},
+            onShown = { _, _ -> },
+            onTap = {},
+            onFavoriteClick = {},
+            onSaveClick = {},
+            onShareClick = {},
+        )
     }
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -220,10 +221,15 @@ private fun ImagesPagerContent(
     val density = LocalDensity.current
     val dismissThresholdPx = with(density) { 150.dp.toPx() }
 
+    // rememberUpdatedState so the running snapshotFlow collector always sees the latest
+    // list without restarting the collection (which would cause a page-tracking glitch).
+    val latestList by rememberUpdatedState(list)
+
     LaunchedEffect(pagerState) {
         snapshotFlow { pagerState.currentPage }.collect { page ->
-            if (list.isNotEmpty() && page < list.size) {
-                val marsPhoto = list[page]
+            val currentList = latestList
+            if (currentList.isNotEmpty() && page < currentList.size) {
+                val marsPhoto = currentList[page]
                 viewModel.onShown(marsPhoto, page)
                 titleState = buildString {
                     append("Sol ")

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
@@ -328,37 +328,25 @@ private fun BoxScope.OnEvent(uiEvent: UiEvent?) {
     val haptic = LocalHapticFeedback.current
     val uriHandler = LocalUriHandler.current
     var showCheckmark by remember { mutableStateOf(false) }
+    // Captures the saved-image path so the "Open" action in the snackbar can open it.
+    // Held outside the `when` branch so MarsSnackbar (always rendered) can reference it.
+    var openImagePath by remember { mutableStateOf<String?>(null) }
 
     when (uiEvent) {
         is UiEvent.PhotoSaved -> {
             val imagePath = uiEvent.imagePath
-
             LaunchedEffect(uiEvent) {
                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                 showCheckmark = true
-                delay(1500)
-                showCheckmark = false
-            }
-
-            SaveSuccessOverlay(visible = showCheckmark)
-
-            MarsSnackbar(
-                snackbarHostState = snackbarHostState,
-                modifier = Modifier.align(Alignment.BottomCenter).navigationBarsPadding(),
-                actionClick = {
-                    if (!imagePath.isNullOrBlank()) {
-                        try {
-                            uriHandler.openUri(imagePath)
-                        } catch (_: Exception) {
-                            // URI may not be openable on all platforms — silently ignore
-                        }
-                    }
+                openImagePath = imagePath
+                // Show checkmark for 1.5 s concurrently with the snackbar.
+                launch {
+                    delay(1500)
+                    showCheckmark = false
                 }
-            )
-            LaunchedEffect(uiEvent) {
                 snackbarHostState.showSnackbar(
                     message = "Image saved successfully",
-                    actionLabel = if (imagePath != null) "Open" else null
+                    actionLabel = if (!imagePath.isNullOrBlank()) "Open" else null
                 )
             }
         }
@@ -370,11 +358,6 @@ private fun BoxScope.OnEvent(uiEvent: UiEvent?) {
                     message = "Failed to save image: ${uiEvent.errorMessage}"
                 )
             }
-            MarsSnackbar(
-                snackbarHostState = snackbarHostState,
-                modifier = Modifier.align(Alignment.BottomCenter).navigationBarsPadding(),
-                actionClick = null
-            )
         }
 
         is UiEvent.ShareError -> {
@@ -383,15 +366,30 @@ private fun BoxScope.OnEvent(uiEvent: UiEvent?) {
                     message = "Failed to share image: ${uiEvent.errorMessage}"
                 )
             }
-            MarsSnackbar(
-                snackbarHostState = snackbarHostState,
-                modifier = Modifier.align(Alignment.BottomCenter).navigationBarsPadding(),
-                actionClick = null
-            )
         }
 
         null -> { /* idle */ }
     }
+
+    // SaveSuccessOverlay lives outside the when so AnimatedVisibility can play its exit
+    // animation even after the event is consumed (uiEvent → null).
+    SaveSuccessOverlay(visible = showCheckmark)
+
+    // MarsSnackbar is always rendered so the SnackbarHost is never removed mid-display.
+    MarsSnackbar(
+        snackbarHostState = snackbarHostState,
+        modifier = Modifier.align(Alignment.BottomCenter).navigationBarsPadding(),
+        actionClick = {
+            val path = openImagePath
+            if (!path.isNullOrBlank()) {
+                try {
+                    uriHandler.openUri(path)
+                } catch (_: Exception) {
+                    // URI may not be openable on all platforms — silently ignore
+                }
+            }
+        }
+    )
 }
 
 @Composable

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
@@ -44,7 +44,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -66,6 +65,7 @@ import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbolIcon
 import com.sirelon.marsroverphotos.presentation.ui.NetworkImage
 import com.sirelon.marsroverphotos.presentation.ui.PlatformDatePickerDialog
 import com.sirelon.marsroverphotos.presentation.ui.adaptiveGridCells
+import com.sirelon.marsroverphotos.presentation.viewmodels.PhotosUiState
 import com.sirelon.marsroverphotos.presentation.viewmodels.PhotosViewModel
 import com.sirelon.marsroverphotos.shared.resources.Res
 import com.sirelon.marsroverphotos.shared.resources.alien_icon
@@ -86,10 +86,16 @@ import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
 import kotlin.time.Instant
 
-@OptIn(ExperimentalMaterial3Api::class)
+// ── State-holder composable ───────────────────────────────────────────────────
+
+/**
+ * State-holder entry point: collects [PhotosViewModel.uiState] and delegates
+ * all layout to the private [PhotosScreen] UI overload.
+ */
 @Composable
 fun PhotosScreen(
     roverId: Long,
@@ -100,36 +106,61 @@ fun PhotosScreen(
     onClearCameraFilter: () -> Unit = {},
     viewModel: PhotosViewModel = koinViewModel()
 ) {
-    var maxSol by remember { mutableLongStateOf(1L) }
-
     LaunchedEffect(roverId) {
         viewModel.setRoverId(roverId)
-        maxSol = viewModel.maxSol().coerceAtLeast(1L)
     }
 
     LaunchedEffect(cameraFilter) {
         viewModel.setCameraFilter(cameraFilter)
     }
 
-    val gridItems by viewModel.gridItemsFlow.collectAsStateWithLifecycle(initialValue = null)
-    val photos = remember(gridItems) {
-        gridItems?.mapNotNull { item ->
-            (item as? GridItem.PhotoItem)?.image
-        }.orEmpty()
-    }
-    val sol by viewModel.solFlow.collectAsStateWithLifecycle(initialValue = 0L)
-    val roverName by viewModel.roverNameFlow.collectAsStateWithLifecycle(initialValue = "")
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
 
+    PhotosScreen(
+        state = state,
+        onLoadBySol = viewModel::loadBySol,
+        onSetEarthTime = viewModel::setEarthTime,
+        onRandomize = viewModel::randomize,
+        onGoToLatest = viewModel::goToLatest,
+        onPhotoClick = viewModel::onPhotoClick,
+        onSetCameraFilter = viewModel::setCameraFilter,
+        onClearCameraFilter = onClearCameraFilter,
+        onNavigateToImages = onNavigateToImages,
+        onBack = onBack,
+        modifier = modifier,
+    )
+}
+
+// ── UI composable ─────────────────────────────────────────────────────────────
+
+/**
+ * Pure UI overload: knows nothing about [PhotosViewModel]. Safe to preview and unit-test.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PhotosScreen(
+    state: PhotosUiState,
+    onLoadBySol: (Long) -> Unit,
+    onSetEarthTime: (Long) -> Unit,
+    onRandomize: () -> Unit,
+    onGoToLatest: () -> Unit,
+    onPhotoClick: () -> Unit,
+    onSetCameraFilter: (String?) -> Unit,
+    onClearCameraFilter: () -> Unit,
+    onNavigateToImages: (String) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     var openSolDialog by rememberSaveable { mutableStateOf(false) }
     var openEarthDateDialog by rememberSaveable { mutableStateOf(false) }
 
     SolDialog(
-        maxSol = maxSol,
+        maxSol = state.maxSol,
         openDialog = openSolDialog,
-        sol = sol,
+        sol = state.sol,
         onClose = { openSolDialog = false },
         onChoose = {
-            viewModel.loadBySol(it)
+            onLoadBySol(it)
             openSolDialog = false
         }
     )
@@ -143,7 +174,7 @@ fun PhotosScreen(
                 scrollBehavior = scrollBehavior,
                 title = {
                     Column {
-                        Text(text = roverName)
+                        Text(text = state.roverName)
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -153,13 +184,13 @@ fun PhotosScreen(
                             DateSelectorButton(
                                 modifier = Modifier.weight(1f),
                                 label = "Sol date",
-                                value = sol.toString(),
+                                value = state.sol.toString(),
                                 onClick = { openSolDialog = true }
                             )
                             DateSelectorButton(
                                 modifier = Modifier.weight(1f),
                                 label = "Earth date",
-                                value = viewModel.earthDateStr(sol),
+                                value = state.earthDate,
                                 onClick = { openEarthDateDialog = true }
                             )
                         }
@@ -177,8 +208,8 @@ fun PhotosScreen(
         },
         floatingActionButton = {
             RefreshButton(
-                visible = photos.isNotEmpty(),
-                onClick = { viewModel.goToLatest() }
+                visible = state.hasPhotos,
+                onClick = { onGoToLatest() }
             )
         }
     ) { innerPadding ->
@@ -187,11 +218,11 @@ fun PhotosScreen(
                 .fillMaxSize()
                 .padding(innerPadding)
         ) {
-            if (!cameraFilter.isNullOrBlank()) {
+            if (!state.cameraFilter.isNullOrBlank()) {
                 CameraFilterChip(
-                    camera = cameraFilter,
+                    camera = state.cameraFilter,
                     onClear = {
-                        viewModel.setCameraFilter(null)
+                        onSetCameraFilter(null)
                         onClearCameraFilter()
                     }
                 )
@@ -199,11 +230,11 @@ fun PhotosScreen(
 
             if (openEarthDateDialog) {
                 PlatformDatePickerDialog(
-                    selectedDate = millisToUtcLocalDate(viewModel.dateFromSol()),
-                    minDate = millisToUtcLocalDate(viewModel.minDate()),
-                    maxDate = millisToUtcLocalDate(viewModel.maxDate()),
+                    selectedDate = millisToUtcLocalDate(state.datePickerSelectedMillis),
+                    minDate = millisToUtcLocalDate(state.datePickerMinMillis),
+                    maxDate = millisToUtcLocalDate(state.datePickerMaxMillis),
                     onDateSelected = { selectedDate ->
-                        viewModel.setEarthTime(selectedDate.toUtcMillis())
+                        onSetEarthTime(selectedDate.toUtcMillis())
                         openEarthDateDialog = false
                     },
                     onDismissRequest = { openEarthDateDialog = false },
@@ -213,21 +244,21 @@ fun PhotosScreen(
                 )
             }
 
-            Crossfade(targetState = gridItems, label = "[Anim]:PhotosProgress") { items ->
+            Crossfade(targetState = state.gridItems, label = "[Anim]:PhotosProgress") { items ->
                 when {
                     items == null -> CenteredProgress()
                     items.isEmpty() -> {
-                        if (!cameraFilter.isNullOrBlank()) {
+                        if (!state.cameraFilter.isNullOrBlank()) {
                             EmptyPhotos(
-                                title = "No $cameraFilter photos on Sol $sol. Try another Sol.",
+                                title = "No ${state.cameraFilter} photos on Sol ${state.sol}. Try another Sol.",
                                 btnTitle = stringResource(Res.string.tap_to_retry),
-                                callback = { viewModel.randomize() }
+                                callback = { onRandomize() }
                             )
                         } else {
                             EmptyPhotos(
                                 title = stringResource(Res.string.no_photos_title),
                                 btnTitle = stringResource(Res.string.tap_to_retry),
-                                callback = { viewModel.randomize() }
+                                callback = { onRandomize() }
                             )
                         }
                     }
@@ -236,10 +267,10 @@ fun PhotosScreen(
                         PhotosList(
                             gridItems = items,
                             onPhotoClick = { image ->
-                                viewModel.onPhotoClick()
+                                onPhotoClick()
                                 onNavigateToImages(image.id)
                             },
-                            onCameraClick = { cameraName -> viewModel.setCameraFilter(cameraName) }
+                            onCameraClick = { cameraName -> onSetCameraFilter(cameraName) }
                         )
                     }
                 }
@@ -581,6 +612,83 @@ private fun CameraFilterChip(camera: String, onClear: () -> Unit) {
                 containerColor = MaterialTheme.colorScheme.secondaryContainer,
                 labelColor = MaterialTheme.colorScheme.onSecondaryContainer
             )
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview
+@Composable
+private fun PhotosScreenPreview() {
+    MaterialTheme {
+        PhotosScreen(
+            state = PhotosUiState(
+                roverName = "Curiosity",
+                sol = 3200L,
+                earthDate = "Aug 5, 2015",
+                gridItems = emptyList(),
+                maxSol = 4000L,
+                cameraFilter = null,
+                hasPhotos = false,
+            ),
+            onLoadBySol = {},
+            onSetEarthTime = {},
+            onRandomize = {},
+            onGoToLatest = {},
+            onPhotoClick = {},
+            onSetCameraFilter = {},
+            onClearCameraFilter = {},
+            onNavigateToImages = {},
+            onBack = {},
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview
+@Composable
+private fun PhotosScreenWithPhotosPreview() {
+    val sampleImage = MarsImage(
+        id = "123",
+        order = 0,
+        sol = 3200L,
+        name = "Curiosity: FHAZ",
+        imageUrl = "https://example.com/img.jpg",
+        earthDate = "2015-08-05",
+        camera = com.sirelon.marsroverphotos.domain.models.RoverCamera(
+            id = 1,
+            name = "FHAZ",
+            fullName = "Front Hazard Avoidance Camera"
+        ),
+        favorite = false,
+        popular = false,
+        stats = MarsImage.Stats(see = 42, scale = 0, save = 2, share = 1, favorite = 5),
+    )
+    MaterialTheme {
+        PhotosScreen(
+            state = PhotosUiState(
+                roverName = "Curiosity",
+                sol = 3200L,
+                earthDate = "Aug 5, 2015",
+                gridItems = listOf(
+                    com.sirelon.marsroverphotos.presentation.models.GridItem.PhotoItem(sampleImage),
+                    com.sirelon.marsroverphotos.presentation.models.GridItem.PhotoItem(
+                        sampleImage.copy(id = "124", name = "Curiosity: MAST")
+                    ),
+                ),
+                maxSol = 4000L,
+                cameraFilter = null,
+                hasPhotos = true,
+            ),
+            onLoadBySol = {},
+            onSetEarthTime = {},
+            onRandomize = {},
+            onGoToLatest = {},
+            onPhotoClick = {},
+            onSetCameraFilter = {},
+            onClearCameraFilter = {},
+            onNavigateToImages = {},
+            onBack = {},
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
@@ -42,8 +42,8 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -110,14 +110,14 @@ fun PhotosScreen(
         viewModel.setCameraFilter(cameraFilter)
     }
 
-    val gridItems by viewModel.gridItemsFlow.collectAsState(initial = null)
+    val gridItems by viewModel.gridItemsFlow.collectAsStateWithLifecycle(initialValue = null)
     val photos = remember(gridItems) {
         gridItems?.mapNotNull { item ->
             (item as? GridItem.PhotoItem)?.image
         }.orEmpty()
     }
-    val sol by viewModel.solFlow.collectAsState(initial = 0L)
-    val roverName by viewModel.roverNameFlow.collectAsState(initial = "")
+    val sol by viewModel.solFlow.collectAsStateWithLifecycle(initialValue = 0L)
+    val roverName by viewModel.roverNameFlow.collectAsStateWithLifecycle(initialValue = "")
 
     var openSolDialog by rememberSaveable { mutableStateOf(false) }
     var openEarthDateDialog by rememberSaveable { mutableStateOf(false) }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PopularScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PopularScreen.kt
@@ -21,9 +21,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -62,13 +59,15 @@ fun PopularScreen(
     viewModel: PopularPhotosViewModel = koinViewModel(),
 ) {
     val appSettings: AppSettings = koinInject()
+    val gridView by appSettings.gridViewFlow.collectAsState()
     val lazyPagingItems = viewModel.popularPagedFlow.collectAsLazyPagingItems()
 
     PopularPhotosContent(
         modifier = modifier,
         title = stringResource(Res.string.popular_title),
         lazyPagingItems = lazyPagingItems,
-        appSettings = appSettings,
+        gridView = gridView,
+        onGridChange = { appSettings.gridView = !gridView },
         onFavoriteClick = { viewModel.updateFavorite(it) },
         onItemClick = onNavigateToImages,
     )
@@ -77,27 +76,22 @@ fun PopularScreen(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun PopularPhotosContent(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     title: String,
     lazyPagingItems: LazyPagingItems<MarsImage>,
-    appSettings: AppSettings,
+    gridView: Boolean,
+    onGridChange: () -> Unit,
     onItemClick: (image: MarsImage) -> Unit,
     onFavoriteClick: (image: MarsImage) -> Unit,
 ) {
-    val gridViewState by appSettings.gridViewFlow.collectAsState()
-    var gridView by rememberSaveable { mutableStateOf(gridViewState) }
-
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = modifier.fillMaxSize()) {
         val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
         TopAppBar(
             title = { Text(text = title) },
             windowInsets = WindowInsets(0, 0, 0, 0),
             actions = {
                 IconButton(
-                    onClick = {
-                        gridView = !gridView
-                        appSettings.gridView = gridView
-                    },
+                    onClick = onGridChange,
                 ) {
                     if (gridView) {
                         MaterialSymbolIcon(
@@ -138,7 +132,7 @@ private fun PopularPhotosContent(
 
             else -> {
                 LazyVerticalStaggeredGrid(
-                    modifier = modifier
+                    modifier = Modifier
                         .weight(1f)
                         .nestedScroll(scrollBehavior.nestedScrollConnection),
                     contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PopularScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PopularScreen.kt
@@ -19,8 +19,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -59,7 +59,7 @@ fun PopularScreen(
     viewModel: PopularPhotosViewModel = koinViewModel(),
 ) {
     val appSettings: AppSettings = koinInject()
-    val gridView by appSettings.gridViewFlow.collectAsState()
+    val gridView by appSettings.gridViewFlow.collectAsStateWithLifecycle()
     val lazyPagingItems = viewModel.popularPagedFlow.collectAsLazyPagingItems()
 
     PopularPhotosContent(

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoverMissionInfoScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoverMissionInfoScreen.kt
@@ -58,6 +58,7 @@ import com.sirelon.marsroverphotos.presentation.viewmodels.MissionInfoState
 import com.sirelon.marsroverphotos.presentation.viewmodels.RoverMissionInfoViewModel
 import com.sirelon.marsroverphotos.presentation.viewmodels.TimelineMilestone
 import com.sirelon.marsroverphotos.utils.formatThousands
+import kotlinx.collections.immutable.ImmutableList
 import org.koin.compose.viewmodel.koinViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -240,7 +241,7 @@ private fun SectionHeader(title: String) {
 }
 
 @Composable
-private fun MissionTimeline(milestones: List<TimelineMilestone>, status: String) {
+private fun MissionTimeline(milestones: ImmutableList<TimelineMilestone>, status: String) {
     val isActive = status.equals("active", ignoreCase = true)
     val milestoneColor = if (isActive) {
         MaterialTheme.colorScheme.tertiary
@@ -430,7 +431,7 @@ private fun StatCard(label: String, value: String, modifier: Modifier = Modifier
 
 @Composable
 private fun CamerasList(
-    cameras: List<CameraSpec>,
+    cameras: ImmutableList<CameraSpec>,
     onCameraClick: (String) -> Unit = {}
 ) {
     if (cameras.isEmpty()) {

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoverMissionInfoScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoverMissionInfoScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sirelon.marsroverphotos.domain.models.Rover
 import com.sirelon.marsroverphotos.domain.models.mission.CameraSpec
@@ -75,8 +76,11 @@ fun RoverMissionInfoScreen(
         viewModel.setRoverId(roverId)
     }
 
+    // rememberUpdatedState so the analytics call reads the latest state after the
+    // roverId key settles, even if state arrives one frame after the id changes.
+    val latestState by rememberUpdatedState(state)
     LaunchedEffect(state?.rover?.id) {
-        state?.rover?.let {
+        latestState?.rover?.let {
             viewModel.trackEvent("mission_info_opened_${it.name}")
         }
     }
@@ -251,8 +255,11 @@ private fun MissionTimeline(milestones: ImmutableList<TimelineMilestone>, status
 
     // Animate the Landing→Current segment from 0f → 1f on first composition for
     // active rovers. Completed rovers go straight to 1f (mission ended).
+    // Key on the full milestones list (ImmutableList has value equality) so the animation
+    // replays when the rover changes. Reset animationStarted first to restart from 0f.
     var animationStarted by remember { mutableStateOf(false) }
-    LaunchedEffect(milestones.firstOrNull()?.date) {
+    LaunchedEffect(milestones) {
+        animationStarted = false  // reset so the animation starts from 0f for the new rover
         animationStarted = true
     }
     val landingToCurrentProgress by animateFloatAsState(

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoverMissionInfoScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoverMissionInfoScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -41,6 +40,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
@@ -262,7 +263,7 @@ private fun MissionTimeline(milestones: ImmutableList<TimelineMilestone>, status
         animationStarted = false  // reset so the animation starts from 0f for the new rover
         animationStarted = true
     }
-    val landingToCurrentProgress by animateFloatAsState(
+    val landingToCurrentProgress = animateFloatAsState(
         targetValue = if (animationStarted) 1f else 0f,
         animationSpec = tween(durationMillis = 600),
         label = "LandingToCurrentProgress"
@@ -325,10 +326,10 @@ private fun MissionTimeline(milestones: ImmutableList<TimelineMilestone>, status
                 // journey is complete once the rover has landed.
                 // Second connector (Landing → Current/End) is animated for
                 // active rovers and fully filled for completed missions.
-                val segmentProgress = when {
-                    index == 0 -> 1f
-                    !isActive -> 1f
-                    else -> landingToCurrentProgress
+                val segmentProgress: () -> Float = when {
+                    index == 0 -> {{ 1f }}
+                    !isActive -> {{ 1f }}
+                    else -> {{ landingToCurrentProgress.value }}
                 }
                 TimelineSegment(
                     progress = segmentProgress,
@@ -343,23 +344,23 @@ private fun MissionTimeline(milestones: ImmutableList<TimelineMilestone>, status
 }
 
 @Composable
-private fun TimelineSegment(progress: Float, modifier: Modifier = Modifier) {
+private fun TimelineSegment(progress: () -> Float, modifier: Modifier = Modifier) {
     val shape = RoundedCornerShape(3.dp)
+    val fillColor = MaterialTheme.colorScheme.tertiary
+    val trackColor = MaterialTheme.colorScheme.outlineVariant
     Box(
         modifier = modifier
             .fillMaxWidth()
             .height(6.dp)
             .clip(shape)
-            .background(MaterialTheme.colorScheme.outlineVariant)
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth(progress.coerceIn(0f, 1f))
-                .fillMaxHeight()
-                .clip(shape)
-                .background(MaterialTheme.colorScheme.tertiary)
-        )
-    }
+            .drawBehind {
+                drawRect(trackColor)
+                drawRect(
+                    color = fillColor,
+                    size = Size(size.width * progress().coerceIn(0f, 1f), size.height),
+                )
+            },
+    )
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoverMissionInfoScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoverMissionInfoScreen.kt
@@ -366,13 +366,13 @@ private fun MissionTimeline(milestones: ImmutableList<TimelineMilestone>, status
                 // journey is complete once the rover has landed.
                 // Second connector (Landing → Current/End) is animated for
                 // active rovers and fully filled for completed missions.
-                val segmentProgress: () -> Float = when {
-                    index == 0 -> {{ 1f }}
-                    !isActive -> {{ 1f }}
-                    else -> {{ landingToCurrentProgress.value }}
+                val segmentProgress = when {
+                    index == 0 -> 1f
+                    !isActive -> 1f
+                    else -> landingToCurrentProgress.value
                 }
                 TimelineSegment(
-                    progress = segmentProgress,
+                    progress = { segmentProgress },
                     modifier = Modifier
                         .weight(0.5f)
                         .align(Alignment.CenterVertically)
@@ -656,4 +656,3 @@ private fun RoverMissionInfoScreenLoadedPreview() {
         onCameraClick = {},
     )
 }
-

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoverMissionInfoScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoverMissionInfoScreen.kt
@@ -67,7 +67,21 @@ import com.sirelon.marsroverphotos.presentation.viewmodels.RoverMissionInfoViewM
 import com.sirelon.marsroverphotos.presentation.viewmodels.TimelineMilestone
 import com.sirelon.marsroverphotos.utils.formatThousands
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
+
+/**
+ * Immutable UI state for [RoverMissionInfoScreen].
+ *
+ * [missionInfoState] is null while the data is loading — the screen shows a
+ * centered progress indicator in that case.
+ */
+data class RoverMissionInfoUiState(
+    val missionInfoState: MissionInfoState? = null,
+)
+
+// ── State-holder composable ───────────────────────────────────────────────────
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -92,6 +106,22 @@ fun RoverMissionInfoScreen(
         }
     }
 
+    RoverMissionInfoScreen(
+        state = RoverMissionInfoUiState(missionInfoState = state),
+        onBack = onBack,
+        onCameraClick = onCameraClick,
+    )
+}
+
+// ── Pure-UI composable ────────────────────────────────────────────────────────
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun RoverMissionInfoScreen(
+    state: RoverMissionInfoUiState,
+    onBack: () -> Unit,
+    onCameraClick: (String) -> Unit = {},
+) {
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     Scaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -99,7 +129,7 @@ fun RoverMissionInfoScreen(
         topBar = {
             TopAppBar(
                 scrollBehavior = scrollBehavior,
-                title = { Text(state?.rover?.name ?: "Mission Info") },
+                title = { Text(state.missionInfoState?.rover?.name ?: "Mission Info") },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         MaterialSymbolIcon(
@@ -112,7 +142,7 @@ fun RoverMissionInfoScreen(
         }
     ) { paddingValues ->
         Crossfade(
-            targetState = state,
+            targetState = state.missionInfoState,
             label = "MissionInfoCrossfade",
             modifier = Modifier.padding(paddingValues)
         ) { currentState ->
@@ -563,5 +593,67 @@ private fun FunFacts(facts: List<String>) {
             }
         }
     }
+}
+
+// ── Previews ──────────────────────────────────────────────────────────────────
+
+@Preview
+@Composable
+private fun RoverMissionInfoScreenLoadingPreview() {
+    RoverMissionInfoScreen(
+        state = RoverMissionInfoUiState(missionInfoState = null),
+        onBack = {},
+        onCameraClick = {},
+    )
+}
+
+@Preview
+@Composable
+private fun RoverMissionInfoScreenLoadedPreview() {
+    val previewRover = Rover(
+        id = 5,
+        name = "Curiosity",
+        drawableName = "curiosity",
+        landingDate = "2012-08-06",
+        launchDate = "2011-11-26",
+        status = "active",
+        maxSol = 4000,
+        maxDate = "2023-10-01",
+        totalPhotos = 695670
+    )
+    val previewMilestones = persistentListOf(
+        TimelineMilestone(label = "Launch", date = "2011-11-26", sol = null, type = MilestoneType.LAUNCH),
+        TimelineMilestone(label = "Landing", date = "2012-08-06", sol = null, type = MilestoneType.LANDING),
+        TimelineMilestone(label = "Today", date = "2023-10-01", sol = 4000L, type = MilestoneType.CURRENT),
+    )
+    val previewCameras = persistentListOf(
+        CameraSpec(
+            name = "MAST",
+            fullName = "Mast Camera",
+            description = "Two cameras mounted on the mast for color imaging."
+        )
+    )
+    val previewFacts = RoverMissionFacts(
+        roverId = 5,
+        roverName = "Curiosity",
+        objectives = listOf("Assess habitability", "Study Martian climate"),
+        funFacts = listOf("Curiosity is the size of a small car.")
+    )
+    RoverMissionInfoScreen(
+        state = RoverMissionInfoUiState(
+            missionInfoState = MissionInfoState(
+                rover = previewRover,
+                daysActive = 4001L,
+                earthDaysActive = 4110L,
+                cameras = previewCameras,
+                missionFacts = previewFacts,
+                factsLoading = false,
+                factsError = null,
+                timelineMilestones = previewMilestones,
+            )
+        ),
+        onBack = {},
+        onCameraClick = {},
+    )
 }
 

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoversScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoversScreen.kt
@@ -67,10 +67,12 @@ fun RoversScreen(
 fun RoversContent(
     rovers: List<Rover>,
     onClick: (rover: Rover) -> Unit,
-    onMissionInfoClick: (rover: Rover) -> Unit
+    onMissionInfoClick: (rover: Rover) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     LazyVerticalGrid(
         columns = GridCells.Adaptive(minSize = 360.dp),
+        modifier = modifier,
         contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp)

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/Theme.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/Theme.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.graphics.Color
 
 /**
@@ -86,6 +87,7 @@ fun MarsRoverPhotosTheme(
  * Platform-specific implementation.
  */
 @Composable
+@ReadOnlyComposable
 expect fun isSystemInDarkTheme(): Boolean
 
 /**
@@ -93,6 +95,7 @@ expect fun isSystemInDarkTheme(): Boolean
  * Returns true for Android 12+ (API 31+), false for other platforms.
  */
 @Composable
+@ReadOnlyComposable
 expect fun supportsDynamicColor(): Boolean
 
 /**
@@ -100,6 +103,7 @@ expect fun supportsDynamicColor(): Boolean
  * Returns static dark scheme for platforms without dynamic color support.
  */
 @Composable
+@ReadOnlyComposable
 expect fun getDynamicDarkColorScheme(): ColorScheme
 
 /**
@@ -107,4 +111,5 @@ expect fun getDynamicDarkColorScheme(): ColorScheme
  * Returns static light scheme for platforms without dynamic color support.
  */
 @Composable
+@ReadOnlyComposable
 expect fun getDynamicLightColorScheme(): ColorScheme

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/AppTopBar.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/AppTopBar.kt
@@ -1,0 +1,67 @@
+package com.sirelon.marsroverphotos.presentation.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarColors
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AppTopBar(
+    title: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    subtitle: (@Composable () -> Unit)? = null,
+    onBack: (() -> Unit)? = null,
+    navigationIcon: (@Composable () -> Unit)? = null,
+    actions: @Composable () -> Unit = {},
+    scrollBehavior: TopAppBarScrollBehavior? = null,
+    colors: TopAppBarColors = TopAppBarDefaults.topAppBarColors(),
+    windowInsets: WindowInsets = TopAppBarDefaults.windowInsets,
+) {
+    val resolvedNavigationIcon: @Composable () -> Unit = when {
+        navigationIcon != null -> navigationIcon
+        onBack != null -> {
+            {
+                IconButton(onClick = onBack) {
+                    MaterialSymbolIcon(
+                        symbol = MaterialSymbol.ArrowBack,
+                        contentDescription = "Back",
+                    )
+                }
+            }
+        }
+        else -> ({})
+    }
+
+    val bottomInsets = WindowInsets.navigationBars.only(WindowInsetsSides.Bottom)
+    val safeInsets = windowInsets.union(bottomInsets)
+
+    TopAppBar(
+        modifier = modifier.windowInsetsPadding(safeInsets),
+        title = {
+            if (subtitle == null) {
+                title()
+            } else {
+                Column {
+                    title()
+                    subtitle()
+                }
+            }
+        },
+        navigationIcon = resolvedNavigationIcon,
+        actions = { actions() },
+        scrollBehavior = scrollBehavior,
+        colors = colors,
+    )
+}

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/MarsImage.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/MarsImage.kt
@@ -87,11 +87,15 @@ fun MarsImageComposable(
 }
 
 @Composable
-fun PhotoStats(marsImage: MarsImage, onFavoriteClick: () -> Unit) {
+fun PhotoStats(
+    marsImage: MarsImage,
+    onFavoriteClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     val stats = marsImage.stats
 
     Column(
-        modifier = Modifier
+        modifier = modifier
             .padding(horizontal = 8.dp, vertical = 4.dp)
             .fillMaxWidth(),
     ) {

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/widgets.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/widgets.kt
@@ -55,19 +55,19 @@ fun MarsSnackbar(
 }
 
 /**
- * Radio button with text label component.
+ * Radio button with a composable label slot.
  *
- * @param text The label text to display
  * @param selected Whether the radio button is selected
- * @param modifier Modifier for the component
  * @param onClick Callback when the component is clicked
+ * @param modifier Modifier for the component
+ * @param labelContent The label rendered below the radio button
  */
 @Composable
 fun RadioButtonText(
-    text: String,
     selected: Boolean,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    onClick: () -> Unit
+    labelContent: @Composable () -> Unit,
 ) {
     Column(
         modifier = modifier
@@ -80,7 +80,7 @@ fun RadioButtonText(
             selected = selected,
             onClick = null
         )
-        Text(text = text)
+        labelContent()
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/PhotosViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/PhotosViewModel.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlin.random.Random
@@ -167,6 +168,39 @@ class PhotosViewModel(
      * Flow of current sol number.
      */
     val solFlow = queryEmitter.mapNotNull { it?.sol }
+
+    /**
+     * Single-observable UI state for [PhotosScreen].
+     *
+     * Combines rover info, current sol, grid items, and camera filter into one snapshot.
+     * By the time [combine] fires, [roverFlow] has emitted (setting [dateUtil]), so all
+     * date computations inside the lambda are safe.
+     */
+    val uiState: StateFlow<PhotosUiState> = combine(
+        roverFlow.map { it.name to it.maxSol.coerceAtLeast(1L) },
+        solFlow,
+        gridItemsFlow,
+        cameraFilterEmitter,
+    ) { roverInfo, sol, gridItems, cameraFilter ->
+        val (roverName, maxSol) = roverInfo
+        PhotosUiState(
+            roverName = roverName,
+            sol = sol,
+            earthDate = earthDateStr(sol),
+            gridItems = gridItems,
+            maxSol = maxSol,
+            cameraFilter = cameraFilter,
+            hasPhotos = gridItems?.any { it is GridItem.PhotoItem } ?: false,
+            datePickerSelectedMillis = earthTime(sol),
+            datePickerMinMillis = minDate(),
+            datePickerMaxMillis = maxDate(),
+        )
+    }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = PhotosUiState()
+        )
 
     init {
         viewModelScope.launch {
@@ -333,3 +367,27 @@ class PhotosViewModel(
         return PhotosQueryRequest(rover.id, sol, null)
     }
 }
+
+/**
+ * UI state for [PhotosScreen].
+ *
+ * All values are plain/immutable — the UI composable has no dependency on the ViewModel.
+ */
+data class PhotosUiState(
+    val roverName: String = "",
+    val sol: Long = 0L,
+    /** Earth-date string pre-formatted for the current sol (e.g. "Jan 15, 2021"). */
+    val earthDate: String = "",
+    /** Null = loading; empty list = no photos found for this sol. */
+    val gridItems: List<GridItem>? = null,
+    val maxSol: Long = 1L,
+    val cameraFilter: String? = null,
+    /** True when the photos list is non-empty and the "go to latest" FAB should be shown. */
+    val hasPhotos: Boolean = false,
+    /** Earth-date millis for the current sol — the date-picker's initial selection. */
+    val datePickerSelectedMillis: Long = 0L,
+    /** Rover landing-date millis — lower bound for the date picker. */
+    val datePickerMinMillis: Long = 0L,
+    /** Rover last-date millis — upper bound for the date picker. */
+    val datePickerMaxMillis: Long = 0L,
+)

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/RoverMissionInfoViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/RoverMissionInfoViewModel.kt
@@ -12,6 +12,8 @@ import com.sirelon.marsroverphotos.platform.FirebaseAnalytics
 import com.sirelon.marsroverphotos.utils.Logger
 import com.sirelon.marsroverphotos.utils.buildTimelineMilestones
 import com.sirelon.marsroverphotos.utils.calculateEarthDaysActive
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -67,11 +69,11 @@ class RoverMissionInfoViewModel(
                     rover = rover,
                     daysActive = daysActive,
                     earthDaysActive = earthDaysActive,
-                    cameras = cameras,
+                    cameras = cameras.toImmutableList(),
                     missionFacts = factsUiState.facts,
                     factsLoading = factsUiState.loading,
                     factsError = factsUiState.error,
-                    timelineMilestones = milestones
+                    timelineMilestones = milestones.toImmutableList()
                 )
             }.collect { state ->
                 _stateFlow.value = state
@@ -174,11 +176,11 @@ data class MissionInfoState(
     val rover: Rover,
     val daysActive: Long,
     val earthDaysActive: Long,
-    val cameras: List<CameraSpec>,
+    val cameras: ImmutableList<CameraSpec>,
     val missionFacts: RoverMissionFacts?,
     val factsLoading: Boolean,
     val factsError: String?,
-    val timelineMilestones: List<TimelineMilestone>
+    val timelineMilestones: ImmutableList<TimelineMilestone>
 )
 
 /**

--- a/shared/src/desktopMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/Theme.desktop.kt
+++ b/shared/src/desktopMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/Theme.desktop.kt
@@ -2,12 +2,14 @@ package com.sirelon.marsroverphotos.presentation.theme
 
 import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 
 /**
  * Desktop implementation: Detect system dark mode via system property.
  * Checks for dark appearance using system properties or defaults to false.
  */
 @Composable
+@ReadOnlyComposable
 actual fun isSystemInDarkTheme(): Boolean {
     // Try to detect dark mode from system properties
     // This works on macOS and some Linux desktops
@@ -24,6 +26,7 @@ actual fun isSystemInDarkTheme(): Boolean {
  * Desktop implementation: No dynamic color support.
  */
 @Composable
+@ReadOnlyComposable
 actual fun supportsDynamicColor(): Boolean {
     return false
 }
@@ -32,6 +35,7 @@ actual fun supportsDynamicColor(): Boolean {
  * Desktop implementation: Return static dark color scheme.
  */
 @Composable
+@ReadOnlyComposable
 actual fun getDynamicDarkColorScheme(): ColorScheme {
     return DarkColorPalette
 }
@@ -40,6 +44,7 @@ actual fun getDynamicDarkColorScheme(): ColorScheme {
  * Desktop implementation: Return static light color scheme.
  */
 @Composable
+@ReadOnlyComposable
 actual fun getDynamicLightColorScheme(): ColorScheme {
     return LightColorPalette
 }

--- a/shared/src/iosMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/Theme.ios.kt
+++ b/shared/src/iosMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/Theme.ios.kt
@@ -2,6 +2,7 @@ package com.sirelon.marsroverphotos.presentation.theme
 
 import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import platform.UIKit.UIScreen
 import platform.UIKit.UIUserInterfaceStyle
 
@@ -9,6 +10,7 @@ import platform.UIKit.UIUserInterfaceStyle
  * iOS implementation: Detect system dark mode.
  */
 @Composable
+@ReadOnlyComposable
 actual fun isSystemInDarkTheme(): Boolean {
     return UIScreen.mainScreen.traitCollection.userInterfaceStyle == UIUserInterfaceStyle.UIUserInterfaceStyleDark
 }
@@ -17,6 +19,7 @@ actual fun isSystemInDarkTheme(): Boolean {
  * iOS implementation: No dynamic color support.
  */
 @Composable
+@ReadOnlyComposable
 actual fun supportsDynamicColor(): Boolean {
     return false
 }
@@ -25,6 +28,7 @@ actual fun supportsDynamicColor(): Boolean {
  * iOS implementation: Return static dark color scheme.
  */
 @Composable
+@ReadOnlyComposable
 actual fun getDynamicDarkColorScheme(): ColorScheme {
     return DarkColorPalette
 }
@@ -33,6 +37,7 @@ actual fun getDynamicDarkColorScheme(): ColorScheme {
  * iOS implementation: Return static light color scheme.
  */
 @Composable
+@ReadOnlyComposable
 actual fun getDynamicLightColorScheme(): ColorScheme {
     return LightColorPalette
 }


### PR DESCRIPTION
## Summary
This branch applies a Compose-pattern quality pass across shared KMP screens by splitting state-holder vs pure-UI responsibilities, moving `PhotosUiState` into the ViewModel layer, and adding focused previews for `PhotosScreen`, `ImagesPagerContent`, and mission-info states. It also hardens state collection and side effects by adopting `collectAsStateWithLifecycle`, using `rememberUpdatedState` for long-lived collectors/effects, and keeping snackbar/overlay hosts stable in the images flow. Reusable UI APIs were normalized with modifier-first and slot-style patterns (`RadioButtonText`, `PhotoStats`, screen content composables), while mission timeline rendering was updated to draw progress via `drawBehind` and immutable model inputs. The full workspace diff also includes theme accessor annotations (`@ReadOnlyComposable`) and related shared/android/desktop/ios theme wiring updates to keep behavior consistent across platforms.

## Validation
- `./gradlew :shared:compileDebugKotlinAndroid`
