### PR TITLE
Redesign About screen with M3 grouped settings + design-system primitives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,15 @@ Run commands from the repository root so the Gradle wrapper can supply the pinne
 ## Coding Style & Naming Conventions
 Kotlin files use four-space indentation, `val` first, and explicit visibility for public APIs. Compose functions and classes stay in PascalCase, constants in `UPPER_SNAKE_CASE`, and extension files match their receiver (`ImageRequestExt.kt`). Keep packages cohesive; add a `feature/*` subpackage for new screens. Run `./gradlew detekt` before review instead of hand-tuning formatting.
 
+## Design System & UI/UX
+Before writing or changing any Compose UI, read **[docs/DESIGN_SYSTEM.md](docs/DESIGN_SYSTEM.md)** — the
+living design-system doc. It carries the prescriptive UI/UX rules (token usage, the `App*` component
+family, adaptive-nav ownership), a component index with file links, and the non-obvious insights
+(e.g. dark `surface` == `background`, no green slot in the M3 palette, the full Material Symbols font).
+Reuse the `App*` components in `presentation/ui/` before adding new ones; never inline raw `.dp` literals
+(use `AppSpacing` / `AppSize`) or hardcode theme colors (use `MaterialTheme.colorScheme`). **Keep the doc
+updated**: when you add a reusable component, a token, or learn a UI gotcha, record it there.
+
 ## Testing Guidelines
 Place unit specs in `shared/src/commonTest` (or `androidTest` for Android-instrumented tests), mirroring the source package and ending class names with `*Test`. Use JUnit4 and Mockito-Kotlin for Android tests. Compose UI or Room integration checks belong in `androidApp/src/androidTest` and should describe the scenario in the test name. Cover paging boundaries, offline caching, and error flows whenever you touch those areas.
 

