### PR TITLE
Redesign Rovers screen with M3 "Refined List" rows + adaptive layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ iosApp/iosApp/GoogleService-Info.plist
 
 # Claude Code session artifacts
 .claude/tmp/
+
+# Claude Design handoff bundle (local only)
+.design-bundle/

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -44,9 +44,12 @@ coral **accent/secondary** (`#FC6C4B`, "the Mars accent"). Light theme is white-
   Symbols Outlined set**, so standard glyphs are present (verify the ligature name if unsure).
 
 ### Adaptive layout & navigation
-- The nav chrome (compact = bottom bar, medium/expanded = nav rail) is owned by **`MarsNavigationSuite`**
-  (`navigation/MarsBottomBar.kt`). Screens render **content only** — do not add your own nav or a
-  duplicate top bar for the primary destinations.
+- The **navigation** chrome (compact = bottom bar, medium/expanded = nav rail) is owned by
+  **`MarsNavigationSuite`** (`navigation/MarsBottomBar.kt`). Don't add your own bottom bar / nav rail.
+- A screen **does** own its own `Scaffold` + **`AppTopBar`** (title / subtitle / actions, with
+  `TopAppBarDefaults.enterAlwaysScrollBehavior()` via `nestedScroll`) — that's the title bar, distinct
+  from the nav chrome above. See `FavoriteScreen.kt`, `PopularScreen.kt`, `RoversScreen.kt`. Use
+  `contentWindowInsets = WindowInsets()` and consume `innerPadding` in the content.
 - For content that shouldn't stretch on wide windows, constrain to a centered max width
   (`AppSize` content-width token) rather than filling.
 
@@ -63,8 +66,9 @@ coral **accent/secondary** (`#FC6C4B`, "the Mars accent"). Light theme is white-
   against the screen in dark mode. Use a raised role (**`surfaceContainerHigh`**) for cards that must
   lift off the background. (`surfaceColorAtElevation` is **not** available in the M3 version pinned
   here — use the `surfaceContainer*` role family.)
-- **No green slot in the M3 palette.** The "live/connected" green is resolved per applied theme via a
-  documented luminance-based helper (`#5BBF86` dark / `#2E9E63` light), not a palette token.
+- **No green slot in the M3 palette.** The "live/connected" green is resolved per applied theme via the
+  documented luminance-based helper **`activeStatusColor()`** (`theme/AppColors.kt`; `#5BBF86` dark /
+  `#2E9E63` light), not a palette token. Use the helper — never a literal green.
 - **Theme-aware hero tint.** The About hero gradient top must be resolved per theme (deep navy in dark,
   soft light-blue `#DCE8F6` in light) — a fixed navy looks wrong in light. Same luminance-helper pattern.
 - **Material Symbols font is the full ~10MB variable file**, not a subset — all standard glyphs render;
@@ -72,6 +76,10 @@ coral **accent/secondary** (`#FC6C4B`, "the Mars accent"). Light theme is white-
 - **Brand color overrides survive dynamic color.** `Theme.kt` re-applies brand-critical slots
   (secondary/coral, secondaryContainer, tertiary, primaryContainer) on top of Material You so
   design-system components stay on-brand. Read `Theme.kt` before touching colors.
+- **`./gradlew detekt` does NOT lint `shared/commonMain`.** It only sources `androidApp` + root, so
+  shared-module style violations (raw `.dp`, hardcoded theme colors) are **not** caught automatically.
+  Verify shared UI by reading the diff for those rules + `:shared:compileKotlinDesktop` — a clean
+  detekt run is not evidence the shared code is clean.
 - **Android in-app review silently no-ops in debug.** `AppReview.requestReview()` returns `true` even
   when nothing renders (Play throttling), so any "rate" flow needs a guaranteed store-listing fallback;
   ensure each platform shell passes a store URL.
