### PR TITLE
Fix AGP 9.0 Gradle deprecation warnings

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -3,7 +3,6 @@ import java.util.Properties
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
     alias(libs.plugins.compose.compiler)
@@ -78,12 +77,6 @@ android {
     buildFeatures {
         compose = true
         buildConfig = true
-    }
-}
-
-kotlin {
-    compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,11 +14,6 @@
 org.gradle.jvmargs=-Xmx4096M -Dkotlin.daemon.jvm.options\="-Xmx4096M"
 android.useAndroidX=true
 android.nonTransitiveRClass=true
-android.nonFinalResIds=false
-# AGP 9.0: disabled to allow shared KMP module (android.library + kotlin.multiplatform)
-# TODO: migrate shared to com.android.kotlin.multiplatform.library to re-enable
-android.builtInKotlin=false
-android.newDsl=false
 
 # Kotlin Multiplatform Settings
 kotlin.mpp.enableCInteropCommonization=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -103,6 +103,14 @@ androidx-paging-runtime-ktx = { group = "androidx.paging", name = "paging-runtim
 androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "work" }
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "core-splashscreen" }
 
+# Compose Multiplatform (KMP) — direct coordinates replacing deprecated compose.XXX shorthands
+compose-mp-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose-multiplatform" }
+compose-mp-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose-multiplatform" }
+compose-mp-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "compose-multiplatform" }
+compose-mp-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose-multiplatform" }
+compose-mp-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "compose-multiplatform" }
+compose-mp-components-ui-tooling-preview = { module = "org.jetbrains.compose.components:components-ui-tooling-preview", version.ref = "compose-multiplatform" }
+
 coil = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-network = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
-    alias(libs.plugins.android.library)
+    alias(libs.plugins.android.kotlin.multiplatform.library)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.compose.multiplatform)
     alias(libs.plugins.kotlin.serialization)
@@ -18,8 +18,13 @@ kotlin {
         freeCompilerArgs.add("-Xexpect-actual-classes")
     }
 
-    // Android target
-    androidTarget()
+    // Android target — namespace/compileSdk/minSdk live here with com.android.kotlin.multiplatform.library
+    // jvmToolchain(17) above already covers the JVM target for this Android compilation.
+    android {
+        namespace = "com.sirelon.marsroverphotos.shared"
+        compileSdk = 37
+        minSdk = 23
+    }
 
     // iOS targets — XCFramework bundles both slices so Xcode picks the right one
     // for simulator and real device builds automatically.
@@ -52,13 +57,13 @@ kotlin {
     sourceSets {
         // Common source set - shared across all platforms
         commonMain.dependencies {
-            // Compose Multiplatform
-            implementation(compose.runtime)
-            implementation(compose.foundation)
-            implementation(compose.material3)
-            implementation(compose.ui)
-            implementation(compose.components.resources)
-            implementation(compose.components.uiToolingPreview)
+            // Compose Multiplatform (direct coordinates — compose.XXX shorthands deprecated in 1.12+)
+            implementation(libs.compose.mp.runtime)
+            implementation(libs.compose.mp.foundation)
+            implementation(libs.compose.mp.material3)
+            implementation(libs.compose.mp.ui)
+            implementation(libs.compose.mp.components.resources)
+            implementation(libs.compose.mp.components.ui.tooling.preview)
 
             // Ktor (networking)
             implementation(libs.ktor.core)
@@ -175,24 +180,6 @@ kotlin {
 
 compose.resources {
     packageOfResClass = "com.sirelon.marsroverphotos.shared.resources"
-}
-
-android {
-    namespace = "com.sirelon.marsroverphotos.shared"
-    compileSdk = 37
-
-    defaultConfig {
-        minSdk = 23
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    buildFeatures {
-        compose = true
-    }
 }
 
 room3 {


### PR DESCRIPTION
Resolves all AGP 9.0 deprecation warnings by migrating `:shared` from `com.android.library` to the new `com.android.kotlin.multiplatform.library` plugin (android config moves into `kotlin { android { } }`), removing the now-default `android.builtInKotlin`, `android.newDsl`, and `android.nonFinalResIds` flags from `gradle.properties`, dropping the redundant `kotlin.android` plugin from `:androidApp`, and replacing deprecated `compose.XXX` shorthand accessors with direct version-catalog entries (`compose-mp-*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)