--- a/androidApp/src/main/kotlin/com/sirelon/marsroverphotos/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/sirelon/marsroverphotos/MainActivity.kt
@@ -51,7 +51,8 @@ class MainActivity : ComponentActivity() {
                 deepLink = pendingDeepLink,
                 onDeepLinkConsumed = { pendingDeepLink = null },
                 onRateApp = ::openStoreListing,
-                appVersion = BuildConfig.VERSION_NAME
+                appVersion = BuildConfig.VERSION_NAME,
+                rateAppUrl = "https://play.google.com/store/apps/details?id=${BuildConfig.APPLICATION_ID}"
             )
         }
 

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -1,0 +1,122 @@
+# Design System — Mars Rover Photos
+
+**Living document.** Update it whenever you add a reusable UI component, a token, or learn a
+non-obvious UI/UX fact about this codebase. It exists so future sessions don't re-derive the
+conventions or reinvent components under new names. Keep entries short and prescriptive.
+
+The app is **Compose Multiplatform** (Android / iOS / Desktop; Web/WASM disabled). All shared UI
+lives in `shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/`:
+- `theme/` — color scheme, tokens (spacing, sizes, typography)
+- `ui/` — reusable design-system components (the `App*` family)
+- `navigation/` — the adaptive nav shell
+- `screens/` — feature screens (compose tokens + `ui/` components; do not put reusable widgets here)
+
+Signature look: near-black **M3 dark theme** (`#121212`), steel-blue **primary** (`#385C8A`),
+coral **accent/secondary** (`#FC6C4B`, "the Mars accent"). Light theme is white-based.
+
+---
+
+## Rules (prescriptive — follow these)
+
+### Tokens, never raw literals
+- **Spacing / padding / gaps** → `AppSpacing` (`theme/AppSpacing.kt`, 8dp grid: `xs`4 `sm`8 `md`12
+  `lg`16 `xl`24 `xxl`32 `x3l`48). Never a bare `.dp` for spacing.
+- **Component dimensions & corner radii** → `AppSize` (`theme/AppSize.kt`). Add a token here rather
+  than inlining a size literal. If a needed value is neither a grid spacing nor a clear size, prefer
+  extending `AppSize` over leaving a magic number.
+- **Type** → `AppTypography` (`theme/AppTypography.kt`) semantic aliases over the M3 type scale, or
+  `MaterialTheme.typography.*` directly (they resolve identically). Do **not** bake colors into type.
+- **Color** → always `MaterialTheme.colorScheme.*`. **No hardcoded theme colors.** The only allowed
+  exceptions are documented per-theme helpers that fill a missing M3 slot (see Insights). Apply text
+  color at the call site so light/dark both work.
+
+### Components
+- Reuse the `App*` family in `presentation/ui/` before writing new UI. If you need a variant, prefer a
+  new design-system component over a one-off in a screen file.
+- **Cards:** `AppCard` = elevated (2dp), no border. The grouped/outlined card = hairline outline +
+  `surfaceContainerHigh` fill, 16dp radius, **no elevation** — a *separate* component, never a flag on
+  `AppCard`.
+- **Naming:** design-system components are general and `App*`-prefixed (e.g. `AppCard`, `AppChip`,
+  `AppButton`). Do **not** name an app-wide reusable component after the screen it first appeared in
+  (no `Settings*`, `About*` for shared pieces). Screens own only screen-specific composition.
+- **Icons:** `MaterialSymbolIcon` + the `MaterialSymbol` enum (`ui/MaterialSymbolIcon.kt`). Render via
+  font ligatures. To add an icon, add an enum entry — the bundled font is the **full variable Material
+  Symbols Outlined set**, so standard glyphs are present (verify the ligature name if unsure).
+
+### Adaptive layout & navigation
+- The nav chrome (compact = bottom bar, medium/expanded = nav rail) is owned by **`MarsNavigationSuite`**
+  (`navigation/MarsBottomBar.kt`). Screens render **content only** — do not add your own nav or a
+  duplicate top bar for the primary destinations.
+- For content that shouldn't stretch on wide windows, constrain to a centered max width
+  (`AppSize` content-width token) rather than filling.
+
+### Process
+- Run `./gradlew detekt` before review; `./gradlew testDebugUnitTest` (JVM) and
+  `:shared:desktopTest` run the shared logic tests. There is **no Compose UI-test infra** in `shared`
+  yet — styling-only changes are verified by compile + visual smoke test, not unit tests.
+
+---
+
+## Insights / gotchas (the expensive-to-rediscover stuff)
+
+- **Dark `surface` == `background` (`#121212`).** A card filled with `colorScheme.surface` is invisible
+  against the screen in dark mode. Use a raised role (**`surfaceContainerHigh`**) for cards that must
+  lift off the background. (`surfaceColorAtElevation` is **not** available in the M3 version pinned
+  here — use the `surfaceContainer*` role family.)
+- **No green slot in the M3 palette.** The "live/connected" green is resolved per applied theme via a
+  documented luminance-based helper (`#5BBF86` dark / `#2E9E63` light), not a palette token.
+- **Theme-aware hero tint.** The About hero gradient top must be resolved per theme (deep navy in dark,
+  soft light-blue `#DCE8F6` in light) — a fixed navy looks wrong in light. Same luminance-helper pattern.
+- **Material Symbols font is the full ~10MB variable file**, not a subset — all standard glyphs render;
+  no need to fall back to vector paths for common icons.
+- **Brand color overrides survive dynamic color.** `Theme.kt` re-applies brand-critical slots
+  (secondary/coral, secondaryContainer, tertiary, primaryContainer) on top of Material You so
+  design-system components stay on-brand. Read `Theme.kt` before touching colors.
+- **Android in-app review silently no-ops in debug.** `AppReview.requestReview()` returns `true` even
+  when nothing renders (Play throttling), so any "rate" flow needs a guaranteed store-listing fallback;
+  ensure each platform shell passes a store URL.
+
+---
+
+## Component index
+
+Stable design-system pieces (path = `shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/`):
+
+| Component | File | Notes |
+| --- | --- | --- |
+| `AppCard` | `ui/AppCard.kt` | **Elevated** card (2dp), 16dp radius. `AppFactCard` = secondaryContainer fact card. |
+| `AppOutlinedCard` | `ui/AppOutlinedCard.kt` | **Non-elevated** grouped card: `surfaceContainerHigh` fill + hairline outline + 16dp radius. Exports `CardShape`. Use for grouped lists/surfaces; not a flag on `AppCard`. |
+| `AppIconBox` | `ui/AppIconBox.kt` | Tinted rounded container holding a `MaterialSymbol` (tinted container + icon). General — use anywhere a colored icon tile is needed. |
+| `AppBadge` / `StatusBadge` / `BadgeRow` | `ui/Badges.kt` | `AppBadge` = neutral outlined pill; `StatusBadge(label, color)` = colored dot + label (parameterized); `BadgeRow` = slot row composing them. |
+| `SegmentedControl<T>` | `ui/SegmentedControl.kt` | Generic pill selector with an **animated sliding** indicator (measured bounds, ~200ms emphasized tween) + **swipe/drag** to change; tap retained. API: `options, selected, onSelect, label`. |
+| `AppChip` | `ui/AppChip.kt` | secondaryContainer assist chip. |
+| `AppButton` / `AppOutlinedButton` | `ui/AppButton.kt` | Brand buttons. |
+| `MaterialSymbolIcon` + `MaterialSymbol` | `ui/MaterialSymbolIcon.kt` | Icon font; add glyphs to the enum. Default size `AppSize.iconDefault` (24dp). |
+| `MarsSnackbar` | `ui/` | Branded snackbar host. |
+| `MarsImage` | `ui/MarsImage.kt` | Coil-backed image. |
+| `MarsNavigationSuite` | `navigation/MarsBottomBar.kt` | Adaptive bottom bar ↔ nav rail (compact ↔ medium/expanded). |
+| `AppSpacing` | `theme/AppSpacing.kt` | 8dp-grid **spacing** tokens. |
+| `AppSize` | `theme/AppSize.kt` | Component **dimension/radius** tokens (icon/card/hero/content-width, etc.). |
+| `AppTypography` | `theme/AppTypography.kt` | Semantic type aliases. |
+| `MarsRoverPhotosTheme` + palettes | `theme/Theme.kt` | Color schemes, brand overrides, dynamic color. |
+
+> Settings-row primitives (`SettingsRow`, `SettingsSectionLabel`, `SettingsRowDivider`) live in
+> `ui/SettingsComponents.kt` and compose the general pieces above; they're list-row-shaped, so they
+> keep the `Settings*` name. The general building blocks (`AppIconBox`, `AppOutlinedCard`, badges) are
+> reusable beyond settings.
+
+**Adaptive centering:** to cap+center content only on large windows, use
+`currentWindowAdaptiveInfo().windowSizeClass.isWidthAtLeastBreakpoint(WIDTH_DP_EXPANDED_LOWER_BOUND)`
+(the same adaptive source as the nav suite) rather than a hand-rolled `BoxWithConstraints` threshold.
+See `AboutScreen.kt` for the pattern (full-bleed hero + content capped at `AppSize.contentMaxWidth`).
+
+---
+
+## History
+- 2026-06-03 — Created during the **About screen redesign**. Captured the dark surface==background,
+  no-green-slot, theme-aware-hero, full-icon-font, and in-app-review insights; established the
+  no-raw-`.dp` / `AppSize` rule and the "generalize, don't screen-prefix" component rule.
+- 2026-06-03 — Backfilled the component index with the pieces the About redesign generalized:
+  `AppIconBox`, `AppOutlinedCard`, `AppBadge`/`StatusBadge`/`BadgeRow`, animated+swipeable
+  `SegmentedControl<T>`, and the `AppSize` token class. Added the adaptive-centering pattern
+  (`windowSizeClass.isWidthAtLeastBreakpoint`).

--- a/shared/src/androidMain/kotlin/com/sirelon/marsroverphotos/platform/AppReview.android.kt
+++ b/shared/src/androidMain/kotlin/com/sirelon/marsroverphotos/platform/AppReview.android.kt
@@ -1,6 +1,7 @@
 package com.sirelon.marsroverphotos.platform
 
 import android.content.Context