@@ -84,9 +92,10 @@ Stable design-system pieces (path = `shared/src/commonMain/kotlin/com/sirelon/ma
 
 | Component | File | Notes |
 | --- | --- | --- |
-| `AppCard` | `ui/AppCard.kt` | **Elevated** card (2dp), 16dp radius. `AppFactCard` = secondaryContainer fact card. |
+| `AppCard` | `ui/AppCard.kt` | **Elevated** card (2dp), 16dp radius. Optional `onClick` makes it interactive: the card owns the `clickable` + a desktop **hover-lift** (`cardElevationResting`→`cardElevationHover` via `animateDpAsState`) internally — pass `onClick` rather than wrapping the card in your own `clickable`/elevation. Null `onClick` ⇒ non-interactive and honors the caller's `elevation` param (default resting; e.g. a 4dp header card). `AppFactCard` = secondaryContainer fact card. |
 | `AppOutlinedCard` | `ui/AppOutlinedCard.kt` | **Non-elevated** grouped card: `surfaceContainerHigh` fill + hairline outline + 16dp radius. Exports `CardShape`. Use for grouped lists/surfaces; not a flag on `AppCard`. |
 | `AppIconBox` | `ui/AppIconBox.kt` | Tinted rounded container holding a `MaterialSymbol` (tinted container + icon). General — use anywhere a colored icon tile is needed. |
+| `AppMetricItem` | `ui/AppMetricItem.kt` | Inline icon + value + label trio in one `Row` (e.g. "🖼 134K photos"). Icon/label = `onSurfaceVariant`, value = `onSurface` (SemiBold `bodyMedium`); inline icon size. Repeats 3× in a rover row's metric strip; general anywhere a compact metric is needed. |
 | `AppBadge` / `StatusBadge` / `BadgeRow` | `ui/Badges.kt` | `AppBadge` = neutral outlined pill; `StatusBadge(label, color)` = colored dot + label (parameterized); `BadgeRow` = slot row composing them. |
 | `SegmentedControl<T>` | `ui/SegmentedControl.kt` | Generic pill selector with an **animated sliding** indicator (measured bounds, ~200ms emphasized tween). Drag to slide through options continuously; tap to jump. Uses `draggable` + `rememberDraggableState` — never cancelled mid-gesture by recomposition. API: `options, selected, onSelect, label`. |
 | `AppChip` | `ui/AppChip.kt` | secondaryContainer assist chip. |
@@ -99,16 +108,99 @@ Stable design-system pieces (path = `shared/src/commonMain/kotlin/com/sirelon/ma
 | `AppSize` | `theme/AppSize.kt` | Component **dimension/radius** tokens (icon/card/hero/content-width, etc.). |
 | `AppTypography` | `theme/AppTypography.kt` | Semantic type aliases. |
 | `MarsRoverPhotosTheme` + palettes | `theme/Theme.kt` | Color schemes, brand overrides, dynamic color. |
+| `activeStatusColor()` | `theme/AppColors.kt` | Theme-aware "active / live / connected" green (`@Composable @ReadOnlyComposable`). Luminance-based: `#5BBF86` dark / `#2E9E63` light. Fills the **no-green-slot** gap (see Insights); use instead of a literal. Generalized out of the old AboutScreen-local `liveColor`. |
 
 > Settings-row primitives (`SettingsRow`, `SettingsSectionLabel`, `SettingsRowDivider`) live in
 > `ui/SettingsComponents.kt` and compose the general pieces above; they're list-row-shaped, so they
 > keep the `Settings*` name. The general building blocks (`AppIconBox`, `AppOutlinedCard`, badges) are
 > reusable beyond settings.
 
-**Adaptive centering:** to cap+center content only on large windows, use
-`currentWindowAdaptiveInfo().windowSizeClass.isWidthAtLeastBreakpoint(WIDTH_DP_EXPANDED_LOWER_BOUND)`
-(the same adaptive source as the nav suite) rather than a hand-rolled `BoxWithConstraints` threshold.
-See `AboutScreen.kt` for the pattern (full-bleed hero + content capped at `AppSize.contentMaxWidth`).
+**New `MaterialSymbol` glyphs (Rovers):** `Collections`, `Schedule`, `Event`, `Search` — added to the
+enum in `ui/MaterialSymbolIcon.kt` (the bundled full variable font renders them).
+
+**New `AppSize` tokens (Rovers):** `roverThumbWidth` (112dp portrait-thumb fixed width),
+`roverInfoReserve` (40dp title-line trailing reserve clearing the overlaid info button),
+`cardElevationResting` (2dp) / `cardElevationHover` (6dp) for the hover-lift.
+
+**Number formatting** (`utils/NumberFormat.kt`): `formatThousands` → grouped (`74,525`) for exact
+counts; `formatCompact` → abbreviated K/M (`1.5K`, `134K`, `1.2M`) for tight metric strips. Use
+`formatCompact` in dense/inline metric contexts (rover `AppMetricItem`s), `formatThousands` where the
+full number reads better.
+
+**Adaptive layout (one source, two breakpoints):** drive both column count and width-cap from
+`currentWindowAdaptiveInfo().windowSizeClass.isWidthAtLeastBreakpoint(...)` (the same adaptive source
+as the nav suite) — never a hand-rolled `BoxWithConstraints` threshold or column math.
+- **Columns:** `isWidthAtLeastBreakpoint(WIDTH_DP_MEDIUM_LOWER_BOUND)` → `GridCells.Fixed(2)` on
+  medium+expanded, else `Fixed(1)` on compact. (Rovers grid.)
+- **Width cap:** `isWidthAtLeastBreakpoint(WIDTH_DP_EXPANDED_LOWER_BOUND)` → `widthIn(max =
+  AppSize.contentMaxWidth)` and center, else `fillMaxWidth()`. (Cap only in EXPANDED.)
+See `RoversScreen.kt` (`RoversContent`) and `AboutScreen.kt` (full-bleed hero + capped content) for
+the pattern.
+
+**Rovers chrome (`RoversContent`):** a `Scaffold` + `AppTopBar` with
+`TopAppBarDefaults.enterAlwaysScrollBehavior()` (the `FavoriteScreen` pattern) — not a scrolling
+header `Column`. The top bar shows the title (`rovers_title`) + a counts subtitle
+(`rovers_subtitle_fmt`, computed from the FULL `allRovers` list) and a trailing **search
+`IconButton`**. The grid consumes `innerPadding` (`consumeWindowInsets` + top/bottom `calculateXPadding()`),
+keeping the width-cap above. **Toggle search:** search is hidden by default; tapping the search action
+flips a hoisted `searchActive` flag that swaps the title slot for an inline single-line
+`OutlinedTextField` (focused via `FocusRequester` + `LaunchedEffect`) and the action for a **close
+`IconButton`** that clears the query and exits. Filtering still lives in the VM (`filteredRovers`).
+
+---
+
+## Rovers — Variant A "Refined List" row
+
+The rover list row (`screens/RoversScreen.kt` → `RoverItem`). Anatomy, top→bottom / left→right:
+
+- **Base:** `AppCard` (elevated, large radius). The whole card is clickable via `AppCard(onClick = …)`
+  → `onNavigateToPhotos` (the card owns the `clickable` + hover-lift; the row no longer wraps it).
+- **Thumbnail:** full-height portrait `Image`, fixed width `AppSize.roverThumbWidth`,
+  `ContentScale.Crop`, clipped to `shapes.medium`. The row uses `height(IntrinsicSize.Min)` so the
+  thumb fills the text column's height.
+- **Title line:** a `FlowRow` of the coral rover name (`colorScheme.secondary`, `titleLarge`, 1 line +
+  ellipsis) followed by an Active/Complete `StatusBadge` — `FlowRow` (not `Row`) so a long name + chip
+  wrap gracefully instead of squeezing. The line reserves `AppSize.roverInfoReserve` trailing padding
+  so the name/chip never collide with the overlaid info button.
+- **Status chip:** `StatusBadge(label, color)`. `rover.status.equals("active", ignoreCase = true)` →
+  label "Active" + `activeStatusColor()`; otherwise "Complete" + `onSurfaceVariant` (neutral). Derive
+  from `rover.status` (case-insensitive) — never hardcode the label, never a literal green.
+- **Blurb:** 2-line `bodyMedium` / `onSurfaceVariant`, ellipsized, from `Rover.blurb()` (presentation
+  string resource — see gotcha below).
+- **Metric strip:** a top hairline `HorizontalDivider` (`AppSize.hairline` / `colorScheme.outline`)
+  then a `FlowRow` of EXACTLY three `AppMetricItem`s — Photos (`totalPhotos` via `formatCompact`),
+  Sols (`maxSol` via `formatCompact`), Last date (`maxDate` via `formatDisplayDate`).
+- **Info affordance:** an `IconButton` (info glyph) `align(Alignment.TopEnd)` as an overlay in the
+  row's `Box` — **outside** the card's `clickable` — so tapping info fires `onMissionInfoClick` and
+  does NOT trigger the row tap. (Tap isolation = separate clickable target, not event consumption.)
+- **Hover lift:** owned by `AppCard` itself when `onClick` is passed — `MutableInteractionSource` +
+  `collectIsHoveredAsState` drive `animateDpAsState` between `AppSize.cardElevationResting` and
+  `cardElevationHover`, with desktop hover + all-platform press feedback via `LocalIndication`. The row
+  just hands `AppCard` an `onClick`; it no longer manages the interaction source/elevation locally.
+
+**Gotchas:**
+- `roverInfoReserve` (40dp) is **hand-tuned** to clear the 48dp info `IconButton` overlay — it is not
+  derived from the icon-button size (deferred to follow-ups). Re-tune if the info button size changes.
+- Rover **mission blurbs are presentation-only** localized string resources, keyed on `RoverConstants`
+  ids in `ui/RoverBlurb.kt` (`Rover.blurb()` / `blurbResource()`) — **NOT** domain data. Never add a
+  blurb field to the `Rover` model or the data/API layer.
+- Rover **search is VM-derived**, not filtered in composition: `RoversViewModel` exposes
+  `filteredRovers` as `combine(rovers, searchQuery)`. Screens read the derived `StateFlow`.
+
+### Handoff design-token → app-token mapping
+
+The design bundle's `colors_and_type.css` is a mirror of the app, not the source — it states
+*"Source of truth: Theme.kt"*. When implementing from the handoff, map design tokens back to app
+tokens rather than re-introducing literals:
+
+| Design token (`colors_and_type.css`) | App token |
+| --- | --- |
+| `--accent` / `--t-accent` `#FC6C4B` (coral) | `colorScheme.secondary` |
+| `--t-active` `#5BBF86` dark / `#2E9E63` light | `activeStatusColor()` |
+| `--primary` `#385C8A` (steel blue) | `colorScheme.primary` |
+| `--space-*` (8dp grid) | `AppSpacing` |
+| `--radius-*` | `MaterialTheme.shapes` (small/medium/large) / `AppSize` radii |
+| M3 type scale (`--body-medium`, `--title-large`, …) | `MaterialTheme.typography.*` / `AppTypography` |
 
 ---
 
@@ -124,3 +216,11 @@ See `AboutScreen.kt` for the pattern (full-bleed hero + content capped at `AppSi
   `awaitEachGesture` with `draggable` + `rememberDraggableState`. Root cause: `pointerInput` keys
   included `offsets.toList()`, so each recomposition triggered by `onSelect` restarted the gesture
   coroutine mid-drag. `rememberDraggableState` is stable across recompositions and immune to this.
+- 2026-06-07 — **Rovers redesign (Variant A "Refined List")**. Generalized `activeStatusColor()` into
+  `theme/AppColors.kt` (was AboutScreen-local `liveColor`) and added `AppMetricItem` to the index.
+  Added `MaterialSymbol` glyphs (Collections/Schedule/Event/Search), `AppSize` tokens
+  (`roverThumbWidth`, `roverInfoReserve`, `cardElevation{Resting,Hover}`), and `formatCompact`
+  (`utils/NumberFormat.kt`). New "Rovers — Variant A row" section (row anatomy, tap isolation,
+  hover-lift, blurb/search provenance) + the handoff token-mapping table. Generalized the
+  adaptive-centering note into the columns-from-MEDIUM / cap-from-EXPANDED pattern. Recorded that
+  `./gradlew detekt` does not lint `shared/commonMain`.

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -38,6 +38,24 @@
     <string name="images_empty_title">No photos available.</string>
     <string name="images_empty_btn">Go back</string>
 
+    <!-- Rover mission blurbs -->
+    <string name="rover_blurb_curiosity">Car-sized, nuclear-powered, climbing Mount Sharp since 2012.</string>
+    <string name="rover_blurb_opportunity">Built for 90 sols, it roamed for nearly 15 Earth years.</string>
+    <string name="rover_blurb_spirit">Found mineral evidence of ancient water before going silent.</string>
+    <string name="rover_blurb_insight">A stationary lander probing the deep interior of Mars.</string>
+    <string name="rover_blurb_perseverance">Hunting for ancient life and caching rock in Jezero Crater.</string>
+
+    <!-- Rovers screen header + search -->
+    <string name="rovers_title">Mars Rovers</string>
+    <string name="rovers_subtitle_fmt">%1$d missions · %2$d active</string>
+    <string name="rovers_search_placeholder">Search rovers</string>
+    <string name="rovers_search_empty_fmt">No rovers match \"%1$s\"</string>
+
+    <!-- Rover row metric-strip labels -->
+    <string name="metric_label_photos">photos</string>
+    <string name="metric_label_sols">sols</string>
+    <string name="metric_label_last">last</string>
+
     <!-- Navigation labels -->
     <string name="nav_rovers">Rovers</string>
     <string name="nav_favorite">Favorites</string>

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/AboutScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/AboutScreen.kt
@@ -44,6 +44,7 @@ import com.sirelon.marsroverphotos.platform.AppReview
 import com.sirelon.marsroverphotos.presentation.navigation.LocalAboutCallbacks
 import com.sirelon.marsroverphotos.presentation.theme.AppSize
 import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
+import com.sirelon.marsroverphotos.presentation.theme.activeStatusColor
 import com.sirelon.marsroverphotos.presentation.theme.primaryVariant
 import com.sirelon.marsroverphotos.presentation.ui.AppBadge
 import com.sirelon.marsroverphotos.presentation.ui.AppIconBox
@@ -110,7 +111,7 @@ private fun AboutContent(
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
     val colors = MaterialTheme.colorScheme
-    val live = liveColor()
+    val live = activeStatusColor()
 
     Box(modifier = Modifier.fillMaxSize().background(colors.background)) {
         Column(
@@ -231,15 +232,6 @@ private fun SettingsSection(label: String, content: @Composable () -> Unit) {
         AppOutlinedCard { content() }
     }
 }
-
-/**
- * Live / "connected" status green. Not part of the M3 palette, so it is resolved per applied
- * theme (dark vs light) off the background luminance — keeping it legible in both themes,
- * matching the design's `--t-active` (#5BBF86 dark / #2E9E63 light).
- */
-@Composable
-private fun liveColor(): Color =
-    if (MaterialTheme.colorScheme.background.luminance() < 0.5f) Color(0xFF5BBF86) else Color(0xFF2E9E63)
 
 /**
  * Hero gradient top tint — resolved per applied theme so the gradient reads correctly in both.

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoversScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoversScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -126,8 +127,12 @@ fun RoversContent(
     val colors = MaterialTheme.colorScheme
     val activeCount = allRovers.count { it.status.equals("active", ignoreCase = true) }
 
-    // Search stays hidden behind the top-bar search action until the user opts in.
-    var searchActive by remember { mutableStateOf(false) }
+    // Search stays hidden behind the top-bar search action until the user opts in. The flag is
+    // saveable so it survives recreation, and search mode also stays visible whenever a query is
+    // active — the VM-held query outlives this composable, so the field + clear action must never
+    // disappear while filtering a non-empty query.
+    var searchActive by rememberSaveable { mutableStateOf(false) }
+    val showSearch = searchActive || searchQuery.isNotBlank()
     val focusRequester = remember { FocusRequester() }
 
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
@@ -137,7 +142,7 @@ fun RoversContent(
         topBar = {
             AppTopBar(
                 title = {
-                    if (searchActive) {
+                    if (showSearch) {
                         OutlinedTextField(
                             value = searchQuery,
                             onValueChange = onSearchQueryChange,
@@ -159,7 +164,7 @@ fun RoversContent(
                         Text(text = stringResource(Res.string.rovers_title))
                     }
                 },
-                subtitle = if (searchActive) {
+                subtitle = if (showSearch) {
                     null
                 } else {
                     {
@@ -176,7 +181,7 @@ fun RoversContent(
                 },
                 windowInsets = WindowInsets(0, 0, 0, 0),
                 actions = {
-                    if (searchActive) {
+                    if (showSearch) {
                         IconButton(onClick = {
                             searchActive = false
                             onSearchQueryChange("")

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoversScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoversScreen.kt
@@ -1,45 +1,77 @@
 package com.sirelon.marsroverphotos.presentation.screens
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.IconButton
-import com.sirelon.marsroverphotos.presentation.ui.AppCard
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.window.core.layout.WindowSizeClass.Companion.WIDTH_DP_EXPANDED_LOWER_BOUND
+import androidx.window.core.layout.WindowSizeClass.Companion.WIDTH_DP_MEDIUM_LOWER_BOUND
 import com.sirelon.marsroverphotos.domain.models.Rover
+import com.sirelon.marsroverphotos.presentation.theme.AppSize
 import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
-import com.sirelon.marsroverphotos.presentation.theme.AppTypography
+import com.sirelon.marsroverphotos.presentation.theme.activeStatusColor
+import com.sirelon.marsroverphotos.presentation.ui.AppCard
+import com.sirelon.marsroverphotos.presentation.ui.AppEmptyState
+import com.sirelon.marsroverphotos.presentation.ui.AppMetricItem
+import com.sirelon.marsroverphotos.presentation.ui.AppTopBar
 import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbol
 import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbolIcon
+import com.sirelon.marsroverphotos.presentation.ui.StatusBadge
+import com.sirelon.marsroverphotos.presentation.ui.blurb
 import com.sirelon.marsroverphotos.presentation.ui.painter
 import com.sirelon.marsroverphotos.presentation.viewmodels.RoversViewModel
 import com.sirelon.marsroverphotos.shared.resources.Res
-import com.sirelon.marsroverphotos.shared.resources.label_photos_total
+import com.sirelon.marsroverphotos.shared.resources.metric_label_last
+import com.sirelon.marsroverphotos.shared.resources.metric_label_photos
+import com.sirelon.marsroverphotos.shared.resources.metric_label_sols
+import com.sirelon.marsroverphotos.shared.resources.rovers_search_empty_fmt
+import com.sirelon.marsroverphotos.shared.resources.rovers_search_placeholder
+import com.sirelon.marsroverphotos.shared.resources.rovers_subtitle_fmt
+import com.sirelon.marsroverphotos.shared.resources.rovers_title
+import com.sirelon.marsroverphotos.utils.formatCompact
 import com.sirelon.marsroverphotos.utils.formatDisplayDate
-import com.sirelon.marsroverphotos.utils.formatThousands
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -50,9 +82,14 @@ fun RoversScreen(
 ) {
     val viewModel: RoversViewModel = koinViewModel()
     val rovers by viewModel.rovers.collectAsStateWithLifecycle()
+    val filteredRovers by viewModel.filteredRovers.collectAsStateWithLifecycle()
+    val searchQuery by viewModel.searchQuery.collectAsStateWithLifecycle()
 
     RoversContent(
-        rovers = rovers,
+        rovers = filteredRovers,
+        allRovers = rovers,
+        searchQuery = searchQuery,
+        onSearchQueryChange = viewModel::onSearchQueryChange,
         onClick = { rover ->
             viewModel.onRoverClicked(rover)
             onNavigateToPhotos(rover.id)
@@ -64,27 +101,143 @@ fun RoversScreen(
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RoversContent(
     rovers: List<Rover>,
+    allRovers: List<Rover>,
+    searchQuery: String,
+    onSearchQueryChange: (String) -> Unit,
     onClick: (rover: Rover) -> Unit,
     onMissionInfoClick: (rover: Rover) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LazyVerticalGrid(
-        columns = GridCells.Adaptive(minSize = 360.dp),
-        modifier = modifier,
-        contentPadding = PaddingValues(horizontal = AppSpacing.md, vertical = AppSpacing.sm),
-        verticalArrangement = Arrangement.spacedBy(AppSpacing.sm),
-        horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm)
-    ) {
-        items(rovers, key = { it.id }) { item ->
-            RoverItem(
-                modifier = Modifier.fillMaxWidth(),
-                rover = item,
-                onClick = onClick,
-                onMissionInfoClick = onMissionInfoClick
+    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
+    // 1 column on compact, 2 on medium AND expanded — same adaptive source as the nav suite.
+    val columns = if (windowSizeClass.isWidthAtLeastBreakpoint(WIDTH_DP_MEDIUM_LOWER_BOUND)) 2 else 1
+    // Cap+center the whole content column only in the EXPANDED width class (the AboutScreen pattern).
+    val expandedWidth = windowSizeClass.isWidthAtLeastBreakpoint(WIDTH_DP_EXPANDED_LOWER_BOUND)
+    val contentWidth = if (expandedWidth) {
+        Modifier.widthIn(max = AppSize.contentMaxWidth)
+    } else {
+        Modifier.fillMaxWidth()
+    }
+
+    val colors = MaterialTheme.colorScheme
+    val activeCount = allRovers.count { it.status.equals("active", ignoreCase = true) }
+
+    // Search stays hidden behind the top-bar search action until the user opts in.
+    var searchActive by remember { mutableStateOf(false) }
+    val focusRequester = remember { FocusRequester() }
+
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+    Scaffold(
+        modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        contentWindowInsets = WindowInsets(),
+        topBar = {
+            AppTopBar(
+                title = {
+                    if (searchActive) {
+                        OutlinedTextField(
+                            value = searchQuery,
+                            onValueChange = onSearchQueryChange,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .focusRequester(focusRequester),
+                            singleLine = true,
+                            shape = MaterialTheme.shapes.large,
+                            leadingIcon = {
+                                MaterialSymbolIcon(
+                                    symbol = MaterialSymbol.Search,
+                                    contentDescription = null,
+                                    tint = colors.onSurfaceVariant
+                                )
+                            },
+                            placeholder = { Text(stringResource(Res.string.rovers_search_placeholder)) }
+                        )
+                    } else {
+                        Text(text = stringResource(Res.string.rovers_title))
+                    }
+                },
+                subtitle = if (searchActive) {
+                    null
+                } else {
+                    {
+                        Text(
+                            text = stringResource(
+                                Res.string.rovers_subtitle_fmt,
+                                allRovers.size,
+                                activeCount
+                            ),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = colors.onSurfaceVariant
+                        )
+                    }
+                },
+                windowInsets = WindowInsets(0, 0, 0, 0),
+                actions = {
+                    if (searchActive) {
+                        IconButton(onClick = {
+                            searchActive = false
+                            onSearchQueryChange("")
+                        }) {
+                            MaterialSymbolIcon(
+                                symbol = MaterialSymbol.Close,
+                                contentDescription = "Close search"
+                            )
+                        }
+                    } else {
+                        IconButton(onClick = { searchActive = true }) {
+                            MaterialSymbolIcon(
+                                symbol = MaterialSymbol.Search,
+                                contentDescription = "Search"
+                            )
+                        }
+                    }
+                },
+                scrollBehavior = scrollBehavior,
             )
+        }
+    ) { innerPadding ->
+        // Focus the field the moment search mode turns on so the keyboard appears immediately.
+        LaunchedEffect(searchActive) {
+            if (searchActive) focusRequester.requestFocus()
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(innerPadding),
+            contentAlignment = Alignment.TopCenter
+        ) {
+            if (rovers.isEmpty() && searchQuery.isNotBlank()) {
+                AppEmptyState(
+                    title = stringResource(Res.string.rovers_search_empty_fmt, searchQuery),
+                    showImage = false,
+                    modifier = contentWidth
+                )
+            } else {
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(columns),
+                    modifier = contentWidth.fillMaxSize(),
+                    contentPadding = PaddingValues(
+                        start = AppSpacing.md,
+                        end = AppSpacing.md,
+                        top = innerPadding.calculateTopPadding() + AppSpacing.sm,
+                        bottom = innerPadding.calculateBottomPadding() + AppSpacing.sm
+                    ),
+                    verticalArrangement = Arrangement.spacedBy(AppSpacing.sm),
+                    horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm)
+                ) {
+                    items(rovers, key = { it.id }) { item ->
+                        RoverItem(
+                            modifier = Modifier.fillMaxWidth(),
+                            rover = item,
+                            onClick = onClick,
+                            onMissionInfoClick = onMissionInfoClick
+                        )
+                    }
+                }
+            }
         }
     }
 }
@@ -97,97 +250,107 @@ fun RoverItem(
     modifier: Modifier = Modifier
 ) {
     AppCard(
-        modifier = modifier.padding(AppSpacing.sm),
+        modifier = modifier,
+        onClick = { onClick(rover) },
     ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable(onClick = { onClick(rover) })
-                .padding(AppSpacing.sm)
-        ) {
+        Box(modifier = Modifier.fillMaxWidth()) {
             Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(IntrinsicSize.Min)
+                    .padding(AppSpacing.md),
+                horizontalArrangement = Arrangement.spacedBy(AppSpacing.md)
             ) {
-                Box(
-                    modifier = Modifier.weight(1f),
-                    contentAlignment = Alignment.Center
-                ) {
-                    TitleText(rover.name)
-                }
-                IconButton(onClick = { onMissionInfoClick(rover) }) {
-                    MaterialSymbolIcon(
-                        symbol = MaterialSymbol.Info,
-                        contentDescription = "Mission Info"
+                Image(
+                    painter = rover.painter(),
+                    contentDescription = rover.name,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .width(AppSize.roverThumbWidth)
+                        .fillMaxHeight()
+                        .clip(MaterialTheme.shapes.medium)
+                )
+                Column(modifier = Modifier.weight(1f)) {
+                    TitleLine(rover)
+                    Spacer(modifier = Modifier.height(AppSpacing.sm))
+                    Text(
+                        text = rover.blurb(),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
                     )
+                    Spacer(modifier = Modifier.height(AppSpacing.md))
+                    HorizontalDivider(
+                        thickness = AppSize.hairline,
+                        color = MaterialTheme.colorScheme.outline
+                    )
+                    Spacer(modifier = Modifier.height(AppSpacing.md))
+                    MetricStrip(rover)
                 }
             }
-            InfoText(label = "Status:", text = rover.status)
-
-            Row(modifier = Modifier.padding(AppSpacing.sm)) {
-                Image(
-                    contentScale = ContentScale.FillHeight,
-                    painter = rover.painter(),
-                    modifier = Modifier
-                        .height(175.dp)
-                        .weight(1f)
-                        .clip(shape = MaterialTheme.shapes.large),
-                    contentDescription = rover.name
+            IconButton(
+                onClick = { onMissionInfoClick(rover) },
+                modifier = Modifier.align(Alignment.TopEnd)
+            ) {
+                MaterialSymbolIcon(
+                    symbol = MaterialSymbol.Info,
+                    contentDescription = "Mission Info",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                Spacer(modifier = Modifier.width(AppSpacing.sm))
-                Column(
-                    modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.SpaceAround
-                ) {
-                    InfoText(
-                        label = stringResource(Res.string.label_photos_total),
-                        text = formatThousands(rover.totalPhotos)
-                    )
-                    InfoText(label = "Current sol:", text = "${rover.maxSol}")
-                    InfoText(label = "Last photo date:", text = formatDisplayDate(rover.maxDate))
-                    InfoText(label = "Launch date from Earth:", text = formatDisplayDate(rover.launchDate))
-                    InfoText(label = "Landing date on Mars:", text = formatDisplayDate(rover.landingDate))
-                }
             }
         }
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
-private fun TitleText(text: String) {
-    Text(
-        text = text,
-        style = AppTypography.roverTitle,
-        color = MaterialTheme.colorScheme.secondary,
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis
-    )
-}
-
-@Composable
-private fun InfoText(label: String, text: String) {
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally
+private fun TitleLine(rover: Rover) {
+    val active = rover.status.equals("active", ignoreCase = true)
+    // FlowRow so a long rover name + status chip wrap gracefully instead of truncating tight.
+    FlowRow(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(end = AppSize.roverInfoReserve),
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)
     ) {
         Text(
-            text = label,
-            style = AppTypography.infoLabel,
+            text = rover.name,
+            style = MaterialTheme.typography.titleLarge,
             color = MaterialTheme.colorScheme.secondary,
-            textAlign = TextAlign.Center,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.fillMaxWidth()
-        )
-        Text(
-            text = text,
-            style = AppTypography.infoValue,
-            color = MaterialTheme.colorScheme.onSurface,
-            textAlign = TextAlign.Center,
             maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.fillMaxWidth()
+            overflow = TextOverflow.Ellipsis
+        )
+        StatusBadge(
+            label = if (active) "Active" else "Complete",
+            color = if (active) activeStatusColor() else MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun MetricStrip(rover: Rover) {
+    FlowRow(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.lg),
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)
+    ) {
+        AppMetricItem(
+            symbol = MaterialSymbol.Collections,
+            value = formatCompact(rover.totalPhotos),
+            label = stringResource(Res.string.metric_label_photos)
+        )
+        AppMetricItem(
+            symbol = MaterialSymbol.Schedule,
+            value = formatCompact(rover.maxSol),
+            label = stringResource(Res.string.metric_label_sols)
+        )
+        AppMetricItem(
+            symbol = MaterialSymbol.Event,
+            value = formatDisplayDate(rover.maxDate),
+            label = stringResource(Res.string.metric_label_last)
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/AppColors.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/AppColors.kt
@@ -1,0 +1,20 @@
+package com.sirelon.marsroverphotos.presentation.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+
+/**
+ * Theme-aware "active / live / connected" status green.
+ *
+ * M3 has no green slot, so this color is resolved per applied theme via background luminance —
+ * keeping it legible in both dark and light themes and matching the design's `--t-active` token
+ * (#5BBF86 dark / #2E9E63 light). Use wherever an "active" or "live" state needs a green accent
+ * instead of a literal color.
+ */
+@Composable
+@ReadOnlyComposable
+fun activeStatusColor(): Color =
+    if (MaterialTheme.colorScheme.background.luminance() < 0.5f) Color(0xFF5BBF86) else Color(0xFF2E9E63)

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/AppSize.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/AppSize.kt
@@ -42,6 +42,19 @@ object AppSize {
     /** 16dp — grouped / outlined card corner radius. */
     val cardRadius: Dp = 16.dp
 
+    /** 2dp — resting card elevation (matches the M3 elevated [AppCard] default). */
+    val cardElevationResting: Dp = 2.dp
+
+    /** 6dp — raised card elevation on desktop hover (the subtle lift on a rover row). */
+    val cardElevationHover: Dp = 6.dp
+
+    /** 112dp — fixed width of the full-height portrait thumbnail in a rover row. */
+    val roverThumbWidth: Dp = 112.dp
+
+    /** 40dp — trailing space reserved on a rover row's title line so the name/chip never
+     *  collide with the overlaid top-end info button. */
+    val roverInfoReserve: Dp = 40.dp
+
     /** 13dp — settings-row top/bottom padding. */
     val rowVerticalPadding: Dp = 13.dp
 

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/AppCard.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/AppCard.kt
@@ -1,5 +1,10 @@
 package com.sirelon.marsroverphotos.presentation.ui
 
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.LocalIndication
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardColors
@@ -7,27 +12,60 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CardElevation
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
+import com.sirelon.marsroverphotos.presentation.theme.AppSize
 
 /**
  * Design-system branded card — large-radius (16 dp) elevated card.
  * Drop-in replacement for Material3 [Card] that enforces the app's shape and elevation tokens.
+ *
+ * Pass [onClick] to make the card interactive: the card applies the clickable + a desktop
+ * hover-lift (resting → hover elevation) internally, so callers should hand the card an
+ * [onClick] rather than wrapping it in their own `clickable`/elevation handling. When [onClick]
+ * is null the card is non-interactive and keeps the default resting elevation.
  */
 @Composable
 fun AppCard(
     modifier: Modifier = Modifier,
     shape: Shape = MaterialTheme.shapes.large,
     colors: CardColors = CardDefaults.cardColors(),
-    elevation: CardElevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+    elevation: CardElevation = CardDefaults.cardElevation(defaultElevation = AppSize.cardElevationResting),
+    onClick: (() -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit,
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+    val animatedElevation by animateDpAsState(
+        targetValue = if (isHovered) AppSize.cardElevationHover else AppSize.cardElevationResting,
+        label = "appCardElevation"
+    )
+
+    val cardModifier = if (onClick != null) {
+        modifier.clickable(
+            interactionSource = interactionSource,
+            indication = LocalIndication.current,
+            onClick = onClick
+        )
+    } else {
+        modifier
+    }
+    // Interactive cards animate their elevation on hover; non-interactive cards honor the
+    // caller-supplied [elevation] (e.g. a 4dp header card).
+    val cardElevation: CardElevation = if (onClick != null) {
+        CardDefaults.cardElevation(defaultElevation = animatedElevation)
+    } else {
+        elevation
+    }
+
     Card(
-        modifier = modifier,
+        modifier = cardModifier,
         shape = shape,
         colors = colors,
-        elevation = elevation,
+        elevation = cardElevation,
         content = content,
     )
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/AppMetricItem.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/AppMetricItem.kt
@@ -1,0 +1,50 @@
+package com.sirelon.marsroverphotos.presentation.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import com.sirelon.marsroverphotos.presentation.theme.AppSize
+import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
+
+/**
+ * Design-system inline metric — a leading [symbol] icon, a bold [value], and a dim [label] laid out
+ * in a single row (e.g. "🖼 133,811 photos"). General-purpose: it repeats across a rover row's
+ * metric strip and can be reused anywhere a compact icon + value + label trio is needed.
+ *
+ * Colors are theme roles: the icon and label use `onSurfaceVariant`, the value uses `onSurface`.
+ */
+@Composable
+fun AppMetricItem(
+    symbol: MaterialSymbol,
+    value: String,
+    label: String,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.xs)
+    ) {
+        MaterialSymbolIcon(
+            symbol = symbol,
+            contentDescription = null,
+            size = AppSize.iconInline,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/MaterialSymbolIcon.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/MaterialSymbolIcon.kt
@@ -54,7 +54,11 @@ enum class MaterialSymbol(val iconName: String) {
     Delete("delete"),
     Public("public"),
     ChevronRight("chevron_right"),
-    Reviews("reviews")
+    Reviews("reviews"),
+    Collections("collections"),
+    Schedule("schedule"),
+    Event("event"),
+    Search("search")
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/RoverBlurb.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/RoverBlurb.kt
@@ -1,0 +1,30 @@
+package com.sirelon.marsroverphotos.presentation.ui
+
+import androidx.compose.runtime.Composable
+import com.sirelon.marsroverphotos.domain.models.CURIOSITY_ID
+import com.sirelon.marsroverphotos.domain.models.INSIGHT_ID
+import com.sirelon.marsroverphotos.domain.models.OPPORTUNITY_ID
+import com.sirelon.marsroverphotos.domain.models.PERSEVERANCE_ID
+import com.sirelon.marsroverphotos.domain.models.Rover
+import com.sirelon.marsroverphotos.domain.models.SPIRIT_ID
+import com.sirelon.marsroverphotos.shared.resources.Res
+import com.sirelon.marsroverphotos.shared.resources.rover_blurb_curiosity
+import com.sirelon.marsroverphotos.shared.resources.rover_blurb_insight
+import com.sirelon.marsroverphotos.shared.resources.rover_blurb_opportunity
+import com.sirelon.marsroverphotos.shared.resources.rover_blurb_perseverance
+import com.sirelon.marsroverphotos.shared.resources.rover_blurb_spirit
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+
+/** Returns the localized mission blurb string for this rover, or empty for unknown ids. */
+@Composable
+fun Rover.blurb(): String = blurbResource()?.let { stringResource(it) } ?: ""
+
+fun Rover.blurbResource(): StringResource? = when (id) {
+    CURIOSITY_ID -> Res.string.rover_blurb_curiosity
+    OPPORTUNITY_ID -> Res.string.rover_blurb_opportunity
+    SPIRIT_ID -> Res.string.rover_blurb_spirit
+    INSIGHT_ID -> Res.string.rover_blurb_insight
+    PERSEVERANCE_ID -> Res.string.rover_blurb_perseverance
+    else -> null
+}

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/RoversViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/RoversViewModel.kt
@@ -6,9 +6,12 @@ import com.sirelon.marsroverphotos.domain.models.Rover
 import com.sirelon.marsroverphotos.domain.repositories.RoversRepository
 import com.sirelon.marsroverphotos.platform.Tracker
 import com.sirelon.marsroverphotos.utils.Logger
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 
 class RoversViewModel(
@@ -27,6 +30,21 @@ class RoversViewModel(
             initialValue = emptyList()
         )
 
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
+    val filteredRovers: StateFlow<List<Rover>> = combine(rovers, searchQuery) { list, query ->
+        filterRovers(list, query)
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS),
+        initialValue = emptyList()
+    )
+
+    fun onSearchQueryChange(query: String) {
+        _searchQuery.value = query
+    }
+
     fun onRoverClicked(rover: Rover) {
         tracker.trackClick("click_rover_${rover.name}")
     }
@@ -39,3 +57,7 @@ class RoversViewModel(
         const val STOP_TIMEOUT_MILLIS = 5_000L
     }
 }
+
+internal fun filterRovers(rovers: List<Rover>, query: String): List<Rover> =
+    if (query.isBlank()) rovers
+    else rovers.filter { it.name.contains(query, ignoreCase = true) }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/utils/NumberFormat.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/utils/NumberFormat.kt
@@ -26,3 +26,31 @@ fun formatThousands(value: Long): String {
 }
 
 fun formatThousands(value: Int): String = formatThousands(value.toLong())
+
+/**
+ * KMP-safe compact/abbreviated formatter mirroring the design's `fmtK`:
+ * `<1000` → as-is; `<1,000,000` → "X.YK" (1 decimal below 10,000, else 0 decimal);
+ * `≥1,000,000` → "X.YM".
+ *
+ * Examples: 999 → "999", 1505 → "1.5K", 133811 → "134K", 1_200_000 → "1.2M".
+ */
+fun formatCompact(value: Long): String {
+    if (value < 0) return "-" + formatCompact(-value)
+    return when {
+        value < 1_000L -> value.toString()
+        value < 1_000_000L ->
+            if (value < 10_000L) decimal1(value, 1_000L) + "K" else roundDiv(value, 1_000L).toString() + "K"
+        else -> decimal1(value, 1_000_000L) + "M"
+    }
+}
+
+fun formatCompact(value: Int): String = formatCompact(value.toLong())
+
+/** Rounds value/divisor to the nearest whole number (half-up); value/divisor assumed non-negative. */
+private fun roundDiv(value: Long, divisor: Long): Long = (value + divisor / 2) / divisor
+
+/** Formats value/divisor with exactly one decimal place, half-up rounded, no locale dependency. */
+private fun decimal1(value: Long, divisor: Long): String {
+    val tenths = roundDiv(value * 10, divisor)
+    return "${tenths / 10}.${tenths % 10}"
+}

--- a/shared/src/commonTest/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/RoversFilterTest.kt
+++ b/shared/src/commonTest/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/RoversFilterTest.kt
@@ -1,0 +1,58 @@
+package com.sirelon.marsroverphotos.presentation.viewmodels
+
+import com.sirelon.marsroverphotos.domain.models.Rover
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private fun rover(id: Long, name: String) = Rover(
+    id = id,
+    name = name,
+    drawableName = "",
+    landingDate = "",
+    launchDate = "",
+    status = "active",
+    maxSol = 0L,
+    maxDate = "",
+    totalPhotos = 0
+)
+
+class RoversFilterTest {
+
+    private val curiosity = rover(5L, "Curiosity")
+    private val opportunity = rover(6L, "Opportunity")
+    private val spirit = rover(7L, "Spirit")
+    private val insight = rover(4L, "InSight")
+    private val perseverance = rover(3L, "Perseverance")
+    private val all = listOf(curiosity, opportunity, spirit, insight, perseverance)
+
+    @Test
+    fun blankQuery_returnsAll() {
+        assertEquals(all, filterRovers(all, ""))
+    }
+
+    @Test
+    fun whitespaceQuery_returnsAll() {
+        assertEquals(all, filterRovers(all, "   "))
+    }
+
+    @Test
+    fun exactMatch_returnsSingleRover() {
+        assertEquals(listOf(curiosity), filterRovers(all, "Curiosity"))
+    }
+
+    @Test
+    fun caseInsensitive_matches() {
+        assertEquals(listOf(curiosity), filterRovers(all, "curiosity"))
+    }
+
+    @Test
+    fun partialQuery_returnsSubset() {
+        // "ity" matches Curiosity and Opportunity
+        assertEquals(listOf(curiosity, opportunity), filterRovers(all, "ity"))
+    }
+
+    @Test
+    fun noMatch_returnsEmpty() {
+        assertEquals(emptyList(), filterRovers(all, "Viking"))
+    }
+}

--- a/shared/src/commonTest/kotlin/com/sirelon/marsroverphotos/utils/NumberFormatTest.kt
+++ b/shared/src/commonTest/kotlin/com/sirelon/marsroverphotos/utils/NumberFormatTest.kt
@@ -1,0 +1,27 @@
+package com.sirelon.marsroverphotos.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NumberFormatTest {
+
+    @Test
+    fun formatCompact_belowThousand_returnsAsIs() {
+        assertEquals("999", formatCompact(999))
+    }
+
+    @Test
+    fun formatCompact_belowTenThousand_oneDecimalK() {
+        assertEquals("1.5K", formatCompact(1505))
+    }
+
+    @Test
+    fun formatCompact_atOrAboveTenThousand_zeroDecimalK() {
+        assertEquals("134K", formatCompact(133811))
+    }
+
+    @Test
+    fun formatCompact_millions_oneDecimalM() {
+        assertEquals("1.2M", formatCompact(1_200_000))
+    }
+}


### PR DESCRIPTION
## What

Reimplements the **Rovers** screen from the Claude Design handoff ("Variant A — Refined List"). Replaces the centered-text rover cards with left-aligned Material 3 rows and an adaptive, multi-pane-friendly layout.

### Screen
- **Left-aligned M3 row** (`RoverItem`): fixed-width full-height portrait thumbnail (Crop, medium radius), coral rover name + **Active/Complete** status chip, 2-line mission blurb, hairline-topped metric strip (**Photos · Sols · Last date**), and a top-right info affordance. Whole row → Photos; info button → Mission Info (isolated from the row tap).
- **`Scaffold` + `AppTopBar`** with collapse-on-scroll (`enterAlwaysScrollBehavior`); title "Mars Rovers" + a "{N} missions · {M} active" subtitle.
- **Search hidden behind a top-bar icon** — tapping it reveals a focused field; the close action clears + collapses. Filtering is VM-derived (`combine(rovers, query)`), not in composition.
- **Adaptive grid**: 1 column on compact, 2 on medium+expanded (`isWidthAtLeastBreakpoint`), content capped/centered at `contentMaxWidth` on expanded.

### Design-system additions / reuse
- New `AppMetricItem` (icon · value · label).
- Generalized `activeStatusColor()` theme helper (lifted out of `AboutScreen`; fills the M3 "no green slot" gap).
- `AppCard` gains an optional `onClick` with a built-in desktop **hover-lift** (non-interactive cards still honor a caller-supplied `elevation`).
- `formatCompact()` K/M number formatter (`utils/NumberFormat.kt`).
- Reuses `StatusBadge`, `MarsImage`/`rover.painter()`, `AppSpacing`/`AppSize`/`AppTypography`, `AppEmptyState`.
- Rover mission **blurbs are presentation-only string resources** (no domain/data/API changes).
- `docs/DESIGN_SYSTEM.md` updated (new components, Rovers row anatomy, handoff token mapping, adaptive pattern, gotchas).

## Out of scope (unchanged)
`Rover` domain model, data/API layer, and `RoverMissionInfoScreen` are untouched. Filter chips deferred (only 5 rovers).

## Test plan
- Installed & smoke-tested on **iPhone 15 Pro Max** and **Galaxy A50** (phone single-column; row tap → Photos; info → Mission Info; search toggle/filter; empty-results state).
- `./gradlew :shared:compileKotlinDesktop`, `:shared:assembleSharedDebugXCFramework` (iOS/native), `:shared:compileDebugKotlinAndroid`, and `:shared:desktopTest` all green (incl. `NumberFormatTest`, `RoversFilterTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)