### PR TITLE
Add photos filters bottom sheet and camera toggles

### DIFF
--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/RoverFeedPager.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/RoverFeedPager.kt
@@ -36,7 +36,7 @@ class RoverFeedPager(
         val anchorSol: Long,
         val minSol: Long,
         val maxSol: Long,
-        val camera: String?,
+        val cameras: Set<String>,
         /**
          * Monotonic token making every explicit [setFeed] distinct. Without it, re-anchoring to
          * the *current* sol (e.g. re-picking the same date after scrolling away, or re-randomizing
@@ -83,7 +83,7 @@ class RoverFeedPager(
                         photosRepository = photosRepository,
                         imagesDao = imagesDao,
                         roverId = p.roverId,
-                        camera = p.camera,
+                        cameras = p.cameras,
                         initialSol = p.anchorSol,
                         minSol = p.minSol,
                         maxSol = p.maxSol,
@@ -93,13 +93,13 @@ class RoverFeedPager(
         }
         .cachedIn(appScope)
 
-    fun setFeed(roverId: Long, anchorSol: Long, minSol: Long, maxSol: Long, camera: String?) {
+    fun setFeed(roverId: Long, anchorSol: Long, minSol: Long, maxSol: Long, cameras: Set<String>) {
         paramsFlow.value = Params(
             roverId = roverId,
             anchorSol = anchorSol,
             minSol = minSol,
             maxSol = maxSol,
-            camera = camera,
+            cameras = cameras,
             generation = generation++,
         )
     }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/SolPagingSource.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/SolPagingSource.kt
@@ -41,7 +41,7 @@ class SolPagingSource(
     private val photosRepository: PhotosRepository,
     private val imagesDao: ImagesDao,
     private val roverId: Long,
-    private val camera: String?,
+    private val cameras: Set<String>,
     private val initialSol: Long,
     private val minSol: Long,
     private val maxSol: Long,
@@ -59,27 +59,40 @@ class SolPagingSource(
     override suspend fun load(params: LoadParams<Long>): LoadResult<Long, MarsImage> {
         return try {
             when (params) {
-                is LoadParams.Append -> when (val r = findDay(params.key, step = +1)) {
-                    is FindResult.Found -> r.day.toPage()
-                    // Budget hit, not the bound: keep the forward key so the next load resumes.
-                    is FindResult.Exhausted ->
-                        continuationPage(prevKey = null, nextKey = clampMax(r.nextSol))
-                    FindResult.End -> terminalPage()
-                }
-
-                is LoadParams.Prepend -> when (val r = findDay(params.key, step = -1)) {
-                    is FindResult.Found -> r.day.toPage()
-                    // Budget hit, not the bound: keep the backward key so the next load resumes.
-                    is FindResult.Exhausted ->
-                        continuationPage(prevKey = clampMin(r.nextSol), nextKey = null)
-                    FindResult.End -> terminalPage()
-                }
-
+                is LoadParams.Append -> findNextPage(params.key, step = +1)
+                is LoadParams.Prepend -> findNextPage(params.key, step = -1)
                 is LoadParams.Refresh -> loadRefresh(params.key ?: initialSol)
             }
         } catch (e: Exception) {
             Logger.e("SolPagingSource", e) { "Error loading sol page (rover=$roverId)" }
             LoadResult.Error(e)
+        }
+    }
+
+    /**
+     * Finds the next non-empty page in [step] direction.
+     *
+     * For unfiltered feeds: returns a continuation page on budget exhaustion so each [load]
+     * call is bounded. Paging 3 auto-enqueues another load from the continuation key.
+     *
+     * For camera-filtered feeds: loops within the same [load] call instead of returning an
+     * empty continuation page. Per the class-level comment, Paging 3 does not reliably
+     * re-trigger loads after empty pages, which would stall filtered pagination.
+     */
+    private suspend fun findNextPage(start: Long, step: Int): LoadResult<Long, MarsImage> {
+        var key = start
+        while (true) {
+            when (val r = findDay(key, step)) {
+                is FindResult.Found -> return r.day.toPage()
+                is FindResult.Exhausted -> {
+                    if (cameras.isEmpty()) {
+                        return if (step > 0) continuationPage(prevKey = null, nextKey = clampMax(r.nextSol))
+                        else continuationPage(prevKey = clampMin(r.nextSol), nextKey = null)
+                    }
+                    key = r.nextSol
+                }
+                FindResult.End -> return terminalPage()
+            }
         }
     }
 
@@ -127,7 +140,7 @@ class SolPagingSource(
             // camera-aware for every rover — Perseverance/Insight raw APIs ignore the camera param.
             val photos = photosRepository
                 .refreshImages(PhotosQueryRequest(roverId, sol, camera = null))
-                .filterByCamera(camera)
+                .filterByCameras(cameras)
             probes++
             if (photos.isNotEmpty()) {
                 return FindResult.Found(Day(sol, cacheAndMerge(photos)))
@@ -144,7 +157,7 @@ class SolPagingSource(
      * returns a continuation page so the next load resumes the scan.
      */
     private val scanBudget: Int
-        get() = if (camera.isNullOrBlank()) UNFILTERED_SCAN_BUDGET else FILTER_SCAN_BUDGET
+        get() = if (cameras.isEmpty()) UNFILTERED_SCAN_BUDGET else FILTER_SCAN_BUDGET
 
     private fun Day.toPage(): LoadResult.Page<Long, MarsImage> = LoadResult.Page(
         data = photos,
@@ -191,13 +204,30 @@ class SolPagingSource(
         }
     }
 
-    /** In-memory camera filter matching [RoverCamera.name] or [RoverCamera.fullName]. */
-    private fun List<MarsImage>.filterByCamera(camera: String?): List<MarsImage> {
-        if (camera.isNullOrBlank()) return this
+    /**
+     * In-memory camera filter.
+     *
+     * Standard rovers (Curiosity, Opportunity, Spirit) return abbreviated camera names in
+     * [RoverCamera.name] (e.g. "FHAZ"), so a direct name equality check is sufficient.
+     *
+     * Perseverance returns a compact instrument identifier in [RoverCamera.fullName]
+     * (e.g. "FRONT_HAZCAM_LEFT_A", "NAVCAM_LEFT", "MCZ_RIGHT"). The [RoverMissionData]
+     * spec's [fullName][CameraSpec.fullName] is stored as a prefix of those identifiers
+     * (e.g. "FRONT_HAZCAM", "NAVCAM", "MCZ"), so we use a startsWith check.
+     */
+    private fun List<MarsImage>.filterByCameras(cameras: Set<String>): List<MarsImage> {
+        if (cameras.isEmpty()) return this
+        val specsByName = com.sirelon.marsroverphotos.domain.models.mission.RoverMissionData
+            .getCamerasForRover(roverId)
+            .associateBy { it.name.uppercase() }
         return filter { image ->
             val cam = image.camera ?: return@filter false
-            cam.name.equals(camera, ignoreCase = true) ||
-                cam.fullName.equals(camera, ignoreCase = true)
+            cameras.any { filter ->
+                val spec = specsByName[filter.uppercase()]
+                cam.name.equals(filter, ignoreCase = true) ||
+                    cam.fullName.equals(filter, ignoreCase = true) ||
+                    (spec != null && cam.fullName.startsWith(spec.fullName, ignoreCase = true))
+            }
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/di/NavigationModule.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/di/NavigationModule.kt
@@ -41,6 +41,7 @@ val navigationModule = module {
             source = destination.source,
             roverId = destination.roverId,
             camera = destination.camera,
+            cameras = destination.cameras,
             onBack = { navigator.goBack() }
         )
     }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/domain/models/mission/RoverMissionData.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/domain/models/mission/RoverMissionData.kt
@@ -117,42 +117,45 @@ object RoverMissionData {
         )
     )
 
+    // fullName values are prefixes of the instrument identifiers the NASA Mars 2020 API
+    // returns in the "instrument" field (e.g. "FRONT_HAZCAM_LEFT_A", "NAVCAM_LEFT").
+    // filterByCameras uses startsWith matching against these prefixes.
     private val perseveranceCameras = listOf(
         CameraSpec(
             name = "FHAZ",
-            fullName = "Front Hazard Avoidance Camera",
+            fullName = "FRONT_HAZCAM",
             description = "Mounted on the rover's lower front, detects hazards in the path ahead"
         ),
         CameraSpec(
             name = "RHAZ",
-            fullName = "Rear Hazard Avoidance Camera",
+            fullName = "REAR_HAZCAM",
             description = "Mounted on the rover's lower rear, monitors the area behind the rover"
         ),
         CameraSpec(
             name = "NAVCAM",
-            fullName = "Navigation Camera",
+            fullName = "NAVCAM",
             description = "Stereo cameras for 3D terrain mapping and navigation planning"
         ),
         CameraSpec(
             name = "MCZ",
-            fullName = "Mastcam-Z",
+            fullName = "MCZ",
             description = "Zoomable stereo color camera system on the mast"
         ),
         CameraSpec(
             name = "SHERLOC",
-            fullName = "Scanning Habitable Environments with Raman & Luminescence for Organics & Chemicals",
-            description = "Spectrometer and imaging system on the robotic arm"
+            fullName = "SHERLOC",
+            description = "Arm-mounted close-up imager for rock and soil imaging"
         ),
         CameraSpec(
             name = "SUPERCAM",
-            fullName = "SuperCam",
+            fullName = "SUPERCAM",
             description = "Remote sensing instrument with camera, laser, and spectrometers"
         ),
         CameraSpec(
-            name = "EDL",
-            fullName = "Entry, Descent, and Landing Cameras",
-            description = "Multiple cameras captured the landing sequence"
-        )
+            name = "SKYCAM",
+            fullName = "SKYCAM",
+            description = "Sky-facing camera for atmospheric imaging"
+        ),
     )
 
     private val insightCameras = listOf(

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/domain/settings/AppSettings.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/domain/settings/AppSettings.kt
@@ -17,10 +17,14 @@ class AppSettings(
         const val KEY_THEME = "theme"
         const val KEY_GRID_VIEW = "gridView"
         const val KEY_SHOW_FACTS = "showFacts"
+        const val KEY_SHOW_CAMERA_NAME = "showCameraName"
     }
 
     private val _showFactsFlow = MutableStateFlow(preferences.getBoolean(KEY_SHOW_FACTS, true))
     val showFactsFlow: StateFlow<Boolean> = _showFactsFlow.asStateFlow()
+
+    private val _showCameraNameFlow = MutableStateFlow(preferences.getBoolean(KEY_SHOW_CAMERA_NAME, true))
+    val showCameraNameFlow: StateFlow<Boolean> = _showCameraNameFlow.asStateFlow()
 
     private val _gridViewFlow = MutableStateFlow(preferences.getBoolean(KEY_GRID_VIEW, false))
     val gridViewFlow: StateFlow<Boolean> = _gridViewFlow.asStateFlow()
@@ -36,6 +40,16 @@ class AppSettings(
         set(value) {
             preferences.setBoolean(KEY_SHOW_FACTS, value)
             _showFactsFlow.value = value
+        }
+
+    /**
+     * Show or hide the camera name on photo cards.
+     */
+    var showCameraName: Boolean
+        get() = preferences.getBoolean(KEY_SHOW_CAMERA_NAME, true)
+        set(value) {
+            preferences.setBoolean(KEY_SHOW_CAMERA_NAME, value)
+            _showCameraNameFlow.value = value
         }
 
     /**

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppDestinations.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppDestinations.kt
@@ -59,4 +59,8 @@ sealed interface AppDestination : NavKey {
     /** Dialog destination: Earth date picker. Shares PhotosViewModel with [Photos]. */
     @Serializable
     data class PhotosEarthDatePicker(val roverId: Long) : DialogDestination
+
+    /** Dialog destination: filters sheet (camera, date, appearance). Shares PhotosViewModel with [Photos]. */
+    @Serializable
+    data class PhotosFilters(val roverId: Long) : DialogDestination
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppDestinations.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppDestinations.kt
@@ -33,8 +33,10 @@ sealed interface AppDestination : NavKey {
         val source: ImagesSource = ImagesSource.DIRECT_IDS,
         /** Set for [ImagesSource.ROVER_FEED] — the rover whose shared feed the pager scrolls. */
         val roverId: Long? = null,
-        /** Set for [ImagesSource.ROVER_FEED] when opened from a camera-filtered photos feed. */
+        /** Legacy single-camera filter for [ImagesSource.ROVER_FEED]. */
         val camera: String? = null,
+        /** Active camera filters for [ImagesSource.ROVER_FEED] when opened from Photos. */
+        val cameras: Set<String> = emptySet(),
     ) : AppDestination
 
     @Serializable

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppNavigation.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppNavigation.kt
@@ -31,6 +31,7 @@ import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import androidx.navigation3.runtime.NavEntry
 import com.sirelon.marsroverphotos.presentation.screens.EarthDatePickerScreen
+import com.sirelon.marsroverphotos.presentation.screens.PhotosFiltersScreen
 import com.sirelon.marsroverphotos.presentation.screens.PhotosScreen
 import com.sirelon.marsroverphotos.presentation.screens.SolPickerScreen
 import org.koin.compose.koinInject
@@ -97,6 +98,9 @@ fun AppNavigation(
                     onOpenEarthDatePicker = {
                         navigator.navigate(AppDestination.PhotosEarthDatePicker(key.roverId))
                     },
+                    onOpenFilters = {
+                        navigator.navigate(AppDestination.PhotosFilters(key.roverId))
+                    },
                 )
             }
 
@@ -121,6 +125,25 @@ fun AppNavigation(
                 EarthDatePickerScreen(
                     viewModel = koinViewModel(viewModelStoreOwner = LocalSharedViewModelStoreOwner.current),
                     onDismiss = { navigator.goBack() },
+                )
+            }
+
+            is AppDestination.PhotosFilters -> NavEntry<NavKey>(
+                key = key,
+                contentKey = "${photosContentKey(key.roverId)}/filters",
+                metadata = SharedViewModelStoreNavEntryDecorator.parent(photosContentKey(key.roverId)) +
+                    DialogOverlaySceneStrategy.dialogOverlay(),
+            ) {
+                PhotosFiltersScreen(
+                    viewModel = koinViewModel(viewModelStoreOwner = LocalSharedViewModelStoreOwner.current),
+                    roverId = key.roverId,
+                    onDismiss = { navigator.goBack() },
+                    onOpenSolPicker = {
+                        navigator.replaceTop(AppDestination.PhotosSolPicker(key.roverId))
+                    },
+                    onOpenEarthDatePicker = {
+                        navigator.replaceTop(AppDestination.PhotosEarthDatePicker(key.roverId))
+                    },
                 )
             }
 
@@ -246,7 +269,8 @@ private fun AppDestination.topLevelDestination(): AppDestination {
         is AppDestination.Mission,
         AppDestination.Ukraine,
         is AppDestination.PhotosSolPicker,
-        is AppDestination.PhotosEarthDatePicker -> AppDestination.Rovers
+        is AppDestination.PhotosEarthDatePicker,
+        is AppDestination.PhotosFilters -> AppDestination.Rovers
 
         AppDestination.Favorite -> AppDestination.Favorite
         AppDestination.Popular -> AppDestination.Popular
@@ -261,6 +285,7 @@ private val AppDestination.analyticsTag: String
         AppDestination.Popular -> "popular"
         AppDestination.About -> "about"
         AppDestination.Ukraine -> "ukraine"
+        is AppDestination.PhotosFilters -> "photos_filters"
         else -> "other"
     }
 
@@ -277,6 +302,7 @@ private val navBackStackConfiguration = SavedStateConfiguration {
             subclass(AppDestination.Ukraine::class, AppDestination.Ukraine.serializer())
             subclass(AppDestination.PhotosSolPicker::class, AppDestination.PhotosSolPicker.serializer())
             subclass(AppDestination.PhotosEarthDatePicker::class, AppDestination.PhotosEarthDatePicker.serializer())
+            subclass(AppDestination.PhotosFilters::class, AppDestination.PhotosFilters.serializer())
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppNavigation.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppNavigation.kt
@@ -82,12 +82,13 @@ fun AppNavigation(
                 PhotosScreen(
                     roverId = key.roverId,
                     cameraFilter = key.camera,
-                    onNavigateToImages = { clickedId ->
+                    onNavigateToImages = { clickedId, cameras ->
                         navigator.navigate(
                             AppDestination.Images(
                                 selectedId = clickedId,
                                 roverId = key.roverId,
                                 camera = key.camera,
+                                cameras = cameras,
                                 source = AppDestination.ImagesSource.ROVER_FEED,
                             )
                         )

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
@@ -98,7 +98,8 @@ import org.koin.compose.viewmodel.koinViewModel
  * @param selectedId  Which ID to land on initially (null → first page).
  * @param source      Where images are loaded from.
  * @param roverId     Rover id used to restore [AppDestination.ImagesSource.ROVER_FEED] after recreation.
- * @param camera      Camera filter used to restore [AppDestination.ImagesSource.ROVER_FEED] after recreation.
+ * @param camera      Legacy single-camera filter used to restore [AppDestination.ImagesSource.ROVER_FEED].
+ * @param cameras     Active camera filters used to restore [AppDestination.ImagesSource.ROVER_FEED].
  * @param onBack      Navigate back.
  */
 @Composable
@@ -108,6 +109,7 @@ fun ImagesScreen(
     source: AppDestination.ImagesSource,
     roverId: Long? = null,
     camera: String? = null,
+    cameras: Set<String> = emptySet(),
     onBack: () -> Unit,
     viewModel: ImageViewModel = koinViewModel(),
 ) {
@@ -117,13 +119,14 @@ fun ImagesScreen(
         return
     }
 
-    LaunchedEffect(photoIds, selectedId, source, roverId, camera) {
+    LaunchedEffect(photoIds, selectedId, source, roverId, camera, cameras) {
         viewModel.setImageSource(
             source = source,
             ids = photoIds,
             selectedId = selectedId,
             roverId = roverId,
             camera = camera,
+            cameras = cameras,
         )
     }
 

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosFiltersScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosFiltersScreen.kt
@@ -1,0 +1,159 @@
+package com.sirelon.marsroverphotos.presentation.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.sirelon.marsroverphotos.domain.models.mission.RoverMissionData
+import com.sirelon.marsroverphotos.domain.settings.AppSettings
+import com.sirelon.marsroverphotos.presentation.viewmodels.PhotosViewModel
+import org.koin.compose.koinInject
+
+/**
+ * Filters bottom sheet — camera selection, date navigation shortcuts, and appearance toggles.
+ * Camera selection is staged locally; changes only take effect when Apply is tapped.
+ * Shares [PhotosViewModel] with the Photos back-stack entry via [LocalSharedViewModelStoreOwner].
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun PhotosFiltersScreen(
+    viewModel: PhotosViewModel,
+    roverId: Long,
+    onDismiss: () -> Unit,
+    onOpenSolPicker: () -> Unit,
+    onOpenEarthDatePicker: () -> Unit,
+    appSettings: AppSettings = koinInject(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val cameras = RoverMissionData.getCamerasForRover(roverId)
+
+    // Pending camera selection — committed only when Apply is tapped.
+    var pendingCameras by remember(uiState.cameraFilters) { mutableStateOf(uiState.cameraFilters) }
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = "Filters",
+                style = MaterialTheme.typography.headlineSmall,
+            )
+
+            // ── Camera ──────────────────────────────────────────────────────────
+            if (cameras.isNotEmpty()) {
+                Text(
+                    text = "Camera",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    FilterChip(
+                        selected = pendingCameras.isEmpty(),
+                        onClick = { pendingCameras = emptySet() },
+                        label = { Text("All") },
+                    )
+                    cameras.forEach { camera ->
+                        val selected = camera.name in pendingCameras
+                        FilterChip(
+                            selected = selected,
+                            onClick = {
+                                pendingCameras = if (selected) {
+                                    pendingCameras - camera.name
+                                } else {
+                                    pendingCameras + camera.name
+                                }
+                            },
+                            label = { Text(camera.name) },
+                        )
+                    }
+                }
+
+                HorizontalDivider()
+            }
+
+            // ── Date ─────────────────────────────────────────────────────────────
+            Text(
+                text = "Date",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedButton(onClick = onOpenSolPicker) {
+                    Text("Pick by Sol")
+                }
+                OutlinedButton(onClick = onOpenEarthDatePicker) {
+                    Text("Pick by Earth date")
+                }
+            }
+
+            HorizontalDivider()
+
+            // ── Appearance ───────────────────────────────────────────────────────
+            Text(
+                text = "Appearance",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = "Show camera name",
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+                Switch(
+                    checked = uiState.showCameraName,
+                    onCheckedChange = { appSettings.showCameraName = it },
+                )
+            }
+
+            HorizontalDivider()
+
+            // ── Apply ────────────────────────────────────────────────────────────
+            Spacer(modifier = Modifier.height(4.dp))
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = {
+                    viewModel.setCameraFilters(pendingCameras)
+                    onDismiss()
+                },
+            ) {
+                Text("Apply")
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -103,6 +104,7 @@ fun PhotosScreen(
     onBack: () -> Unit,
     onOpenSolPicker: () -> Unit,
     onOpenEarthDatePicker: () -> Unit,
+    onOpenFilters: () -> Unit,
     modifier: Modifier = Modifier,
     cameraFilter: String? = null,
     onClearCameraFilter: () -> Unit = {},
@@ -113,12 +115,19 @@ fun PhotosScreen(
     }
 
     LaunchedEffect(cameraFilter) {
-        viewModel.setCameraFilter(cameraFilter)
+        viewModel.setCameraFilters(if (cameraFilter != null) setOf(cameraFilter) else emptySet())
     }
 
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val pagingItems = viewModel.gridItemsFlow.collectAsLazyPagingItems()
     val gridState = rememberLazyGridState()
+
+    // Scroll to top whenever the camera filter changes so the LazyGridState's scroll position
+    // is consistent with the new PagingData. This also forces a fresh Paging 3 layout pass,
+    // which re-connects the viewport-hint mechanism that drives APPEND/PREPEND loads.
+    LaunchedEffect(state.cameraFilters) {
+        gridState.scrollToItem(0)
+    }
 
     // Keep the floating chip + pickers in sync with the top-visible day as the user scrolls.
     val currentPagingItems = rememberUpdatedState(pagingItems)
@@ -150,12 +159,15 @@ fun PhotosScreen(
         gridState = gridState,
         onRandomize = viewModel::randomize,
         onGoToLatest = viewModel::goToLatest,
-        onSetCameraFilter = viewModel::setCameraFilter,
-        onClearCameraFilter = onClearCameraFilter,
+        onClearCameraFilters = {
+            viewModel.setCameraFilters(emptySet())
+            onClearCameraFilter()
+        },
         onNavigateToImages = onNavigateToImages,
         onBack = onBack,
         onOpenSolPicker = onOpenSolPicker,
         onOpenEarthDatePicker = onOpenEarthDatePicker,
+        onOpenFilters = onOpenFilters,
         modifier = modifier,
     )
 }
@@ -173,12 +185,12 @@ private fun PhotosScreen(
     gridState: LazyGridState,
     onRandomize: () -> Unit,
     onGoToLatest: () -> Unit,
-    onSetCameraFilter: (String?) -> Unit,
-    onClearCameraFilter: () -> Unit,
+    onClearCameraFilters: () -> Unit,
     onNavigateToImages: (clickedId: String) -> Unit,
     onBack: () -> Unit,
     onOpenSolPicker: () -> Unit,
     onOpenEarthDatePicker: () -> Unit,
+    onOpenFilters: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
@@ -192,6 +204,14 @@ private fun PhotosScreen(
                 scrollBehavior = scrollBehavior,
                 title = { Text(text = state.roverName) },
                 onBack = onBack,
+                actions = {
+                    IconButton(onClick = onOpenFilters) {
+                        MaterialSymbolIcon(
+                            symbol = MaterialSymbol.Tune,
+                            contentDescription = "Filters"
+                        )
+                    }
+                }
             )
         },
         floatingActionButton = {
@@ -206,13 +226,10 @@ private fun PhotosScreen(
                 .fillMaxSize()
                 .padding(innerPadding)
         ) {
-            if (!state.cameraFilter.isNullOrBlank()) {
+            if (state.cameraFilters.isNotEmpty()) {
                 CameraFilterChip(
-                    camera = state.cameraFilter,
-                    onClear = {
-                        onSetCameraFilter(null)
-                        onClearCameraFilter()
-                    }
+                    cameras = state.cameraFilters,
+                    onClear = onClearCameraFilters,
                 )
             }
 
@@ -227,8 +244,8 @@ private fun PhotosScreen(
                     )
 
                     pagingItems.itemCount == 0 -> EmptyPhotos(
-                        title = if (!state.cameraFilter.isNullOrBlank()) {
-                            "No ${state.cameraFilter} photos near Sol ${state.sol}. Try another Sol."
+                        title = if (state.cameraFilters.isNotEmpty()) {
+                            "No ${state.cameraFilters.joinToString()} photos near Sol ${state.sol}. Try another Sol."
                         } else {
                             stringResource(Res.string.no_photos_title)
                         },
@@ -240,8 +257,8 @@ private fun PhotosScreen(
                         PhotosGrid(
                             pagingItems = pagingItems,
                             gridState = gridState,
+                            showCameraName = state.showCameraName,
                             onPhotoClick = { image -> onNavigateToImages(image.id) },
-                            onCameraClick = onSetCameraFilter,
                         )
 
                         // Floating "sticky" date chip — mirrors the top-visible day.
@@ -292,8 +309,8 @@ private fun RefreshButton(
 private fun PhotosGrid(
     pagingItems: LazyPagingItems<GridItem>,
     gridState: LazyGridState,
+    showCameraName: Boolean,
     onPhotoClick: (image: MarsImage) -> Unit,
-    onCameraClick: ((cameraName: String) -> Unit)? = null
 ) {
     LazyVerticalGrid(
         state = gridState,
@@ -324,8 +341,8 @@ private fun PhotosGrid(
             when (val item = pagingItems[index]) {
                 is GridItem.PhotoItem -> PhotoCard(
                     image = item.image,
+                    showCameraName = showCameraName,
                     onPhotoClick = onPhotoClick,
-                    onCameraClick = onCameraClick
                 )
 
                 is GridItem.DateHeader -> DateHeaderRow(header = item)
@@ -428,8 +445,8 @@ private fun EdgeProgress(modifier: Modifier = Modifier) {
 @Composable
 private fun PhotoCard(
     image: MarsImage,
+    showCameraName: Boolean,
     onPhotoClick: (image: MarsImage) -> Unit,
-    onCameraClick: ((cameraName: String) -> Unit)? = null
 ) {
     AppCard(
         modifier = Modifier
@@ -443,20 +460,17 @@ private fun PhotoCard(
                     .aspectRatio(1F),
                 imageUrl = image.imageUrl
             )
-            Text(
-                text = shortCaption(image.name.orEmpty()),
-                style = AppTypography.photoCaption,
-                color = MaterialTheme.colorScheme.secondary,
-                modifier = Modifier
-                    .padding(AppSpacing.xs)
-                    .fillMaxWidth()
-                    .then(
-                        if (onCameraClick != null && image.camera != null) {
-                            Modifier.clickable { onCameraClick(image.camera.name) }
-                        } else Modifier
-                    ),
-                textAlign = TextAlign.Center
-            )
+            if (showCameraName) {
+                Text(
+                    text = shortCaption(image.name.orEmpty()),
+                    style = AppTypography.photoCaption,
+                    color = MaterialTheme.colorScheme.secondary,
+                    modifier = Modifier
+                        .padding(AppSpacing.xs)
+                        .fillMaxWidth(),
+                    textAlign = TextAlign.Center
+                )
+            }
         }
     }
 }
@@ -524,7 +538,12 @@ private fun shortCaption(full: String): String =
     full.substringAfter(": ", missingDelimiterValue = full).trim()
 
 @Composable
-private fun CameraFilterChip(camera: String, onClear: () -> Unit) {
+private fun CameraFilterChip(cameras: Set<String>, onClear: () -> Unit) {
+    val label = if (cameras.size == 1) {
+        "Camera: ${cameras.first()} ×"
+    } else {
+        "Cameras: ${cameras.joinToString()} ×"
+    }
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -533,7 +552,7 @@ private fun CameraFilterChip(camera: String, onClear: () -> Unit) {
     ) {
         AssistChip(
             onClick = onClear,
-            label = { Text("Camera: $camera ×") },
+            label = { Text(label) },
             colors = AssistChipDefaults.assistChipColors(
                 containerColor = MaterialTheme.colorScheme.secondaryContainer,
                 labelColor = MaterialTheme.colorScheme.onSecondaryContainer
@@ -608,18 +627,17 @@ private fun PhotosScreenPreview() {
                 sol = 3200L,
                 earthDate = "Aug 5, 2015",
                 maxSol = 4000L,
-                cameraFilter = null,
             ),
             pagingItems = pagingItems,
             gridState = rememberLazyGridState(),
             onRandomize = {},
             onGoToLatest = {},
-            onSetCameraFilter = {},
-            onClearCameraFilter = {},
+            onClearCameraFilters = {},
             onNavigateToImages = {},
             onBack = {},
             onOpenSolPicker = {},
             onOpenEarthDatePicker = {},
+            onOpenFilters = {},
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
@@ -651,7 +651,7 @@ private fun PhotosScreenPreview() {
             onRandomize = {},
             onGoToLatest = {},
             onClearCameraFilters = {},
-            onNavigateToImages = {},
+            onNavigateToImages = { _, _ -> },
             onBack = {},
             onOpenSolPicker = {},
             onOpenEarthDatePicker = {},

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
@@ -102,7 +102,7 @@ import org.koin.compose.viewmodel.koinViewModel
 @Composable
 fun PhotosScreen(
     roverId: Long,
-    onNavigateToImages: (clickedId: String) -> Unit,
+    onNavigateToImages: (clickedId: String, cameras: Set<String>) -> Unit,
     onBack: () -> Unit,
     onOpenSolPicker: () -> Unit,
     onOpenEarthDatePicker: () -> Unit,
@@ -216,7 +216,7 @@ private fun PhotosScreen(
     onRandomize: () -> Unit,
     onGoToLatest: () -> Unit,
     onClearCameraFilters: () -> Unit,
-    onNavigateToImages: (clickedId: String) -> Unit,
+    onNavigateToImages: (clickedId: String, cameras: Set<String>) -> Unit,
     onBack: () -> Unit,
     onOpenSolPicker: () -> Unit,
     onOpenEarthDatePicker: () -> Unit,
@@ -288,7 +288,7 @@ private fun PhotosScreen(
                             pagingItems = pagingItems,
                             gridState = gridState,
                             showCameraName = state.showCameraName,
-                            onPhotoClick = { image -> onNavigateToImages(image.id) },
+                            onPhotoClick = { image -> onNavigateToImages(image.id, state.cameraFilters) },
                         )
 
                         // Floating "sticky" date chip — mirrors the top-visible day.

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/MaterialSymbolIcon.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/MaterialSymbolIcon.kt
@@ -49,7 +49,8 @@ enum class MaterialSymbol(val iconName: String) {
     Error("error"),
     CheckCircle("check_circle"),
     Close("close"),
-    ExpandMore("expand_more")
+    ExpandMore("expand_more"),
+    Tune("tune")
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/ImageViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/ImageViewModel.kt
@@ -96,8 +96,9 @@ class ImageViewModel(
     private fun restoreRoverFeedIfNeeded(roverId: Long?, selectedId: String?, camera: String?) {
         if (roverId == null) return
 
+        val cameras = if (camera != null) setOf(camera) else emptySet()
         val current = roverFeedPager.currentParams
-        if (current?.roverId == roverId && current.camera == camera) return
+        if (current?.roverId == roverId && current.cameras == cameras) return
 
         viewModelScope.launch {
             val rover = roversRepository.loadRoverById(roverId) ?: return@launch
@@ -110,7 +111,7 @@ class ImageViewModel(
                 anchorSol = anchorSol.coerceIn(0L, maxSol),
                 minSol = 0L,
                 maxSol = maxSol,
-                camera = camera,
+                cameras = cameras,
             )
         }
     }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/ImageViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/ImageViewModel.kt
@@ -85,20 +85,31 @@ class ImageViewModel(
         selectedId: String?,
         roverId: Long?,
         camera: String?,
+        cameras: Set<String>,
     ) {
         sourceEmitter.value = source
         idsEmitter.value = ids
         if (source == AppDestination.ImagesSource.ROVER_FEED) {
-            restoreRoverFeedIfNeeded(roverId = roverId, selectedId = selectedId, camera = camera)
+            restoreRoverFeedIfNeeded(
+                roverId = roverId,
+                selectedId = selectedId,
+                camera = camera,
+                cameras = cameras,
+            )
         }
     }
 
-    private fun restoreRoverFeedIfNeeded(roverId: Long?, selectedId: String?, camera: String?) {
+    private fun restoreRoverFeedIfNeeded(
+        roverId: Long?,
+        selectedId: String?,
+        camera: String?,
+        cameras: Set<String>,
+    ) {
         if (roverId == null) return
 
-        val cameras = if (camera != null) setOf(camera) else emptySet()
+        val effectiveCameras = if (cameras.isNotEmpty()) cameras else if (camera != null) setOf(camera) else emptySet()
         val current = roverFeedPager.currentParams
-        if (current?.roverId == roverId && current.cameras == cameras) return
+        if (current?.roverId == roverId && current.cameras == effectiveCameras) return
 
         viewModelScope.launch {
             val rover = roversRepository.loadRoverById(roverId) ?: return@launch
@@ -111,7 +122,7 @@ class ImageViewModel(
                 anchorSol = anchorSol.coerceIn(0L, maxSol),
                 minSol = 0L,
                 maxSol = maxSol,
-                cameras = cameras,
+                cameras = effectiveCameras,
             )
         }
     }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/PhotosViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/PhotosViewModel.kt
@@ -53,7 +53,7 @@ class PhotosViewModel(
 ) : ViewModel() {
 
     private val roverIdEmitter = MutableStateFlow<Long?>(null)
-    private val cameraFilterEmitter = MutableStateFlow<String?>(null)
+    private val cameraFilterEmitter = MutableStateFlow<Set<String>>(emptySet())
 
     /** Top-visible sol — drives the floating header chip and the Sol/Earth pickers. */
     private val visibleSolEmitter = MutableStateFlow<Long?>(null)
@@ -115,17 +115,19 @@ class PhotosViewModel(
         roverFlow.map { it.name to it.maxSol.coerceAtLeast(1L) },
         visibleSolEmitter.filterNotNull(),
         cameraFilterEmitter,
-    ) { roverInfo, sol, cameraFilter ->
+        appSettings.showCameraNameFlow,
+    ) { roverInfo, sol, cameraFilters, showCameraName ->
         val (roverName, maxSol) = roverInfo
         PhotosUiState(
             roverName = roverName,
             sol = sol,
             earthDate = earthDateStr(sol),
             maxSol = maxSol,
-            cameraFilter = cameraFilter,
+            cameraFilters = cameraFilters,
             datePickerSelectedMillis = earthTime(sol),
             datePickerMinMillis = minDate(),
             datePickerMaxMillis = maxDate(),
+            showCameraName = showCameraName,
         )
     }.stateIn(
         scope = viewModelScope,
@@ -168,17 +170,29 @@ class PhotosViewModel(
     }
 
     /**
-     * Set (or clear with `null`) the camera filter. Rebuilds the feed source so the empty-sol
-     * skip stays camera-aware across all rovers.
+     * Apply a set of camera filters (empty = show all). Rebuilds the feed source synchronously
+     * using the current pager params — no DB roundtrip needed.
      */
-    fun setCameraFilter(camera: String?) {
-        val normalized = camera?.takeIf { it.isNotBlank() }
-        if (cameraFilterEmitter.value == normalized) return
-        cameraFilterEmitter.value = normalized
-        viewModelScope.launch {
-            val rover = roverFlow.first()
-            val anchor = visibleSolEmitter.value ?: roverFeedPager.currentParams?.anchorSol ?: return@launch
-            applyAnchor(rover, anchor)
+    fun setCameraFilters(cameras: Set<String>) {
+        if (cameraFilterEmitter.value == cameras) return
+        cameraFilterEmitter.value = cameras
+        val params = roverFeedPager.currentParams
+        if (params != null) {
+            val anchor = (visibleSolEmitter.value ?: params.anchorSol)
+                .coerceIn(params.minSol, params.maxSol)
+            roverFeedPager.setFeed(
+                roverId = params.roverId,
+                anchorSol = anchor,
+                minSol = params.minSol,
+                maxSol = params.maxSol,
+                cameras = cameras,
+            )
+        } else {
+            viewModelScope.launch {
+                val rover = roverFlow.first()
+                val anchor = visibleSolEmitter.value ?: return@launch
+                applyAnchor(rover, anchor)
+            }
         }
     }
 
@@ -277,7 +291,7 @@ class PhotosViewModel(
             anchorSol = clamped,
             minSol = 0L,
             maxSol = maxSol,
-            camera = cameraFilterEmitter.value,
+            cameras = cameraFilterEmitter.value,
         )
     }
 
@@ -307,11 +321,13 @@ data class PhotosUiState(
     /** Earth-date string for [sol] (e.g. "Jan 15, 2021"). */
     val earthDate: String = "",
     val maxSol: Long = 1L,
-    val cameraFilter: String? = null,
+    val cameraFilters: Set<String> = emptySet(),
     /** Earth-date millis for [sol] — the date-picker's initial selection. */
     val datePickerSelectedMillis: Long = 0L,
     /** Rover landing-date millis — lower bound for the date picker. */
     val datePickerMinMillis: Long = 0L,
     /** Rover last-date millis — upper bound for the date picker. */
     val datePickerMaxMillis: Long = 0L,
+    /** Whether to show the camera name label on photo cards. */
+    val showCameraName: Boolean = true,
 )


### PR DESCRIPTION
This PR adds a new Photos filters bottom sheet for camera, date picker shortcuts, and appearance controls. It migrates photo filtering from a single camera to a multi-camera set and updates paging/feed wiring so filtered pagination keeps advancing correctly. It also adds a persisted setting to show or hide camera names on photo cards and wires it into Photos UI state. Navigation now includes a dedicated PhotosFilters dialog destination shared with the Photos ViewModel.