+import android.content.pm.ApplicationInfo
 import com.google.android.play.core.ktx.launchReview
 import com.google.android.play.core.ktx.requestReview
 import com.google.android.play.core.review.ReviewException
@@ -26,6 +27,14 @@ class AndroidAppReview(
     override suspend fun requestReview(): Boolean {
         val activity = activityProvider() ?: run {
             Logger.w(TAG) { "No Activity available for in-app review" }
+            return false
+        }
+        // On debuggable builds the in-app review UI never renders (Play has no backing for the
+        // app), yet the flow still completes "successfully" — which would swallow the tap. Report
+        // "not shown" so the caller reliably falls back to the store listing.
+        val debuggable = (context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
+        if (debuggable) {
+            Logger.w(TAG) { "Debuggable build — skipping in-app review, falling back to store" }
             return false
         }
         return try {

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/AboutScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/AboutScreen.kt
@@ -1,50 +1,70 @@
 package com.sirelon.marsroverphotos.presentation.screens
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextDecoration
-import androidx.compose.ui.unit.dp
-import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
-import com.sirelon.marsroverphotos.presentation.theme.AppTypography
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.window.core.layout.WindowSizeClass.Companion.WIDTH_DP_EXPANDED_LOWER_BOUND
 import coil3.SingletonImageLoader
 import coil3.compose.LocalPlatformContext
 import com.sirelon.marsroverphotos.domain.settings.Theme
 import com.sirelon.marsroverphotos.platform.AppReview
 import com.sirelon.marsroverphotos.presentation.navigation.LocalAboutCallbacks
-import com.sirelon.marsroverphotos.presentation.ui.AppButton
-import com.sirelon.marsroverphotos.presentation.ui.AppCard
-import com.sirelon.marsroverphotos.presentation.ui.AppOutlinedButton
+import com.sirelon.marsroverphotos.presentation.theme.AppSize
+import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
+import com.sirelon.marsroverphotos.presentation.theme.primaryVariant
+import com.sirelon.marsroverphotos.presentation.ui.AppBadge
+import com.sirelon.marsroverphotos.presentation.ui.AppIconBox
+import com.sirelon.marsroverphotos.presentation.ui.AppOutlinedCard
+import com.sirelon.marsroverphotos.presentation.ui.BadgeRow
+import com.sirelon.marsroverphotos.presentation.ui.CardShape
 import com.sirelon.marsroverphotos.presentation.ui.MarsSnackbar
-import com.sirelon.marsroverphotos.presentation.ui.RadioButtonText
+import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbol
+import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbolIcon
+import com.sirelon.marsroverphotos.presentation.ui.SegmentedControl
+import com.sirelon.marsroverphotos.presentation.ui.SettingsRow
+import com.sirelon.marsroverphotos.presentation.ui.SettingsRowDivider
+import com.sirelon.marsroverphotos.presentation.ui.SettingsRowIndent
+import com.sirelon.marsroverphotos.presentation.ui.SettingsSectionLabel
+import com.sirelon.marsroverphotos.presentation.ui.StatusBadge
 import com.sirelon.marsroverphotos.presentation.ui.rememberPlatformUriHandler
 import com.sirelon.marsroverphotos.presentation.viewmodels.AboutViewModel
-import kotlinx.coroutines.launch
 import com.sirelon.marsroverphotos.shared.resources.Res
 import com.sirelon.marsroverphotos.shared.resources.alien_icon
 import kotlin.time.Clock
+import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.painterResource
@@ -89,80 +109,110 @@ private fun AboutContent(
     val appReview: AppReview = koinInject()
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
+    val colors = MaterialTheme.colorScheme
+    val live = liveColor()
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = Modifier.fillMaxSize().background(colors.background)) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = AppSpacing.lg)
                 .verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(AppSpacing.lg),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Image(
-                painter = painterResource(Res.drawable.alien_icon),
-                contentDescription = "logo"
-            )
-            Text(text = "Mars Rover Photos", style = AppTypography.appTitle)
-            Text(
-                text = "Browse photos taken by NASA's Mars rovers. Explore the red planet through the eyes of Curiosity, Opportunity, Spirit, Perseverance, and InSight.",
-                style = AppTypography.body,
-                textAlign = TextAlign.Center
-            )
+            // Hero is full-bleed: it sits outside the capped column so its gradient
+            // reaches both screen edges on every surface.
+            Hero(appVersion = appVersion, live = live)
 
+            // Settings content fills the width (minus the screen padding) until the window
+            // reaches the EXPANDED width class — the same adaptive source the navigation uses
+            // ([currentWindowAdaptiveInfo]) — beyond which it caps at [AppSize.contentMaxWidth]
+            // and centers within the parent column.
+            val expandedWidth = currentWindowAdaptiveInfo().windowSizeClass
+                .isWidthAtLeastBreakpoint(WIDTH_DP_EXPANDED_LOWER_BOUND)
+            val contentWidth = if (expandedWidth) {
+                Modifier.widthIn(max = AppSize.contentMaxWidth)
+            } else {
+                Modifier.fillMaxWidth()
+            }
             Column(
-                modifier = Modifier
-                    .padding(vertical = AppSpacing.sm)
-                    .fillMaxWidth()
+                modifier = contentWidth
+                    .padding(horizontal = AppSpacing.lg)
+                    .padding(bottom = AppSpacing.xxl),
+                verticalArrangement = Arrangement.spacedBy(AppSpacing.xl)
             ) {
-                LinkifyText(text = "API provided by ", link = "https://api.nasa.gov/")
-                LinkifyText(
-                    text = "Email: ",
-                    link = "mailto:sasha.sirelon@gmail.com",
-                    displayLink = "sasha.sirelon@gmail.com"
-                )
-                if (appVersion.isNotEmpty()) {
-                    Text(
-                        text = "Version: $appVersion",
-                        modifier = Modifier.padding(AppSpacing.xs)
+                Blurb()
+
+                SettingsSection(label = "Appearance") {
+                    ThemeRow(currentTheme = currentTheme, onThemeChange = onThemeChange)
+                    SettingsRowDivider()
+                    SettingsRow(
+                        icon = MaterialSymbol.Info,
+                        iconContainer = colors.secondaryContainer,
+                        iconTint = colors.onSecondaryContainer,
+                        label = "Fact Cards",
+                        sub = if (showFacts) "\"Did You Know?\" cards visible" else "Fact cards hidden",
+                        trailing = {
+                            Switch(checked = showFacts, onCheckedChange = onFactsToggle)
+                        }
                     )
                 }
-            }
 
-            ThemeChanger(currentTheme = currentTheme, onThemeChange = onThemeChange)
-            FactsToggle(showFacts = showFacts, onFactsToggle = onFactsToggle)
+                SettingsSection(label = "Data") {
+                    SettingsRow(
+                        icon = MaterialSymbol.Delete,
+                        iconContainer = colors.error.copy(alpha = 0.16f),
+                        iconTint = colors.error,
+                        label = "Clear Cache",
+                        sub = "Free up storage used by cached photos",
+                        onClick = {
+                            onClearCache()
+                            scope.launch { snackbarHostState.showSnackbar("Cache cleared") }
+                        }
+                    )
+                }
 
-            AppOutlinedButton(onClick = {
-                onClearCache()
-                scope.launch { snackbarHostState.showSnackbar("Cache cleared") }
-            }) {
-                Text(text = "Clear Cache")
-            }
-
-            AppButton(
-                onClick = {
-                    scope.launch {
-                        val shown = appReview.requestReview()
-                        if (!shown) {
-                            if (rateAppUrl.isNotBlank()) {
-                                uriHandler.openUri(rateAppUrl)
-                            } else {
-                                onRateApp()
+                SettingsSection(label = "Connect") {
+                    SettingsRow(
+                        icon = MaterialSymbol.Public,
+                        iconContainer = live.copy(alpha = 0.15f),
+                        iconTint = live,
+                        label = "NASA Open API",
+                        sub = "api.nasa.gov",
+                        onClick = { uriHandler.openUri("https://api.nasa.gov/") }
+                    )
+                    SettingsRowDivider()
+                    SettingsRow(
+                        icon = MaterialSymbol.Star,
+                        iconContainer = colors.secondary.copy(alpha = 0.18f),
+                        iconTint = colors.secondary,
+                        label = "Rate the App",
+                        sub = "Enjoying Mars? Leave a review",
+                        onClick = {
+                            scope.launch {
+                                val shown = appReview.requestReview()
+                                if (!shown) {
+                                    if (rateAppUrl.isNotBlank()) {
+                                        uriHandler.openUri(rateAppUrl)
+                                    } else {
+                                        onRateApp()
+                                    }
+                                }
                             }
                         }
-                    }
+                    )
+                    SettingsRowDivider()
+                    SettingsRow(
+                        icon = MaterialSymbol.Reviews,
+                        iconContainer = colors.tertiary.copy(alpha = 0.16f),
+                        iconTint = colors.tertiary,
+                        label = "Send Feedback",
+                        sub = "Report a bug or suggest a feature",
+                        onClick = { uriHandler.openUri("mailto:sasha.sirelon@gmail.com") }
+                    )
                 }
-            ) {
-                Text(text = "Rate App")
-            }
 
-            val currentYear = Clock.System.now()
-                .toLocalDateTime(TimeZone.currentSystemDefault()).year
-            Text(
-                text = "© $currentYear All rights reserved.",
-                style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier.padding(AppSpacing.lg)
-            )
+                Footer()
+            }
         }
 
         MarsSnackbar(
@@ -173,97 +223,189 @@ private fun AboutContent(
     }
 }
 
+/** Section label + grouped card — the About screen's grouped-settings glue. */
 @Composable
-private fun ThemeChanger(currentTheme: Theme, onThemeChange: (Theme) -> Unit) {
-    AppCard(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = AppSpacing.sm),
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = AppSpacing.lg)
-        ) {
-            Text(
-                modifier = Modifier.fillMaxWidth(),
-                text = "Change the app theme",
-                style = MaterialTheme.typography.titleLarge.copy(textAlign = TextAlign.Center)
-            )
-            FlowRow(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                RadioButtonText(selected = currentTheme == Theme.WHITE, onClick = { onThemeChange(Theme.WHITE) }) {
-                    Text("White")
-                }
-                RadioButtonText(selected = currentTheme == Theme.DARK, onClick = { onThemeChange(Theme.DARK) }) {
-                    Text("Dark")
-                }
-                RadioButtonText(selected = currentTheme == Theme.SYSTEM, onClick = { onThemeChange(Theme.SYSTEM) }) {
-                    Text("System")
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun FactsToggle(showFacts: Boolean, onFactsToggle: (Boolean) -> Unit) {
-    AppCard(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = AppSpacing.sm),
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = AppSpacing.lg, vertical = AppSpacing.md),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = "Educational Facts",
-                    style = MaterialTheme.typography.titleMedium
-                )
-                Text(
-                    text = "Show \"Did You Know?\" fact cards while browsing photos.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-            Switch(
-                checked = showFacts,
-                onCheckedChange = onFactsToggle
-            )
-        }
+private fun SettingsSection(label: String, content: @Composable () -> Unit) {
+    Column {
+        SettingsSectionLabel(text = label)
+        AppOutlinedCard { content() }
     }
 }
 
 /**
- * Shows a label followed by a tappable hyperlink.
- *
- * Uses [Modifier.clickable] on the link portion rather than [detectTapGestures] so the
- * tap reliably fires on iOS inside a vertically scrollable container.
+ * Live / "connected" status green. Not part of the M3 palette, so it is resolved per applied
+ * theme (dark vs light) off the background luminance — keeping it legible in both themes,
+ * matching the design's `--t-active` (#5BBF86 dark / #2E9E63 light).
  */
 @Composable
-private fun LinkifyText(text: String, link: String, displayLink: String = link) {
-    val uriHandler = rememberPlatformUriHandler()
-    val textStyle = LocalTextStyle.current
-    val colors = MaterialTheme.colorScheme
+private fun liveColor(): Color =
+    if (MaterialTheme.colorScheme.background.luminance() < 0.5f) Color(0xFF5BBF86) else Color(0xFF2E9E63)
 
-    Row(
-        modifier = Modifier.padding(AppSpacing.xs),
-        verticalAlignment = Alignment.CenterVertically
+/**
+ * Hero gradient top tint — resolved per applied theme so the gradient reads correctly in both.
+ * Dark keeps the deep navy [primaryVariant]; light uses a soft light-blue (the design's light
+ * variant, ~#DCE8F6) so the hero fades light-blue→white instead of navy→white.
+ */
+@Composable
+private fun heroTopColor(): Color =
+    if (MaterialTheme.colorScheme.background.luminance() < 0.5f) primaryVariant else Color(0xFFDCE8F6)
+
+@Composable
+private fun Hero(appVersion: String, live: Color) {
+    val colors = MaterialTheme.colorScheme
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Brush.verticalGradient(listOf(heroTopColor(), colors.background)))
+            .padding(horizontal = AppSpacing.xl)
+            .padding(top = AppSize.heroTopPadding, bottom = AppSpacing.xxl),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.lg)
     ) {
-        if (text.isNotEmpty()) {
-            Text(text = text, style = textStyle)
+        Box(contentAlignment = Alignment.Center) {
+            // Soft coral radial glow
+            Box(
+                modifier = Modifier
+                    .size(AppSize.heroGlow)
+                    .background(
+                        Brush.radialGradient(listOf(colors.secondary.copy(alpha = 0.20f), Color.Transparent)),
+                        shape = CircleShape
+                    )
+            )
+            // Thin coral ring
+            Box(
+                modifier = Modifier
+                    .size(AppSize.heroRing)
+                    .border(AppSize.hairline, colors.secondary.copy(alpha = 0.22f), CircleShape)
+            )
+            Image(
+                painter = painterResource(Res.drawable.alien_icon),
+                contentDescription = "Mars Rover Photos",
+                modifier = Modifier
+                    .size(AppSize.heroMascot)
+                    .shadow(AppSize.heroShadow, CircleShape)
+                    .clip(CircleShape)
+            )
         }
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = "Mars Rover Photos",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = colors.onBackground,
+                textAlign = TextAlign.Center
+            )
+            Spacer(Modifier.height(AppSpacing.xs))
+            Text(
+                text = "Real NASA rover photography · Red Planet direct",
+                style = MaterialTheme.typography.bodySmall,
+                color = colors.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+        }
+        BadgeRow {
+            AppBadge(text = "v$appVersion")
+            StatusBadge(label = "NASA API", color = live)
+        }
+    }
+}
+
+@Composable
+private fun Blurb() {
+    val colors = MaterialTheme.colorScheme
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(CardShape)
+            .background(colors.secondaryContainer)
+            .padding(horizontal = AppSpacing.lg, vertical = AppSpacing.lg),
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.md)
+    ) {
+        MaterialSymbolIcon(
+            symbol = MaterialSymbol.Info,
+            contentDescription = null,
+            tint = colors.onSecondaryContainer,
+            size = AppSize.iconInline
+        )
         Text(
-            text = displayLink,
-            style = textStyle.copy(textDecoration = TextDecoration.Underline),
-            color = colors.primary,
-            modifier = Modifier.clickable { uriHandler.openUri(link) }
+            text = "Discover Mars with exploration rovers! A great selection of recent and historic " +
+                "photos directly from the Red Planet. Maybe you'll even spot signs of Martian life ;-)",
+            style = MaterialTheme.typography.bodyMedium,
+            color = colors.onSecondaryContainer
+        )
+    }
+}
+
+/** Theme row: identity line + segmented control on its own line so it fits any width. */
+@Composable
+private fun ThemeRow(currentTheme: Theme, onThemeChange: (Theme) -> Unit) {
+    val colors = MaterialTheme.colorScheme
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = AppSpacing.lg, vertical = AppSize.rowVerticalPadding),
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.md)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(AppSize.rowIconGap)
+        ) {
+            AppIconBox(
+                symbol = MaterialSymbol.Tune,
+                container = colors.tertiary.copy(alpha = 0.16f),
+                tint = colors.tertiary
+            )
+            Column {
+                Text(
+                    text = "App Theme",
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium,
+                    color = colors.onSurface
+                )
+                Text(
+                    text = "Color scheme",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = colors.onSurfaceVariant
+                )
+            }
+        }
+        // Indent to align under the label (icon-box + gap).
+        Row(modifier = Modifier.padding(start = SettingsRowIndent)) {
+            SegmentedControl(
+                options = listOf(Theme.DARK, Theme.WHITE, Theme.SYSTEM),
+                selected = currentTheme,
+                onSelect = onThemeChange,
+                label = { theme ->
+                    when (theme) {
+                        Theme.DARK -> "Dark"
+                        Theme.WHITE -> "Light"
+                        Theme.SYSTEM -> "System"
+                    }
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun Footer() {
+    val colors = MaterialTheme.colorScheme
+    val currentYear = Clock.System.now()
+        .toLocalDateTime(TimeZone.currentSystemDefault()).year
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.xs)
+    ) {
+        Text(
+            text = "© $currentYear · All rights reserved",
+            style = MaterialTheme.typography.bodySmall,
+            color = colors.onSurfaceVariant
+        )
+        Text(
+            text = "Made with ♥ · Standing with 🇺🇦",
+            style = MaterialTheme.typography.labelSmall,
+            color = colors.onSurfaceVariant
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/AppSize.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/AppSize.kt
@@ -1,0 +1,68 @@
+package com.sirelon.marsroverphotos.presentation.theme
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Mars Rover Photos size scale — component dimensions and corner radii.
+ *
+ * Distinct from [AppSpacing] (gaps / padding on the 8dp grid): [AppSize] holds the fixed
+ * measurements of design-system components — icon-box size, badge dot, card radius, hero
+ * illustration sizes, content max width, etc. Reach for [AppSpacing] for spacing between things
+ * and [AppSize] for how big a thing is, so neither leaves bare `.dp` literals at the call site.
+ */
+object AppSize {
+    /** 1dp — hairline borders and dividers. */
+    val hairline: Dp = 1.dp
+
+    /** 18dp — inline icon glyph (e.g. a paragraph's leading icon). */
+    val iconInline: Dp = 18.dp
+
+    /** 20dp — standard icon glyph inside a tinted box, or a row's trailing chevron. */
+    val icon: Dp = 20.dp
+
+    /** 24dp — standard Material icon size; the default for [com.sirelon.marsroverphotos.presentation.ui.MaterialSymbolIcon]. */
+    val iconDefault: Dp = 24.dp
+
+    /** 38dp — tinted icon-box square ([com.sirelon.marsroverphotos.presentation.ui.AppIconBox]). */
+    val iconBox: Dp = 38.dp
+
+    /** 11dp — tinted icon-box corner radius. */
+    val iconBoxRadius: Dp = 11.dp
+
+    /** 6dp — status-badge status dot. */
+    val badgeDot: Dp = 6.dp
+
+    /** 3dp — segmented-control inner inset between the pill border and its segments. */
+    val segmentedControlPadding: Dp = 3.dp
+
+    /** 2dp — gap between adjacent segments in a segmented control. */
+    val segmentedControlGap: Dp = 2.dp
+
+    /** 16dp — grouped / outlined card corner radius. */
+    val cardRadius: Dp = 16.dp
+
+    /** 13dp — settings-row top/bottom padding. */
+    val rowVerticalPadding: Dp = 13.dp
+
+    /** 14dp — gap between a settings row's icon-box and its text. */
+    val rowIconGap: Dp = 14.dp
+
+    /** 840dp — max settings-content width; the column caps and centers only in the EXPANDED width class. */
+    val contentMaxWidth: Dp = 840.dp
+
+    /** 40dp — hero top breathing room above the mascot. */
+    val heroTopPadding: Dp = 40.dp
+
+    /** 100dp — hero mascot image. */
+    val heroMascot: Dp = 100.dp
+
+    /** 110dp — hero coral ring around the mascot. */
+    val heroRing: Dp = 110.dp
+
+    /** 140dp — hero coral radial glow. */
+    val heroGlow: Dp = 140.dp
+
+    /** 16dp — hero mascot drop-shadow elevation. */
+    val heroShadow: Dp = 16.dp
+}

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/AppIconBox.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/AppIconBox.kt
@@ -1,0 +1,34 @@
+package com.sirelon.marsroverphotos.presentation.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import com.sirelon.marsroverphotos.presentation.theme.AppSize
+
+/**
+ * Design-system tinted icon-box — a rounded square ([container] fill) holding a [tint]ed
+ * [MaterialSymbolIcon]. A general leading visual for list rows, settings rows, feature tiles, etc.
+ */
+@Composable
+fun AppIconBox(
+    symbol: MaterialSymbol,
+    container: Color,
+    tint: Color,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .size(AppSize.iconBox)
+            .clip(RoundedCornerShape(AppSize.iconBoxRadius))
+            .background(container),
+        contentAlignment = Alignment.Center
+    ) {
+        MaterialSymbolIcon(symbol = symbol, contentDescription = null, tint = tint, size = AppSize.icon)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/AppOutlinedCard.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/AppOutlinedCard.kt
@@ -1,0 +1,39 @@
+package com.sirelon.marsroverphotos.presentation.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import com.sirelon.marsroverphotos.presentation.theme.AppSize
+
+/** Shared rounded-corner shape ([AppSize.cardRadius]) for [AppOutlinedCard] and other grouped surfaces. */
+internal val CardShape = RoundedCornerShape(AppSize.cardRadius)
+
+/**
+ * Design-system outlined card — a raised surface ([AppSize.cardRadius] radius) with a hairline
+ * outline and NO drop shadow. Distinct from the elevated [AppCard] (shadow, no border): the fill is
+ * the M3 raised `surfaceContainerHigh` role so the card lifts off the screen background in both
+ * themes — in dark, `surface == background`, so the hairline alone wouldn't separate it. A general
+ * container for grouped rows (settings groups, list sections, …).
+ */
+@Composable
+fun AppOutlinedCard(
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    val colors = MaterialTheme.colorScheme
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(CardShape)
+            .background(colors.surfaceContainerHigh)
+            .border(AppSize.hairline, colors.outlineVariant, CardShape),
+        content = content,
+    )
+}

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/Badges.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/Badges.kt
@@ -1,0 +1,71 @@
+package com.sirelon.marsroverphotos.presentation.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import com.sirelon.marsroverphotos.presentation.theme.AppSize
+import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
+
+/**
+ * Design-system pill badge — a neutral, outlined, pill-shaped label (e.g. a version tag).
+ */
+@Composable
+fun AppBadge(text: String, modifier: Modifier = Modifier) {
+    val colors = MaterialTheme.colorScheme
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelMedium,
+        color = colors.onSurfaceVariant,
+        modifier = modifier
+            .clip(CircleShape)
+            .background(colors.onSurface.copy(alpha = 0.06f))
+            .border(AppSize.hairline, colors.outlineVariant, CircleShape)
+            .padding(horizontal = AppSpacing.md, vertical = AppSpacing.xs)
+    )
+}
+
+/**
+ * Design-system status badge — a status dot + [label] on a tinted pill, parameterized by [color]
+ * (e.g. a "live" / "online" indicator). The dot and label share [color]; the pill is a soft tint
+ * of it.
+ */
+@Composable
+fun StatusBadge(label: String, color: Color, modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .clip(CircleShape)
+            .background(color.copy(alpha = 0.15f))
+            .padding(horizontal = AppSpacing.md, vertical = AppSpacing.xs),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm)
+    ) {
+        Box(modifier = Modifier.size(AppSize.badgeDot).background(color, CircleShape))
+        Text(text = label, style = MaterialTheme.typography.labelMedium, color = color)
+    }
+}
+
+/**
+ * Design-system badge row — lays out a set of badges ([AppBadge], [StatusBadge], …) in a spaced
+ * row. Callers fill it with their own badges.
+ */
+@Composable
+fun BadgeRow(modifier: Modifier = Modifier, content: @Composable RowScope.() -> Unit) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
+        content = content
+    )
+}

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/MaterialSymbolIcon.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/MaterialSymbolIcon.kt
@@ -14,8 +14,8 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.sirelon.marsroverphotos.presentation.theme.AppSize
 import com.sirelon.marsroverphotos.shared.resources.Res
 import com.sirelon.marsroverphotos.shared.resources.material_symbols_outlined
 import kotlin.math.max
