### PR TITLE
Add AppSpacing and AppTypography design system tokens

### DIFF
--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/AboutScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/AboutScreen.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
+import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
+import com.sirelon.marsroverphotos.presentation.theme.AppTypography
 import coil3.SingletonImageLoader
 import coil3.compose.LocalPlatformContext
 import com.sirelon.marsroverphotos.domain.settings.Theme
@@ -83,7 +85,6 @@ private fun AboutContent(
     appVersion: String,
     rateAppUrl: String
 ) {
-    val typography = MaterialTheme.typography
     val uriHandler = rememberPlatformUriHandler()
     val appReview: AppReview = koinInject()
     val scope = rememberCoroutineScope()
@@ -93,25 +94,25 @@ private fun AboutContent(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = 16.dp)
+                .padding(horizontal = AppSpacing.lg)
                 .verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.lg),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Image(
                 painter = painterResource(Res.drawable.alien_icon),
                 contentDescription = "logo"
             )
-            Text(text = "Mars Rover Photos", style = typography.headlineSmall)
+            Text(text = "Mars Rover Photos", style = AppTypography.appTitle)
             Text(
                 text = "Browse photos taken by NASA's Mars rovers. Explore the red planet through the eyes of Curiosity, Opportunity, Spirit, Perseverance, and InSight.",
-                style = typography.bodyLarge,
+                style = AppTypography.body,
                 textAlign = TextAlign.Center
             )
 
             Column(
                 modifier = Modifier
-                    .padding(vertical = 8.dp)
+                    .padding(vertical = AppSpacing.sm)
                     .fillMaxWidth()
             ) {
                 LinkifyText(text = "API provided by ", link = "https://api.nasa.gov/")
@@ -123,7 +124,7 @@ private fun AboutContent(
                 if (appVersion.isNotEmpty()) {
                     Text(
                         text = "Version: $appVersion",
-                        modifier = Modifier.padding(4.dp)
+                        modifier = Modifier.padding(AppSpacing.xs)
                     )
                 }
             }
@@ -160,7 +161,7 @@ private fun AboutContent(
             Text(
                 text = "© $currentYear All rights reserved.",
                 style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier.padding(16.dp)
+                modifier = Modifier.padding(AppSpacing.lg)
             )
         }
 
@@ -177,12 +178,12 @@ private fun ThemeChanger(currentTheme: Theme, onThemeChange: (Theme) -> Unit) {
     AppCard(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 8.dp),
+            .padding(horizontal = AppSpacing.sm),
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = 16.dp)
+                .padding(top = AppSpacing.lg)
         ) {
             Text(
                 modifier = Modifier.fillMaxWidth(),
@@ -212,12 +213,12 @@ private fun FactsToggle(showFacts: Boolean, onFactsToggle: (Boolean) -> Unit) {
     AppCard(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 8.dp),
+            .padding(horizontal = AppSpacing.sm),
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 12.dp),
+                .padding(horizontal = AppSpacing.lg, vertical = AppSpacing.md),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Column(modifier = Modifier.weight(1f)) {
@@ -252,7 +253,7 @@ private fun LinkifyText(text: String, link: String, displayLink: String = link) 
     val colors = MaterialTheme.colorScheme
 
     Row(
-        modifier = Modifier.padding(4.dp),
+        modifier = Modifier.padding(AppSpacing.xs),
         verticalAlignment = Alignment.CenterVertically
     ) {
         if (text.isNotEmpty()) {

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/FavoriteScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/FavoriteScreen.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
+import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
+import com.sirelon.marsroverphotos.presentation.theme.AppTypography
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -153,10 +155,10 @@ private fun FavoritePhotosContent(
                 LazyVerticalStaggeredGrid(
                     modifier = Modifier.fillMaxSize().consumeWindowInsets(innerPadding),
                     contentPadding = PaddingValues(
-                        start = 12.dp,
-                        end = 12.dp,
-                        top = innerPadding.calculateTopPadding() + 8.dp,
-                        bottom = innerPadding.calculateBottomPadding() + 8.dp,
+                        start = AppSpacing.md,
+                        end = AppSpacing.md,
+                        top = innerPadding.calculateTopPadding() + AppSpacing.sm,
+                        bottom = innerPadding.calculateBottomPadding() + AppSpacing.sm,
                     ),
                     columns = if (gridView) {
                         StaggeredGridCells.Adaptive(minSize = 180.dp)
@@ -164,7 +166,7 @@ private fun FavoritePhotosContent(
                         StaggeredGridCells.Fixed(1)
                     },
                     verticalItemSpacing = 8.dp,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
                     content = {
                         items(
                             count = lazyPagingItems.itemCount,
@@ -204,13 +206,13 @@ private fun FavoriteEmptyContent(
             contentDescription = null,
             modifier = Modifier.size(120.dp)
         )
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(AppSpacing.lg))
         Text(
             text = title,
-            style = MaterialTheme.typography.bodyLarge,
+            style = AppTypography.body,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(AppSpacing.lg))
         AppButton(onClick = onBtnClick) {
             Text(text = btnTitle)
         }
@@ -224,7 +226,7 @@ private fun LoadingMoreItem(
     AppCard(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
+            .padding(horizontal = AppSpacing.lg, vertical = AppSpacing.sm),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant,
             contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -233,7 +235,7 @@ private fun LoadingMoreItem(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp),
+                .padding(AppSpacing.lg),
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -241,7 +243,7 @@ private fun LoadingMoreItem(
                 modifier = Modifier.size(20.dp),
                 strokeWidth = 2.dp
             )
-            Spacer(modifier = Modifier.width(12.dp))
+            Spacer(modifier = Modifier.width(AppSpacing.md))
             Text(text = "Loading more photos...")
         }
     }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
@@ -200,7 +201,7 @@ private fun ImagesEmptyState(onBack: () -> Unit) {
                 text = stringResource(Res.string.images_empty_title),
                 style = MaterialTheme.typography.titleMedium,
             )
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(AppSpacing.md))
             AppButton(onClick = onBack) {
                 Text(text = stringResource(Res.string.images_empty_btn))
             }
@@ -435,7 +436,7 @@ private fun BoxScope.SaveSuccessOverlay(visible: Boolean) {
         MaterialSymbolIcon(
             symbol = MaterialSymbol.CheckCircle,
             contentDescription = "Saved",
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(AppSpacing.lg),
             tint = MaterialTheme.colorScheme.primary,
             size = 48.dp,
             filled = true

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
@@ -48,6 +48,8 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
+import com.sirelon.marsroverphotos.presentation.theme.AppTypography
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState
 import androidx.paging.PagingData
@@ -234,7 +236,7 @@ private fun PhotosScreen(
                             onOpenEarthDatePicker = onOpenEarthDatePicker,
                             modifier = Modifier
                                 .align(Alignment.TopCenter)
-                                .padding(top = 8.dp)
+                                .padding(top = AppSpacing.sm)
                         )
 
                         // Prepend (scroll-up) progress at the top, append (scroll-down) at the bottom.
@@ -282,15 +284,15 @@ private fun PhotosGrid(
         columns = GridCells.Fixed(2),
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(
-            start = 12.dp,
-            end = 12.dp,
+            start = AppSpacing.md,
+            end = AppSpacing.md,
             // Leave room for the floating date chip at the top.
             top = 52.dp,
             // 56dp FAB + 16dp FAB padding + 8dp margin above FAB
             bottom = 80.dp
         ),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.sm),
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm)
     ) {
         items(
             count = pagingItems.itemCount,
@@ -328,9 +330,9 @@ private fun DateHeaderRow(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 4.dp, vertical = 8.dp),
+            .padding(horizontal = AppSpacing.xs, vertical = AppSpacing.sm),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm)
     ) {
         Text(
             text = formatDisplayDate(header.earthDate),
@@ -427,10 +429,10 @@ private fun PhotoCard(
             )
             Text(
                 text = shortCaption(image.name.orEmpty()),
-                style = MaterialTheme.typography.bodySmall,
+                style = AppTypography.photoCaption,
                 color = MaterialTheme.colorScheme.secondary,
                 modifier = Modifier
-                    .padding(4.dp)
+                    .padding(AppSpacing.xs)
                     .fillMaxWidth()
                     .then(
                         if (onCameraClick != null && image.camera != null) {
@@ -448,17 +450,17 @@ private fun EmptyPhotos(title: String, btnTitle: String, callback: () -> Unit) {
     CenteredColumn(
         modifier = Modifier
             .clickable(onClick = callback)
-            .padding(32.dp)
+            .padding(AppSpacing.xxl)
     ) {
         Image(painter = painterResource(Res.drawable.alien_icon), contentDescription = null)
-        Spacer(modifier = Modifier.size(8.dp))
+        Spacer(modifier = Modifier.size(AppSpacing.sm))
         Text(
             text = title,
-            style = MaterialTheme.typography.headlineSmall,
+            style = AppTypography.appTitle,
             textAlign = TextAlign.Center
         )
-        Spacer(modifier = Modifier.size(8.dp))
-        Text(text = btnTitle, style = MaterialTheme.typography.headlineMedium)
+        Spacer(modifier = Modifier.size(AppSpacing.sm))
+        Text(text = btnTitle, style = AppTypography.roverTitle)
     }
 }
 
@@ -470,17 +472,17 @@ private fun FactCard(
     AppFactCard(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 8.dp, vertical = 12.dp),
+            .padding(horizontal = AppSpacing.sm, vertical = AppSpacing.md),
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+                .padding(AppSpacing.lg),
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm)
             ) {
                 MaterialSymbolIcon(
                     symbol = MaterialSymbol.Info,
@@ -489,15 +491,14 @@ private fun FactCard(
                 )
                 Text(
                     text = stringResource(Res.string.did_you_know),
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
+                    style = AppTypography.factHeader,
                 )
             }
 
             Text(
                 text = fact.text,
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier.padding(top = 4.dp)
+                style = AppTypography.body,
+                modifier = Modifier.padding(top = AppSpacing.xs)
             )
         }
     }
@@ -511,7 +512,7 @@ private fun CameraFilterChip(camera: String, onClear: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 4.dp),
+            .padding(horizontal = AppSpacing.lg, vertical = AppSpacing.xs),
         verticalAlignment = Alignment.CenterVertically
     ) {
         AssistChip(

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PopularScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PopularScreen.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
+import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
+import com.sirelon.marsroverphotos.presentation.theme.AppTypography
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -135,14 +137,14 @@ private fun PopularPhotosContent(
                     modifier = Modifier
                         .weight(1f)
                         .nestedScroll(scrollBehavior.nestedScrollConnection),
-                    contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
+                    contentPadding = PaddingValues(horizontal = AppSpacing.md, vertical = AppSpacing.sm),
                     columns = if (gridView) {
                         StaggeredGridCells.Adaptive(minSize = 180.dp)
                     } else {
                         StaggeredGridCells.Fixed(1)
                     },
                     verticalItemSpacing = 8.dp,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
                     content = {
                         items(
                             count = lazyPagingItems.itemCount,
@@ -173,10 +175,10 @@ private fun PopularEmptyContent(
     CenteredColumn(modifier = modifier) {
         Text(
             text = title,
-            style = MaterialTheme.typography.bodyLarge,
+            style = AppTypography.body,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(AppSpacing.lg))
         AppButton(onClick = onRetry) {
             Text(text = "Retry")
         }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoverMissionInfoScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoverMissionInfoScreen.kt
@@ -48,9 +48,10 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
+import com.sirelon.marsroverphotos.presentation.theme.AppTypography
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sirelon.marsroverphotos.domain.models.Rover
 import com.sirelon.marsroverphotos.domain.models.mission.CameraSpec
@@ -164,15 +165,15 @@ private fun MissionInfoContent(
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 16.dp),
-        verticalArrangement = Arrangement.spacedBy(24.dp),
-        contentPadding = PaddingValues(vertical = 16.dp),
+            .padding(horizontal = AppSpacing.lg),
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.xl),
+        contentPadding = PaddingValues(vertical = AppSpacing.lg),
     ) {
         item { RoverHeader(state.rover) }
 
         item {
             SectionHeader("Mission Timeline")
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(AppSpacing.sm))
             MissionTimeline(
                 milestones = state.timelineMilestones,
                 status = state.rover.status
@@ -181,7 +182,7 @@ private fun MissionInfoContent(
 
         item {
             SectionHeader("Statistics")
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(AppSpacing.sm))
             MissionStatistics(
                 totalPhotos = state.rover.totalPhotos,
                 daysActive = state.daysActive,
@@ -192,7 +193,7 @@ private fun MissionInfoContent(
 
         item {
             SectionHeader("Cameras")
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(AppSpacing.sm))
             CamerasList(
                 cameras = state.cameras,
                 onCameraClick = onCameraClick
@@ -202,7 +203,7 @@ private fun MissionInfoContent(
         when {
             state.factsLoading -> item {
                 SectionHeader("Mission Info")
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(AppSpacing.sm))
                 LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
             }
 
@@ -210,14 +211,14 @@ private fun MissionInfoContent(
                 if (state.missionFacts.objectives.isNotEmpty()) {
                     item {
                         SectionHeader("Mission Objectives")
-                        Spacer(modifier = Modifier.height(8.dp))
+                        Spacer(modifier = Modifier.height(AppSpacing.sm))
                         MissionObjectives(objectives = state.missionFacts.objectives)
                     }
                 }
                 if (state.missionFacts.funFacts.isNotEmpty()) {
                     item {
                         SectionHeader("Fun Facts")
-                        Spacer(modifier = Modifier.height(8.dp))
+                        Spacer(modifier = Modifier.height(AppSpacing.sm))
                         FunFacts(facts = state.missionFacts.funFacts)
                     }
                 }
@@ -239,7 +240,7 @@ private fun RoverHeader(rover: Rover) {
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
     ) {
         Column(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(AppSpacing.lg),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Image(
@@ -251,11 +252,10 @@ private fun RoverHeader(rover: Rover) {
                     .clip(MaterialTheme.shapes.medium),
                 contentScale = ContentScale.Fit
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(AppSpacing.lg))
             Text(
                 text = rover.name,
-                style = MaterialTheme.typography.headlineMedium,
-                fontWeight = FontWeight.Bold,
+                style = AppTypography.roverTitle,
                 color = MaterialTheme.colorScheme.tertiary
             )
         }
@@ -266,8 +266,7 @@ private fun RoverHeader(rover: Rover) {
 private fun SectionHeader(title: String) {
     Text(
         text = title,
-        style = MaterialTheme.typography.titleLarge,
-        fontWeight = FontWeight.Bold,
+        style = AppTypography.sectionHeader,
         color = MaterialTheme.colorScheme.tertiary
     )
 }
@@ -306,11 +305,10 @@ private fun MissionTimeline(milestones: ImmutableList<TimelineMilestone>, status
             ) {
                 Text(
                     text = milestone.label,
-                    style = MaterialTheme.typography.labelSmall,
-                    fontWeight = FontWeight.Bold,
+                    style = AppTypography.milestoneLabel,
                     textAlign = TextAlign.Center
                 )
-                Spacer(modifier = Modifier.height(4.dp))
+                Spacer(modifier = Modifier.height(AppSpacing.xs))
                 Box(
                     modifier = Modifier
                         .size(32.dp)
@@ -331,7 +329,7 @@ private fun MissionTimeline(milestones: ImmutableList<TimelineMilestone>, status
                         modifier = Modifier.size(20.dp)
                     )
                 }
-                Spacer(modifier = Modifier.height(4.dp))
+                Spacer(modifier = Modifier.height(AppSpacing.xs))
                 Text(
                     text = milestone.date,
                     style = MaterialTheme.typography.bodySmall,
@@ -362,7 +360,7 @@ private fun MissionTimeline(milestones: ImmutableList<TimelineMilestone>, status
                     modifier = Modifier
                         .weight(0.5f)
                         .align(Alignment.CenterVertically)
-                        .padding(horizontal = 4.dp)
+                        .padding(horizontal = AppSpacing.xs)
                 )
             }
         }
@@ -400,10 +398,10 @@ private fun MissionStatistics(
     earthDaysActive: Long,
     status: String
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+            horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm)
         ) {
             StatCard(
                 label = "Total Photos",
@@ -418,7 +416,7 @@ private fun MissionStatistics(
         }
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+            horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm)
         ) {
             StatCard(
                 label = "Earth Days",
@@ -440,20 +438,19 @@ private fun StatCard(label: String, value: String, modifier: Modifier = Modifier
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp),
+                .padding(AppSpacing.lg),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Text(
                 text = label,
-                style = MaterialTheme.typography.labelMedium,
+                style = AppTypography.statLabel,
                 color = MaterialTheme.colorScheme.secondary,
                 textAlign = TextAlign.Center
             )
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(AppSpacing.sm))
             Text(
                 text = value,
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold,
+                style = AppTypography.statValue,
                 textAlign = TextAlign.Center
             )
         }
@@ -468,20 +465,20 @@ private fun CamerasList(
     if (cameras.isEmpty()) {
         Text(
             text = "No camera information available",
-            style = MaterialTheme.typography.bodyMedium,
+            style = AppTypography.bodySecondary,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
         return
     }
     AppCard(modifier = Modifier.fillMaxWidth()) {
-        Column(modifier = Modifier.padding(16.dp)) {
+        Column(modifier = Modifier.padding(AppSpacing.lg)) {
             cameras.forEachIndexed { index, camera ->
                 CameraItem(
                     camera = camera,
                     onClick = { onCameraClick(camera.name) }
                 )
                 if (index < cameras.size - 1) {
-                    HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+                    HorizontalDivider(modifier = Modifier.padding(vertical = AppSpacing.md))
                 }
             }
         }
@@ -504,21 +501,20 @@ private fun CameraItem(
                 tint = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.size(24.dp)
             )
-            Spacer(modifier = Modifier.width(12.dp))
+            Spacer(modifier = Modifier.width(AppSpacing.md))
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = camera.name,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold
+                    style = AppTypography.factHeader
                 )
                 Text(
                     text = camera.fullName,
-                    style = MaterialTheme.typography.bodyMedium,
+                    style = AppTypography.bodySecondary,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         }
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(AppSpacing.sm))
         Text(
             text = camera.description,
             style = MaterialTheme.typography.bodySmall,
@@ -530,18 +526,18 @@ private fun CameraItem(
 @Composable
 private fun MissionObjectives(objectives: List<String>) {
     AppCard(modifier = Modifier.fillMaxWidth()) {
-        Column(modifier = Modifier.padding(16.dp)) {
+        Column(modifier = Modifier.padding(AppSpacing.lg)) {
             objectives.forEach { objective ->
-                Row(modifier = Modifier.padding(vertical = 4.dp)) {
+                Row(modifier = Modifier.padding(vertical = AppSpacing.xs)) {
                     Text(
                         text = "•",
-                        style = MaterialTheme.typography.bodyLarge,
+                        style = AppTypography.body,
                         color = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.padding(end = 8.dp)
+                        modifier = Modifier.padding(end = AppSpacing.sm)
                     )
                     Text(
                         text = objective,
-                        style = MaterialTheme.typography.bodyLarge
+                        style = AppTypography.body
                     )
                 }
             }
@@ -558,13 +554,13 @@ private fun FunFacts(facts: List<String>) {
             contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
         ),
     ) {
-        Column(modifier = Modifier.padding(16.dp)) {
+        Column(modifier = Modifier.padding(AppSpacing.lg)) {
             facts.forEach { fact ->
-                Row(modifier = Modifier.padding(vertical = 4.dp)) {
-                    Text(text = "✨", modifier = Modifier.padding(end = 8.dp))
+                Row(modifier = Modifier.padding(vertical = AppSpacing.xs)) {
+                    Text(text = "✨", modifier = Modifier.padding(end = AppSpacing.sm))
                     Text(
                         text = fact,
-                        style = MaterialTheme.typography.bodyLarge
+                        style = AppTypography.body
                     )
                 }
             }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoversScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoversScreen.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sirelon.marsroverphotos.domain.models.Rover
+import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
+import com.sirelon.marsroverphotos.presentation.theme.AppTypography
 import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbol
 import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbolIcon
 import com.sirelon.marsroverphotos.presentation.ui.painter
@@ -72,9 +74,9 @@ fun RoversContent(
     LazyVerticalGrid(
         columns = GridCells.Adaptive(minSize = 360.dp),
         modifier = modifier,
-        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
+        contentPadding = PaddingValues(horizontal = AppSpacing.md, vertical = AppSpacing.sm),
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.sm),
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm)
     ) {
         items(rovers, key = { it.id }) { item ->
             RoverItem(
@@ -95,14 +97,14 @@ fun RoverItem(
     modifier: Modifier = Modifier
 ) {
     AppCard(
-        modifier = modifier.padding(8.dp),
+        modifier = modifier.padding(AppSpacing.sm),
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
                 .fillMaxWidth()
                 .clickable(onClick = { onClick(rover) })
-                .padding(8.dp)
+                .padding(AppSpacing.sm)
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -123,7 +125,7 @@ fun RoverItem(
             }
             InfoText(label = "Status:", text = rover.status)
 
-            Row(modifier = Modifier.padding(8.dp)) {
+            Row(modifier = Modifier.padding(AppSpacing.sm)) {
                 Image(
                     contentScale = ContentScale.FillHeight,
                     painter = rover.painter(),
@@ -133,7 +135,7 @@ fun RoverItem(
                         .clip(shape = MaterialTheme.shapes.large),
                     contentDescription = rover.name
                 )
-                Spacer(modifier = Modifier.width(8.dp))
+                Spacer(modifier = Modifier.width(AppSpacing.sm))
                 Column(
                     modifier = Modifier.weight(1f),
                     verticalArrangement = Arrangement.SpaceAround
@@ -156,7 +158,7 @@ fun RoverItem(
 private fun TitleText(text: String) {
     Text(
         text = text,
-        style = MaterialTheme.typography.headlineMedium,
+        style = AppTypography.roverTitle,
         color = MaterialTheme.colorScheme.secondary,
         maxLines = 1,
         overflow = TextOverflow.Ellipsis
@@ -165,14 +167,13 @@ private fun TitleText(text: String) {
 
 @Composable
 private fun InfoText(label: String, text: String) {
-    val typography = MaterialTheme.typography
     Column(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
             text = label,
-            style = typography.titleMedium,
+            style = AppTypography.infoLabel,
             color = MaterialTheme.colorScheme.secondary,
             textAlign = TextAlign.Center,
             maxLines = 2,
@@ -181,7 +182,7 @@ private fun InfoText(label: String, text: String) {
         )
         Text(
             text = text,
-            style = typography.titleSmall,
+            style = AppTypography.infoValue,
             color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center,
             maxLines = 1,

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/UkraineScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/UkraineScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
+import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
+import com.sirelon.marsroverphotos.presentation.theme.AppTypography
 import com.sirelon.marsroverphotos.platform.Tracker
 import com.sirelon.marsroverphotos.platform.recordException
 import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbol
@@ -92,14 +94,14 @@ private fun UkraineInfoContent(
     onOpenUri: (String) -> Unit,
 ) {
     Column(
-        modifier = Modifier.padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.padding(AppSpacing.lg),
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.sm),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
             text = "Hello, I'm Oleksandr, a proud Ukrainian",
             textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.headlineSmall,
+            style = AppTypography.appTitle,
         )
         Text(
             text = "As you may be aware, Ukraine is currently facing a severe and merciless war. " +

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/AppSpacing.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/AppSpacing.kt
@@ -1,0 +1,39 @@
+package com.sirelon.marsroverphotos.presentation.theme
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Mars Rover Photos spacing scale — 8dp grid.
+ *
+ * Token → dp mapping follows the CSS design tokens in colors_and_type.css:
+ *   xs  =  4dp  (--space-1) — icon inner padding, tiny gaps
+ *   sm  =  8dp  (--space-2) — component gaps, tile inner padding
+ *   md  = 12dp  (--space-3) — content horizontal padding in grid
+ *   lg  = 16dp  (--space-4) — card padding, screen horizontal padding
+ *   xl  = 24dp  (--space-5) — section gap
+ *   xxl = 32dp  (--space-6) — empty-state padding
+ *   x3l = 48dp  (--space-7) — large layout gaps
+ */
+object AppSpacing {
+    /** 4dp — icon padding, hairline gaps. */
+    val xs: Dp = 4.dp
+
+    /** 8dp — between items in a row/column, tile inner padding. */
+    val sm: Dp = 8.dp
+
+    /** 12dp — horizontal content padding in photo grid. */
+    val md: Dp = 12.dp
+
+    /** 16dp — card padding, screen horizontal margin. */
+    val lg: Dp = 16.dp
+
+    /** 24dp — between sections on a content screen. */
+    val xl: Dp = 24.dp
+
+    /** 32dp — large breathing room, empty-state padding. */
+    val xxl: Dp = 32.dp
+
+    /** 48dp — hero / illustration vertical clearance. */
+    val x3l: Dp = 48.dp
+}

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/AppTypography.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/AppTypography.kt
@@ -1,0 +1,90 @@
+package com.sirelon.marsroverphotos.presentation.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+
+/**
+ * Semantic typography shortcuts for the Mars Rover Photos design system.
+ *
+ * Each property is a named alias that maps a product-level intent to a slot
+ * in the Material 3 type scale. Colours are NOT baked in here — apply them
+ * at the call site using [MaterialTheme.colorScheme] so that light/dark
+ * themes work correctly.
+ *
+ * All getters are [@Composable] + [@ReadOnlyComposable] so they must be
+ * accessed inside a composable function, exactly like [MaterialTheme.typography].
+ *
+ * Usage:
+ * ```
+ * Text(text = rover.name, style = AppTypography.roverTitle,
+ *      color = MaterialTheme.colorScheme.secondary)
+ * ```
+ */
+object AppTypography {
+
+    /** Rover name / screen-level title — headlineMedium. */
+    val roverTitle: TextStyle
+        @Composable @ReadOnlyComposable get() =
+            MaterialTheme.typography.headlineMedium
+
+    /** Section header inside a detail screen (e.g. "Mission Timeline") — titleLarge bold. */
+    val sectionHeader: TextStyle
+        @Composable @ReadOnlyComposable get() =
+            MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
+
+    /** Label in a key–value info pair (e.g. "Status:") — titleMedium. */
+    val infoLabel: TextStyle
+        @Composable @ReadOnlyComposable get() =
+            MaterialTheme.typography.titleMedium
+
+    /** Value in a key–value info pair — titleSmall. */
+    val infoValue: TextStyle
+        @Composable @ReadOnlyComposable get() =
+            MaterialTheme.typography.titleSmall
+
+    /**
+     * Photo / camera caption beneath a grid tile — bodySmall.
+     * Typically rendered in [MaterialTheme.colorScheme.secondary] (coral).
+     */
+    val photoCaption: TextStyle
+        @Composable @ReadOnlyComposable get() =
+            MaterialTheme.typography.bodySmall
+
+    /** Stat card value (e.g. "320K") — titleLarge bold. */
+    val statValue: TextStyle
+        @Composable @ReadOnlyComposable get() =
+            MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
+
+    /** Stat card label (e.g. "Total Photos") — labelMedium. */
+    val statLabel: TextStyle
+        @Composable @ReadOnlyComposable get() =
+            MaterialTheme.typography.labelMedium
+
+    /** Primary body text (facts, descriptions) — bodyLarge. */
+    val body: TextStyle
+        @Composable @ReadOnlyComposable get() =
+            MaterialTheme.typography.bodyLarge
+
+    /** Secondary / supporting body text — bodyMedium. */
+    val bodySecondary: TextStyle
+        @Composable @ReadOnlyComposable get() =
+            MaterialTheme.typography.bodyMedium
+
+    /** "Did You Know?" card header — titleMedium bold. */
+    val factHeader: TextStyle
+        @Composable @ReadOnlyComposable get() =
+            MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+
+    /** Small label (e.g. timeline milestone label) — labelSmall bold. */
+    val milestoneLabel: TextStyle
+        @Composable @ReadOnlyComposable get() =
+            MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold)
+
+    /** Large app-title or display text — headlineSmall. */
+    val appTitle: TextStyle
+        @Composable @ReadOnlyComposable get() =
+            MaterialTheme.typography.headlineSmall
+}

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/MarsImage.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/MarsImage.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.Box
+import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
 import coil3.compose.AsyncImage
@@ -62,7 +63,7 @@ fun MarsImageComposable(
     val showStats = state is AsyncImagePainter.State.Success
     AppCard(
         modifier = modifier
-            .padding(vertical = 8.dp)
+            .padding(vertical = AppSpacing.sm)
             .fillMaxWidth()
             .clickable(onClick = onClick),
     ) {
@@ -94,7 +95,7 @@ fun PhotoStats(
 
     Column(
         modifier = modifier
-            .padding(horizontal = 8.dp, vertical = 4.dp)
+            .padding(horizontal = AppSpacing.sm, vertical = AppSpacing.xs)
             .fillMaxWidth(),
     ) {
         Row(
@@ -137,7 +138,7 @@ private fun LikeAction(
             tint = tint,
             size = 22.dp,
         )
-        Spacer(modifier = Modifier.width(8.dp))
+        Spacer(modifier = Modifier.width(AppSpacing.sm))
         Text(
             text = if (count > 0) "Like · ${compactCount(count)}" else "Like",
             style = MaterialTheme.typography.labelLarge,

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/widgets.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/widgets.kt
@@ -14,10 +14,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
 
 /**
- * Custom Snackbar component for Mars Rover Photos app.
- * Displays messages with optional action button.
+ * Design-system snackbar with an optional action button.
  *
  * @param modifier Modifier for the snackbar host
  * @param snackbarHostState State controlling the snackbar
@@ -72,8 +72,8 @@ fun RadioButtonText(
     Column(
         modifier = modifier
             .clickable(onClick = onClick)
-            .padding(all = 16.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+            .padding(all = AppSpacing.lg),
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)
     ) {
         RadioButton(
             modifier = Modifier.align(Alignment.CenterHorizontally),


### PR DESCRIPTION
## Summary

- Introduces `AppSpacing` (8dp grid tokens: `xs`/`sm`/`md`/`lg`/`xl`/`xxl`/`x3l`) and `AppTypography` (semantic M3 type-scale aliases: `roverTitle`, `sectionHeader`, `infoLabel`, `statValue`, `photoCaption`, etc.) in `presentation/theme/`.
- Replaces inline `dp` literals in padding/spacing contexts and `MaterialTheme.typography.*` references across all 10 screen and UI files with the new tokens.
- Non-grid sizes (image dimensions, elevation values) and ambiguous typography usages are left unchanged.

## Test plan

- [ ] Build passes: `./gradlew :shared:compileKotlinIosArm64`
- [ ] Visual inspection: rovers list, photo grid, mission info, about screen — all spacing and text styles render as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)