### PR TITLE
Add design system components (AppButton, AppCard, AppFloatingActionButton)

### DIFF
--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/AboutScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/AboutScreen.kt
@@ -12,11 +12,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
-import androidx.compose.material3.Card
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.SnackbarHostState
@@ -35,6 +32,9 @@ import coil3.compose.LocalPlatformContext
 import com.sirelon.marsroverphotos.domain.settings.Theme
 import com.sirelon.marsroverphotos.platform.AppReview
 import com.sirelon.marsroverphotos.presentation.navigation.LocalAboutCallbacks
+import com.sirelon.marsroverphotos.presentation.ui.AppButton
+import com.sirelon.marsroverphotos.presentation.ui.AppCard
+import com.sirelon.marsroverphotos.presentation.ui.AppOutlinedButton
 import com.sirelon.marsroverphotos.presentation.ui.MarsSnackbar
 import com.sirelon.marsroverphotos.presentation.ui.RadioButtonText
 import com.sirelon.marsroverphotos.presentation.ui.rememberPlatformUriHandler
@@ -125,14 +125,14 @@ private fun AboutContent(
             ThemeChanger(currentTheme = currentTheme, onThemeChange = viewModel::setTheme)
             FactsToggle(showFacts = showFacts, onFactsToggle = viewModel::toggleFacts)
 
-            OutlinedButton(onClick = {
+            AppOutlinedButton(onClick = {
                 onClearCache()
                 scope.launch { snackbarHostState.showSnackbar("Cache cleared") }
             }) {
                 Text(text = "Clear Cache")
             }
 
-            Button(
+            AppButton(
                 onClick = {
                     scope.launch {
                         val shown = appReview.requestReview()
@@ -168,10 +168,10 @@ private fun AboutContent(
 
 @Composable
 private fun ThemeChanger(currentTheme: Theme, onThemeChange: (Theme) -> Unit) {
-    Card(
+    AppCard(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 8.dp)
+            .padding(horizontal = 8.dp),
     ) {
         Column(
             modifier = Modifier
@@ -203,10 +203,10 @@ private fun ThemeChanger(currentTheme: Theme, onThemeChange: (Theme) -> Unit) {
 
 @Composable
 private fun FactsToggle(showFacts: Boolean, onFactsToggle: (Boolean) -> Unit) {
-    Card(
+    AppCard(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 8.dp)
+            .padding(horizontal = 8.dp),
     ) {
         Row(
             modifier = Modifier

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/FavoriteScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/FavoriteScreen.kt
@@ -17,10 +17,10 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
-import androidx.compose.material3.Button
-import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import com.sirelon.marsroverphotos.presentation.ui.AppButton
+import com.sirelon.marsroverphotos.presentation.ui.AppCard
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -211,7 +211,7 @@ private fun FavoriteEmptyContent(
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
         Spacer(modifier = Modifier.height(16.dp))
-        Button(onClick = onBtnClick) {
+        AppButton(onClick = onBtnClick) {
             Text(text = btnTitle)
         }
     }
@@ -221,14 +221,14 @@ private fun FavoriteEmptyContent(
 private fun LoadingMoreItem(
     modifier: Modifier = Modifier
 ) {
-    Card(
+    AppCard(
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 8.dp),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant,
-            contentColor = MaterialTheme.colorScheme.onSurfaceVariant
-        )
+            contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        ),
     ) {
         Row(
             modifier = Modifier

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
@@ -27,8 +27,8 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import com.sirelon.marsroverphotos.presentation.ui.AppButton
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
@@ -202,7 +202,7 @@ private fun ImagesEmptyState(onBack: () -> Unit) {
                 style = MaterialTheme.typography.titleMedium,
             )
             Spacer(modifier = Modifier.height(12.dp))
-            Button(onClick = onBack) {
+            AppButton(onClick = onBack) {
                 Text(text = stringResource(Res.string.images_empty_btn))
             }
         }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
@@ -24,12 +24,8 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
@@ -46,6 +42,10 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sirelon.marsroverphotos.data.database.entities.MarsImage
 import com.sirelon.marsroverphotos.domain.models.EducationalFact
 import com.sirelon.marsroverphotos.presentation.models.GridItem
+import com.sirelon.marsroverphotos.presentation.ui.AppCard
+import com.sirelon.marsroverphotos.presentation.ui.AppFactCard
+import com.sirelon.marsroverphotos.presentation.ui.AppFloatingActionButton
+import com.sirelon.marsroverphotos.presentation.ui.AppOutlinedButton
 import com.sirelon.marsroverphotos.presentation.ui.AppTopBar
 import com.sirelon.marsroverphotos.presentation.ui.CenteredColumn
 import com.sirelon.marsroverphotos.presentation.ui.CenteredProgress
@@ -170,7 +170,7 @@ private fun PhotosScreen(
         floatingActionButton = {
             RefreshButton(
                 visible = state.hasPhotos,
-                onClick = { onGoToLatest() }
+                onClick = onGoToLatest,
             )
         }
     ) { innerPadding ->
@@ -237,7 +237,7 @@ private fun RefreshButton(
         enter = fadeIn(),
         exit = fadeOut()
     ) {
-        FloatingActionButton(onClick = onClick) {
+        AppFloatingActionButton(onClick = onClick) {
             MaterialSymbolIcon(
                 symbol = MaterialSymbol.Autorenew,
                 contentDescription = "Reload random Sol"
@@ -306,12 +306,11 @@ private fun PhotoCard(
     onPhotoClick: (image: MarsImage) -> Unit,
     onCameraClick: ((cameraName: String) -> Unit)? = null
 ) {
-    Card(
+    AppCard(
         modifier = Modifier
             .padding(8.dp)
             .fillMaxWidth()
             .clickable { onPhotoClick(image) },
-        shape = MaterialTheme.shapes.large
     ) {
         Column(verticalArrangement = Arrangement.SpaceBetween) {
             NetworkImage(
@@ -323,6 +322,7 @@ private fun PhotoCard(
             Text(
                 text = shortCaption(image.name.orEmpty()),
                 style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.secondary,
                 modifier = Modifier
                     .padding(4.dp)
                     .fillMaxWidth()
@@ -344,7 +344,7 @@ private fun DateSelectorButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    OutlinedButton(
+    AppOutlinedButton(
         modifier = modifier.animateContentSize(),
         onClick = onClick,
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
@@ -404,14 +404,10 @@ private fun FactCard(
     fact: EducationalFact,
     modifier: Modifier = Modifier
 ) {
-    Card(
+    AppFactCard(
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 8.dp, vertical = 12.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.secondaryContainer,
-        ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
     ) {
         Column(
             modifier = Modifier
@@ -426,21 +422,18 @@ private fun FactCard(
                 MaterialSymbolIcon(
                     symbol = MaterialSymbol.Info,
                     contentDescription = stringResource(Res.string.educational_fact),
-                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
                     modifier = Modifier.size(24.dp)
                 )
                 Text(
                     text = stringResource(Res.string.did_you_know),
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer
                 )
             }
 
             Text(
                 text = fact.text,
                 style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSecondaryContainer,
                 modifier = Modifier.padding(top = 4.dp)
             )
         }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PopularScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PopularScreen.kt
@@ -10,8 +10,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
-import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import com.sirelon.marsroverphotos.presentation.ui.AppButton
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -177,7 +177,7 @@ private fun PopularEmptyContent(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         Spacer(modifier = Modifier.height(16.dp))
-        Button(onClick = onRetry) {
+        AppButton(onClick = onRetry) {
             Text(text = "Retry")
         }
     }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoverMissionInfoScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoverMissionInfoScreen.kt
@@ -25,9 +25,9 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import com.sirelon.marsroverphotos.presentation.ui.AppCard
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.IconButton
@@ -240,9 +240,9 @@ private fun MissionInfoContent(
 
 @Composable
 private fun RoverHeader(rover: Rover) {
-    Card(
+    AppCard(
         modifier = Modifier.fillMaxWidth(),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
     ) {
         Column(
             modifier = Modifier.padding(16.dp),
@@ -443,10 +443,7 @@ private fun MissionStatistics(
 
 @Composable
 private fun StatCard(label: String, value: String, modifier: Modifier = Modifier) {
-    Card(
-        modifier = modifier,
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
-    ) {
+    AppCard(modifier = modifier) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -483,10 +480,7 @@ private fun CamerasList(
         )
         return
     }
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
-    ) {
+    AppCard(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp)) {
             cameras.forEachIndexed { index, camera ->
                 CameraItem(
@@ -542,10 +536,7 @@ private fun CameraItem(
 
 @Composable
 private fun MissionObjectives(objectives: List<String>) {
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
-    ) {
+    AppCard(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp)) {
             objectives.forEach { objective ->
                 Row(modifier = Modifier.padding(vertical = 4.dp)) {
@@ -567,12 +558,12 @@ private fun MissionObjectives(objectives: List<String>) {
 
 @Composable
 private fun FunFacts(facts: List<String>) {
-    Card(
+    AppCard(
         modifier = Modifier.fillMaxWidth(),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.primaryContainer
-        )
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        ),
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             facts.forEach { fact ->

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoversScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoversScreen.kt
@@ -15,9 +15,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.IconButton
+import com.sirelon.marsroverphotos.presentation.ui.AppCard
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -95,10 +94,8 @@ fun RoverItem(
     onMissionInfoClick: (rover: Rover) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Card(
+    AppCard(
         modifier = modifier.padding(8.dp),
-        shape = MaterialTheme.shapes.large,
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -160,7 +157,7 @@ private fun TitleText(text: String) {
     Text(
         text = text,
         style = MaterialTheme.typography.headlineMedium,
-        color = MaterialTheme.colorScheme.tertiary,
+        color = MaterialTheme.colorScheme.secondary,
         maxLines = 1,
         overflow = TextOverflow.Ellipsis
     )

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/Theme.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/Theme.kt
@@ -16,20 +16,32 @@ val primaryDark = Color(0xFF6200EE)
 val primaryVariant = Color(0xFF1A283D)
 val accent = Color(0xFFFC6C4B)
 
+/** Lighter blue used for section headers and rover titles in Mission Info. */
+val primaryLight = Color(0xFF7FA6D8)
+
+/** Navy used for the Fun Facts card background. */
+val primaryNavy = Color(0xFF1A283D)
+
 /**
  * Dark color scheme for the app.
  */
 val DarkColorPalette = darkColorScheme(
     primary = primary,
-    secondary = accent,
+    onPrimary = Color.Black,
+    primaryContainer = primaryNavy,        // Fun Facts card background
+    onPrimaryContainer = Color.White,
+    secondary = accent,                    // coral — rover names, captions, FAB, selected nav
+    onSecondary = Color.Black,
+    secondaryContainer = Color(0xFF2A3A4D), // "Did You Know?" fact card
+    onSecondaryContainer = Color(0xFFDCE6F2),
+    tertiary = primaryLight,               // lighter blue — section headers, Mission Info titles
+    onTertiary = Color.Black,
     background = Color(0xFF121212),
     surface = Color(0xFF121212),
     error = Color(0xFFCF6679),
-    onPrimary = Color.Black,
-    onSecondary = Color.Black,
     onBackground = Color.White,
     onSurface = Color.White,
-    onError = Color.Black
+    onError = Color.Black,
 )
 
 /**
@@ -37,15 +49,21 @@ val DarkColorPalette = darkColorScheme(
  */
 val LightColorPalette = lightColorScheme(
     primary = primary,
+    onPrimary = Color.White,
+    primaryContainer = Color(0xFFD4E3F5),
+    onPrimaryContainer = Color(0xFF1A283D),
     secondary = accent,
+    onSecondary = Color.Black,
+    secondaryContainer = Color(0xFFE4ECF6),
+    onSecondaryContainer = Color(0xFF1A283D),
+    tertiary = primary,
+    onTertiary = Color.White,
     background = Color.White,
     surface = Color.White,
     error = Color(0xFFB00020),
-    onPrimary = Color.White,
-    onSecondary = Color.Black,
     onBackground = Color.Black,
     onSurface = Color.Black,
-    onError = Color.White
+    onError = Color.White,
 )
 
 /**

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/Theme.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/Theme.kt
@@ -67,6 +67,38 @@ val LightColorPalette = lightColorScheme(
 )
 
 /**
+ * Overlays brand-critical color slots onto any [ColorScheme].
+ *
+ * Dynamic color (Material You) replaces the full palette with wallpaper-derived
+ * colors, which would override the design-system tokens for secondary (coral),
+ * secondaryContainer, tertiary, and primaryContainer. This function restores
+ * those slots so branded components always render correctly.
+ */
+private fun ColorScheme.withBrandOverrides(darkTheme: Boolean): ColorScheme = if (darkTheme) {
+    copy(
+        secondary = accent,
+        onSecondary = Color.Black,
+        secondaryContainer = Color(0xFF2A3A4D),
+        onSecondaryContainer = Color(0xFFDCE6F2),
+        tertiary = primaryLight,
+        onTertiary = Color.Black,
+        primaryContainer = primaryNavy,
+        onPrimaryContainer = Color.White,
+    )
+} else {
+    copy(
+        secondary = accent,
+        onSecondary = Color.Black,
+        secondaryContainer = Color(0xFFE4ECF6),
+        onSecondaryContainer = Color(0xFF1A283D),
+        tertiary = primary,
+        onTertiary = Color.White,
+        primaryContainer = Color(0xFFD4E3F5),
+        onPrimaryContainer = Color(0xFF1A283D),
+    )
+}
+
+/**
  * Main theme composable for Mars Rover Photos app.
  * Supports dark/light themes with platform-specific dynamic color support.
  *
@@ -81,15 +113,16 @@ fun MarsRoverPhotosTheme(
     content: @Composable () -> Unit
 ) {
     val colors = when {
-        // Dynamic color is available on Android 12+ (API 31+)
+        // Dynamic color (Material You) on Android 12+: use wallpaper-derived scheme
+        // but restore brand-critical slots so design-system components are consistent.
         dynamicColor && supportsDynamicColor() -> {
             if (darkTheme) {
-                getDynamicDarkColorScheme()
+                getDynamicDarkColorScheme().withBrandOverrides(darkTheme = true)
             } else {
-                getDynamicLightColorScheme()
+                getDynamicLightColorScheme().withBrandOverrides(darkTheme = false)
             }
         }
-        // Fall back to static color schemes
+        // Fall back to fully static brand palettes
         darkTheme -> DarkColorPalette
         else -> LightColorPalette
     }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/AppButton.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/AppButton.kt
@@ -1,0 +1,63 @@
+package com.sirelon.marsroverphotos.presentation.ui
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ButtonElevation
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+
+/**
+ * Design-system branded button — pill-shaped filled button using the theme primary color.
+ * Drop-in replacement for Material3 [Button] that enforces the app's shape token.
+ */
+@Composable
+fun AppButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    shape: Shape = CircleShape,
+    colors: ButtonColors = ButtonDefaults.buttonColors(),
+    elevation: ButtonElevation? = ButtonDefaults.buttonElevation(),
+    content: @Composable RowScope.() -> Unit,
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        shape = shape,
+        colors = colors,
+        elevation = elevation,
+        content = content,
+    )
+}
+
+/**
+ * Design-system branded outlined button — pill-shaped with theme outline border.
+ * Drop-in replacement for Material3 [OutlinedButton] that enforces the app's shape token.
+ */
+@Composable
+fun AppOutlinedButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    shape: Shape = CircleShape,
+    colors: ButtonColors = ButtonDefaults.outlinedButtonColors(),
+    border: BorderStroke? = ButtonDefaults.outlinedButtonBorder,
+    content: @Composable RowScope.() -> Unit,
+) {
+    OutlinedButton(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        shape = shape,
+        colors = colors,
+        border = border,
+        content = content,
+    )
+}

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/AppCard.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/AppCard.kt
@@ -1,0 +1,54 @@
+package com.sirelon.marsroverphotos.presentation.ui
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardColors
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CardElevation
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.dp
+
+/**
+ * Design-system branded card — large-radius (16 dp) elevated card.
+ * Drop-in replacement for Material3 [Card] that enforces the app's shape and elevation tokens.
+ */
+@Composable
+fun AppCard(
+    modifier: Modifier = Modifier,
+    shape: Shape = MaterialTheme.shapes.large,
+    colors: CardColors = CardDefaults.cardColors(),
+    elevation: CardElevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Card(
+        modifier = modifier,
+        shape = shape,
+        colors = colors,
+        elevation = elevation,
+        content = content,
+    )
+}
+
+/**
+ * Design-system "Did You Know?" fact card — secondary-container tinted, medium radius (12 dp),
+ * higher elevation (4 dp) to lift it above the photo grid.
+ */
+@Composable
+fun AppFactCard(
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Card(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.medium,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+        content = content,
+    )
+}

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/AppFloatingActionButton.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/AppFloatingActionButton.kt
@@ -1,0 +1,36 @@
+package com.sirelon.marsroverphotos.presentation.ui
+
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.FloatingActionButtonDefaults
+import androidx.compose.material3.FloatingActionButtonElevation
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.contentColorFor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+
+/**
+ * Design-system branded FAB — coral accent container color (theme secondary).
+ * Drop-in replacement for Material3 [FloatingActionButton] that uses the Mars accent color.
+ */
+@Composable
+fun AppFloatingActionButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    shape: Shape = FloatingActionButtonDefaults.shape,
+    containerColor: Color = MaterialTheme.colorScheme.secondary,
+    contentColor: Color = contentColorFor(containerColor),
+    elevation: FloatingActionButtonElevation = FloatingActionButtonDefaults.elevation(),
+    content: @Composable () -> Unit,
+) {
+    FloatingActionButton(
+        onClick = onClick,
+        modifier = modifier,
+        shape = shape,
+        containerColor = containerColor,
+        contentColor = contentColor,
+        elevation = elevation,
+        content = content,
+    )
+}

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/MarsImage.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/MarsImage.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.Card
 import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -61,12 +60,11 @@ fun MarsImageComposable(
 
     val state by painter.state.collectAsState()
     val showStats = state is AsyncImagePainter.State.Success
-    Card(
+    AppCard(
         modifier = modifier
             .padding(vertical = 8.dp)
             .fillMaxWidth()
             .clickable(onClick = onClick),
-        shape = MaterialTheme.shapes.large
     ) {
         Column {
             Image(


### PR DESCRIPTION
## Summary

- Introduces three new branded component wrappers: `AppButton`/`AppOutlinedButton` (pill-shaped), `AppCard`/`AppFactCard` (16 dp radius, themed elevation), and `AppFloatingActionButton` (coral accent container color).
- Expands the color scheme with explicit `tertiary` (#7FA6D8 lighter blue for section headers), `secondaryContainer` (#2A3A4D for fact cards), and `primaryContainer` (#1A283D navy for fun facts) tokens matching the design system spec.
- Replaces every raw Material3 `Button`, `Card`, `OutlinedButton`, and `FloatingActionButton` call across all screens with the new App-prefixed components.

## Test plan

- [ ] Build compiles without errors on all KMP targets
- [ ] Rovers screen: rover name titles render in coral (`secondary`)
- [ ] Photos grid: photo captions coral, fact cards tinted `#2A3A4D`, FAB coral
- [ ] Mission Info: section headers in lighter blue (`tertiary`), fun facts card in navy (`primaryContainer`)
- [ ] About screen: buttons are pill-shaped; settings cards use `AppCard`
- [ ] Favorites / Popular / Images empty states use `AppButton`

🤖 Generated with [Claude Code](https://claude.com/claude-code)