@@ -50,7 +50,11 @@ enum class MaterialSymbol(val iconName: String) {
     CheckCircle("check_circle"),
     Close("close"),
     ExpandMore("expand_more"),
-    Tune("tune")
+    Tune("tune"),
+    Delete("delete"),
+    Public("public"),
+    ChevronRight("chevron_right"),
+    Reviews("reviews")
 }
 
 /**
@@ -74,7 +78,7 @@ fun MaterialSymbolIcon(
     contentDescription: String?,
     modifier: Modifier = Modifier,
     tint: Color = LocalContentColor.current,
-    size: Dp = 24.dp,
+    size: Dp = AppSize.iconDefault,
     filled: Boolean = false,
     weight: Int = 400
 ) {

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/SegmentedControl.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/SegmentedControl.kt
@@ -1,0 +1,161 @@
+package com.sirelon.marsroverphotos.presentation.ui
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
+import com.sirelon.marsroverphotos.presentation.theme.AppSize
+import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
+import kotlinx.coroutines.launch
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+/** Emphasized motion (~200ms, cubic-bezier(.2,0,0,1)) for the sliding selection indicator. */
+private const val SegmentAnimMillis = 200
+private val SegmentEasing = CubicBezierEasing(0.2f, 0f, 0f, 1f)
+
+/**
+ * Design-system segmented control — a pill of mutually exclusive options. The selected option is
+ * marked by a `tertiary` highlight that **slides** to the chosen segment; the others read as plain
+ * labels. Tap a segment or drag horizontally across the control to change the selection. Generic
+ * over the option type [T]: pass the [options], the currently [selected] one, an [onSelect]
+ * callback, and a [label] mapper.
+ *
+ * Usage:
+ * ```
+ * SegmentedControl(
+ *     options = listOf(Theme.DARK, Theme.WHITE, Theme.SYSTEM),
+ *     selected = currentTheme,
+ *     onSelect = onThemeChange,
+ *     label = { it.displayName },
+ * )
+ * ```
+ */
+@Composable
+fun <T> SegmentedControl(
+    options: List<T>,
+    selected: T,
+    onSelect: (T) -> Unit,
+    label: (T) -> String,
+    modifier: Modifier = Modifier,
+) {
+    val colors = MaterialTheme.colorScheme
+    val density = LocalDensity.current
+    val selectedIndex = options.indexOf(selected).coerceAtLeast(0)
+
+    // Per-segment bounds in px (relative to the segment Row), filled in via onGloballyPositioned.
+    val offsets = remember(options.size) { mutableStateListOf(*Array(options.size) { 0f }) }
+    val widths = remember(options.size) { mutableStateListOf(*Array(options.size) { 0f }) }
+    var segmentHeight by remember { mutableStateOf(0f) }
+
+    // Animated highlight position + width; snapped on first measure, animated on later changes.
+    val indicatorX = remember { Animatable(0f) }
+    val indicatorWidth = remember { Animatable(0f) }
+    var initialized by remember { mutableStateOf(false) }
+
+    LaunchedEffect(selectedIndex, offsets.toList(), widths.toList()) {
+        val targetX = offsets.getOrElse(selectedIndex) { 0f }
+        val targetWidth = widths.getOrElse(selectedIndex) { 0f }
+        if (targetWidth <= 0f) return@LaunchedEffect
+        if (!initialized) {
+            indicatorX.snapTo(targetX)
+            indicatorWidth.snapTo(targetWidth)
+            initialized = true
+        } else {
+            launch { indicatorX.animateTo(targetX, tween(SegmentAnimMillis, easing = SegmentEasing)) }
+            launch {
+                indicatorWidth.animateTo(targetWidth, tween(SegmentAnimMillis, easing = SegmentEasing))
+            }
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .clip(CircleShape)
+            .background(colors.background)
+            .border(AppSize.hairline, colors.outlineVariant, CircleShape)
+            .padding(AppSize.segmentedControlPadding)
+            .pointerInput(options, offsets.toList(), widths.toList()) {
+                val padPx = AppSize.segmentedControlPadding.toPx()
+                detectHorizontalDragGestures { change, _ ->
+                    val x = change.position.x - padPx
+                    var best = selectedIndex
+                    var bestDistance = Float.MAX_VALUE
+                    for (i in options.indices) {
+                        if (widths[i] <= 0f) continue
+                        val distance = abs(x - (offsets[i] + widths[i] / 2f))
+                        if (distance < bestDistance) {
+                            bestDistance = distance
+                            best = i
+                        }
+                    }
+                    if (best in options.indices && options[best] != selected) onSelect(options[best])
+                }
+            }
+    ) {
+        if (initialized) {
+            Box(
+                modifier = Modifier
+                    .offset { IntOffset(indicatorX.value.roundToInt(), 0) }
+                    .width(with(density) { indicatorWidth.value.toDp() })
+                    .height(with(density) { segmentHeight.toDp() })
+                    .clip(CircleShape)
+                    .background(colors.tertiary)
+            )
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(AppSize.segmentedControlGap)) {
+            options.forEachIndexed { index, option ->
+                val isSelected = option == selected
+                Text(
+                    text = label(option),
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+                    color = if (isSelected) colors.onTertiary else colors.onSurfaceVariant,
+                    modifier = Modifier
+                        .onGloballyPositioned { coords ->
+                            val x = coords.positionInParent().x
+                            if (offsets[index] != x) offsets[index] = x
+                            if (widths[index] != coords.size.width.toFloat()) {
+                                widths[index] = coords.size.width.toFloat()
+                            }
+                            segmentHeight = coords.size.height.toFloat()
+                        }
+                        .clip(CircleShape)
+                        // Fallback fill for the one frame before the overlay is measured.
+                        .background(if (!initialized && isSelected) colors.tertiary else Color.Transparent)
+                        .clickable { onSelect(option) }
+                        .padding(horizontal = AppSpacing.lg, vertical = AppSpacing.xs)
+                )
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/SettingsComponents.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/SettingsComponents.kt
@@ -1,0 +1,104 @@
+package com.sirelon.marsroverphotos.presentation.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import com.sirelon.marsroverphotos.presentation.theme.AppSize
+import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
+
+/** Inset where a [SettingsRow]'s text starts: horizontal padding + icon-box + gap. */
+private val RowTextInset = AppSpacing.lg + AppSize.iconBox + AppSize.rowIconGap
+
+/** Indent aligning content under a row's label (icon-box + gap), e.g. the theme segmented control. */
+internal val SettingsRowIndent = AppSize.iconBox + AppSize.rowIconGap
+
+/**
+ * Design-system section label — coral, uppercase, letter-spaced header that sits above a grouped
+ * card. Mirrors the design's grouped-settings section headers (APPEARANCE / DATA …).
+ */
+@Composable
+fun SettingsSectionLabel(text: String, modifier: Modifier = Modifier) {
+    Text(
+        text = text.uppercase(),
+        style = MaterialTheme.typography.labelSmall,
+        fontWeight = FontWeight.Bold,
+        letterSpacing = 1.1.sp,
+        color = MaterialTheme.colorScheme.secondary,
+        modifier = modifier.padding(bottom = AppSpacing.sm)
+    )
+}
+
+/**
+ * Design-system settings row — leading [AppIconBox] + [label] + optional [sub] label, with a
+ * trailing region that is either a custom [trailing] control (toggle, segmented…) or, for a link
+ * row (non-null [onClick] and no [trailing]), a chevron. Tapping anywhere fires [onClick].
+ */
+@Composable
+fun SettingsRow(
+    icon: MaterialSymbol,
+    iconContainer: Color,
+    iconTint: Color,
+    label: String,
+    modifier: Modifier = Modifier,
+    sub: String? = null,
+    onClick: (() -> Unit)? = null,
+    trailing: (@Composable () -> Unit)? = null,
+) {
+    val colors = MaterialTheme.colorScheme
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .let { if (onClick != null) it.clickable(onClick = onClick) else it }
+            .padding(horizontal = AppSpacing.lg, vertical = AppSize.rowVerticalPadding),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(AppSize.rowIconGap)
+    ) {
+        AppIconBox(symbol = icon, container = iconContainer, tint = iconTint)
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+                color = colors.onSurface
+            )
+            if (sub != null) {
+                Text(
+                    text = sub,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = colors.onSurfaceVariant
+                )
+            }
+        }
+        when {
+            trailing != null -> trailing()
+            onClick != null -> MaterialSymbolIcon(
+                symbol = MaterialSymbol.ChevronRight,
+                contentDescription = null,
+                tint = colors.onSurfaceVariant.copy(alpha = 0.7f),
+                size = AppSize.icon
+            )
+        }
+    }
+}
+
+/** Hairline divider between [SettingsRow]s, inset to start after the leading icon-box. */
+@Composable
+fun SettingsRowDivider(modifier: Modifier = Modifier) {
+    HorizontalDivider(
+        modifier = modifier.padding(start = RowTextInset, end = AppSpacing.lg),
+        thickness = AppSize.hairline,
+        color = MaterialTheme.colorScheme.outlineVariant
+    )
+}


### PR DESCRIPTION
## Summary
Rebuilds the **About screen** from the Claude Design handoff and extracts the reusable pieces into the shared design system.

- **Hero** — full-bleed navy→bg gradient, alien mascot with coral glow, app name, tagline, version pill + live "NASA API" status badge.
- **Grouped Material 3 settings** — coral section labels (APPEARANCE / DATA / CONNECT); outlined non-elevated cards (`surfaceContainerHigh` + hairline) with tinted icon-box rows.
  - Theme picker: segmented **Dark / Light / System** (Light→`Theme.WHITE`) with an **animated sliding indicator + swipe-to-change**.
  - Fact Cards toggle, Clear Cache (+ snackbar), NASA / Rate / Feedback link rows.
- **Info blurb** + footer (© year · Made with ♥ · Standing with 🇺🇦).
- **Responsive** — hero is full-width everywhere; content caps at 840dp and centers only on the **expanded** window size class (reuses `currentWindowAdaptiveInfo()`, same source as the nav suite).

## Design-system extractions (reusable app-wide)
`AppIconBox`, `AppOutlinedCard` (+`CardShape`), `AppBadge` / `StatusBadge` / `BadgeRow`, generic animated/swipeable `SegmentedControl<T>`, and a new `AppSize` dimension-token class. No raw `.dp` literals — spacing via `AppSpacing`, sizes via `AppSize`.

## Fixes
- **Rate the App** no longer silently no-ops: Android now passes a Play Store URL and `requestReview()` returns `false` on debug builds, so the store listing reliably opens (in-app review sheet unchanged on release).

## Docs
- New **`docs/DESIGN_SYSTEM.md`** (living doc), linked from `AGENTS.md` — prescriptive UI/UX rules, component index, and the gotchas this redesign surfaced (dark `surface`==`background`, no green M3 slot, full icon font, in-app-review-in-debug).

## Test plan
- `./gradlew :shared:compileAndroidMain` ✅
- `./gradlew :androidApp:compileDebugKotlin` ✅
- `./gradlew :shared:desktopTest` ✅ (existing shared tests green)
- `./gradlew detekt` ✅ (only pre-existing `handleDeepLink` warnings, untouched)
- Manual smoke test: About screen in dark + light, theme switch persists, controls + links work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)