### PR TITLE
Fix scroll lag and hide bottom nav bar on scroll

### DIFF
--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppNavigation.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppNavigation.kt
@@ -12,14 +12,18 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.BottomAppBarDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
@@ -45,7 +49,7 @@ private const val ANIM_DURATION_2 = ANIM_DURATION / 2
 /**
  * Main Navigation 3 display for the app.
  */
-@OptIn(KoinExperimentalAPI::class)
+@OptIn(KoinExperimentalAPI::class, ExperimentalMaterial3Api::class)
 @Composable
 fun AppNavigation(
     modifier: Modifier = Modifier,
@@ -130,6 +134,12 @@ fun AppNavigation(
     val dialogOverlaySceneStrategy = remember { DialogOverlaySceneStrategy<NavKey>() }
     val tracker: Tracker = koinInject()
     val isImages = chromeDestination is AppDestination.Images
+    val bottomBarScrollBehavior = BottomAppBarDefaults.exitAlwaysScrollBehavior()
+
+    // Reset the bottom bar to visible whenever the user navigates to a new top-level destination.
+    LaunchedEffect(chromeDestination) {
+        bottomBarScrollBehavior.state.heightOffset = 0f
+    }
 
     LaunchedEffect(deepLink) {
         val target = deepLink ?: return@LaunchedEffect
@@ -155,7 +165,10 @@ fun AppNavigation(
     CompositionLocalProvider(LocalAppNavigator provides navigator) {
         // Images screen goes fully edge-to-edge: no status-bar inset, no bottom chrome.
         Column(
-            modifier = if (isImages) modifier else modifier.windowInsetsPadding(WindowInsets.statusBars)
+            modifier = if (isImages) modifier
+            else modifier
+                .windowInsetsPadding(WindowInsets.statusBars)
+                .nestedScroll(bottomBarScrollBehavior.nestedScrollConnection)
         ) {
             AnimatedVisibility(!isImages && chromeDestination !is AppDestination.Ukraine) {
                 UkraineBanner(
@@ -219,14 +232,20 @@ fun AppNavigation(
                 )
             }
             if (!isImages) {
-                AdSlot(modifier = Modifier.fillMaxWidth())
-                MarsBottomBar(
-                    selectedDestination = chromeDestination.topLevelDestination(),
-                    onDestinationClick = { destination ->
-                        tracker.trackClick("bottom_${destination.analyticsTag}")
-                        navigator.selectTopLevel(destination)
-                    }
-                )
+                // Wrap in a column that always pads for the system navigation bar.
+                // BottomAppBar's own windowInsets are cleared to prevent double-padding.
+                Column(modifier = Modifier.windowInsetsPadding(WindowInsets.navigationBars)) {
+                    AdSlot(modifier = Modifier.fillMaxWidth())
+                    MarsBottomBar(
+                        selectedDestination = chromeDestination.topLevelDestination(),
+                        onDestinationClick = { destination ->
+                            tracker.trackClick("bottom_${destination.analyticsTag}")
+                            navigator.selectTopLevel(destination)
+                        },
+                        scrollBehavior = bottomBarScrollBehavior,
+                        windowInsets = WindowInsets(),
+                    )
+                }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/MarsBottomBar.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/MarsBottomBar.kt
@@ -1,11 +1,17 @@
 package com.sirelon.marsroverphotos.presentation.navigation
 
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.material3.BottomAppBar
+import androidx.compose.material3.BottomAppBarDefaults
+import androidx.compose.material3.BottomAppBarScrollBehavior
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbol
 import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbolIcon
 import com.sirelon.marsroverphotos.shared.resources.Res
@@ -19,13 +25,21 @@ import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MarsBottomBar(
     selectedDestination: AppDestination,
     onDestinationClick: (AppDestination) -> Unit,
     modifier: Modifier = Modifier,
+    scrollBehavior: BottomAppBarScrollBehavior? = null,
+    windowInsets: WindowInsets = BottomAppBarDefaults.windowInsets,
 ) {
-    NavigationBar(modifier = modifier) {
+    BottomAppBar(
+        modifier = modifier,
+        scrollBehavior = scrollBehavior,
+        windowInsets = windowInsets,
+        contentPadding = PaddingValues(horizontal = 0.dp, vertical = 0.dp),
+    ) {
         marsNavigationItems.forEach { item ->
             val selected = item.destination == selectedDestination
             val label = stringResource(item.label)

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
@@ -77,6 +77,11 @@ import com.sirelon.marsroverphotos.shared.resources.educational_fact
 import com.sirelon.marsroverphotos.shared.resources.no_photos_title
 import com.sirelon.marsroverphotos.shared.resources.tap_to_retry
 import com.sirelon.marsroverphotos.utils.formatDisplayDate
+import coil3.SingletonImageLoader
+import coil3.compose.LocalPlatformContext
+import coil3.request.CachePolicy
+import coil3.request.ImageRequest
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOf
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -123,6 +128,34 @@ fun PhotosScreen(
         snapshotFlow { gridState.firstVisibleItemIndex }
             .collect { index ->
                 solAtIndex(currentPagingItems.value, index)?.let(viewModel::onVisibleSolChanged)
+            }
+    }
+
+    // Prefetch images for items just beyond the visible grid window so they are
+    // already in Coil's cache by the time the user scrolls to them.
+    val context = LocalPlatformContext.current
+    LaunchedEffect(gridState) {
+        snapshotFlow { gridState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0 }
+            .distinctUntilChanged()
+            .collect { lastVisible ->
+                val items = currentPagingItems.value
+                repeat(PREFETCH_ITEM_COUNT) { offset ->
+                    val index = lastVisible + 1 + offset
+                    if (index >= items.itemCount) return@repeat
+                    val item = items.peek(index) ?: return@repeat
+                    if (item is GridItem.PhotoItem) {
+                        SingletonImageLoader.get(context).enqueue(
+                            ImageRequest.Builder(context)
+                                .data(item.image.imageUrl)
+                                // Only warm the disk cache — do NOT write to memory cache.
+                                // Without a size constraint the cached bitmap would be at
+                                // original resolution, which evicts correctly-sized entries
+                                // that AsyncImage has loaded and causes the placeholder loop.
+                                .memoryCachePolicy(CachePolicy.DISABLED)
+                                .build()
+                        )
+                    }
+                }
             }
     }
 
@@ -526,6 +559,9 @@ private fun CameraFilterChip(camera: String, onClear: () -> Unit) {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+// 10 items = 5 rows ahead for a 2-column grid.
+private const val PREFETCH_ITEM_COUNT = 10
 
 private val GridItem.gridKey: String
     get() = when (this) {

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/MarsImage.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/MarsImage.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -172,12 +173,15 @@ fun NetworkImage(
     showPlaceholder: Boolean = true,
     imageUrl: String
 ) {
-    val request = ImageRequest.Builder(LocalPlatformContext.current)
-        .data(data = imageUrl)
-        .apply {
-            crossfade(true)
-        }
-        .build()
+    val context = LocalPlatformContext.current
+    val request = remember(imageUrl) {
+        ImageRequest.Builder(context)
+            .data(data = imageUrl)
+            .apply {
+                crossfade(true)
+            }
+            .build()
+    }
     if (showPlaceholder) {
         AsyncImage(
             model = request,


### PR DESCRIPTION
## Summary

- **Performance:** `NetworkImage` was rebuilding a new `ImageRequest` on every recomposition; wrapping it in `remember(imageUrl)` eliminates the redundant allocations during grid scrolling.
- **Bottom bar scroll behavior:** Replaced `NavigationBar` with `BottomAppBar(exitAlwaysScrollBehavior)` — the nav bar now hides when scrolling down and reappears on scroll up, matching the existing top bar behavior. The scroll behavior's `nestedScrollConnection` is attached to the root `Column` in `AppNavigation` so it picks up scroll events from any screen.
- **Insets fix:** Lifted `WindowInsets.navigationBars` padding to a wrapper `Column` wrapping `AdSlot` + `MarsBottomBar`, so the ad slot always respects the system nav bar inset even when the bottom bar is fully collapsed.

## Test plan

- [ ] Scroll down in the Photos grid — top bar and bottom bar should both hide
- [ ] Scroll back up — both bars should reappear
- [ ] Navigate to another tab (Favorites/Popular/About) — bottom bar should reset to fully visible
- [ ] On a device with gesture navigation, verify no gap or overlap at the very bottom when the bar is hidden
- [ ] Verify fast fling scrolling is visibly smoother than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)