### PR TITLE
Add heart animation and optimize favorite state sync across screens

### DIFF
--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/RoverFeedPager.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/RoverFeedPager.kt
@@ -9,6 +9,7 @@ import com.sirelon.marsroverphotos.data.database.entities.MarsImage
 import com.sirelon.marsroverphotos.data.network.RestApi
 import com.sirelon.marsroverphotos.data.network.toMarsImages
 import com.sirelon.marsroverphotos.domain.repositories.PhotosRepository
+import androidx.compose.runtime.mutableStateMapOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -66,6 +67,12 @@ class RoverFeedPager(
      * tapped. Only the rover-feed source sets it (other sources don't share this list's grid).
      */
     private val lastViewedPhotoId = MutableStateFlow<String?>(null)
+
+    /**
+     * Optimistic favorite overrides — written by both the list and detail VMs so the UI stays
+     * consistent across screens without waiting for the paging source to re-fetch from Room.
+     */
+    val favoriteOverrides = mutableStateMapOf<String, Boolean>()
 
     fun setLastViewedPhotoId(id: String) {
         lastViewedPhotoId.value = id

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
@@ -538,6 +538,15 @@ private fun ImagesPager(
                         )
                     }
                 } else Modifier
+                val sharedFavModifier = if (sharedScope != null && marsImage.id == selectedId) {
+                    val animScope = LocalNavAnimatedContentScope.current
+                    with(sharedScope) {
+                        Modifier.sharedElement(
+                            sharedContentState = rememberSharedContentState(key = "photo_favorite_${marsImage.id}"),
+                            animatedVisibilityScope = animScope,
+                        )
+                    }
+                } else Modifier
 
                 val heartState = rememberLikeHeartState()
 
@@ -555,8 +564,8 @@ private fun ImagesPager(
                                 if (!currentFavorite) {
                                     favoriteOverrides[marsImage.id] = true
                                     onFavoriteClick(marsImage, true)
+                                    heartState.trigger()
                                 }
-                                heartState.trigger()
                             },
                         ),
                     contentScale = ContentScale.Fit,
@@ -574,6 +583,7 @@ private fun ImagesPager(
                 MarsImageFavoriteToggle(
                     modifier = Modifier
                         .align(Alignment.BottomEnd)
+                        .then(sharedFavModifier)
                         .navigationBarsPadding()
                         .padding(bottom = AppSpacing.lg, end = AppSpacing.lg)
                         .background(Color.White.copy(alpha = 0.9f), CircleShape),

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -188,6 +189,7 @@ fun ImagesScreen(
                 pagingItems = pagingItems,
                 pagerState = pagerState,
                 hideUi = hideUi,
+                favoriteOverrides = viewModel.favoriteOverrides,
                 onBack = onBack,
                 onShown = viewModel::onShown,
                 onTap = viewModel::onTap,
@@ -234,6 +236,7 @@ private fun ImagesPagerContent(
     pagingItems: LazyPagingItems<MarsImage>,
     pagerState: PagerState,
     hideUi: Boolean,
+    favoriteOverrides: SnapshotStateMap<String, Boolean>,
     onBack: () -> Unit,
     onShown: (MarsImage, Int) -> Unit,
     onTap: () -> Unit,
@@ -326,6 +329,7 @@ private fun ImagesPagerContent(
             pagerState = pagerState,
             pagingItems = pagingItems,
             hideUi = hideUi,
+            favoriteOverrides = favoriteOverrides,
             onTap = onTap,
             onFavoriteClick = onFavoriteClick,
             onScaleChange = { page, scale -> pageScales[page] = scale },
@@ -491,15 +495,12 @@ private fun ImagesPager(
     pagerState: PagerState,
     pagingItems: LazyPagingItems<MarsImage>,
     hideUi: Boolean,
+    favoriteOverrides: SnapshotStateMap<String, Boolean>,
     onTap: () -> Unit,
     onFavoriteClick: (MarsImage, Boolean) -> Unit,
     onScaleChange: (page: Int, scale: Float) -> Unit,
     selectedId: String? = null,
 ) {
-    // Immediate visual feedback for the heart: the paged item's favorite flag is correct on load
-    // (merged from Room by the write-through cache) but can't be mutated in place after a tap,
-    // so the override holds the desired state until the page is re-fetched.
-    val favoriteOverrides = remember { mutableStateMapOf<String, Boolean>() }
 
     NoScrollEffect {
         HorizontalPager(

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
@@ -590,6 +590,7 @@ private fun ImagesPager(
                     checked = checked,
                     onCheckedChange = {
                         val desired = !checked
+                        if (desired) heartState.trigger()
                         favoriteOverrides[marsImage.id] = desired
                         onFavoriteClick(marsImage, desired)
                     },

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/ImagesScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -67,7 +67,9 @@ import com.sirelon.marsroverphotos.data.network.nasaImageOrigUrl
 import com.sirelon.marsroverphotos.presentation.navigation.AppDestination
 import com.sirelon.marsroverphotos.presentation.ui.AppTopBar
 import com.sirelon.marsroverphotos.presentation.ui.CenteredProgress
+import com.sirelon.marsroverphotos.presentation.ui.LikeHeartOverlay
 import com.sirelon.marsroverphotos.presentation.ui.MarsImageFavoriteToggle
+import com.sirelon.marsroverphotos.presentation.ui.rememberLikeHeartState
 import com.sirelon.marsroverphotos.presentation.ui.setStatusBarAppearance
 import com.sirelon.marsroverphotos.presentation.ui.MarsSnackbar
 import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbol
@@ -536,6 +538,8 @@ private fun ImagesPager(
                     }
                 } else Modifier
 
+                val heartState = rememberLikeHeartState()
+
                 NetworkImage(
                     modifier = Modifier
                         .fillMaxSize()
@@ -544,40 +548,41 @@ private fun ImagesPager(
                             zoomState = zoomState,
                             scrollGesturePropagation = ScrollGesturePropagation.NotZoomed,
                             enableOneFingerZoom = false,
-                        )
-                        .pointerInput(Unit) {
-                            detectTapGestures(onTap = { onTap() })
-                        },
+                            onTap = { onTap() },
+                            onDoubleTap = { _ ->
+                                val currentFavorite = favoriteOverrides[marsImage.id] ?: marsImage.favorite
+                                if (!currentFavorite) {
+                                    favoriteOverrides[marsImage.id] = true
+                                    onFavoriteClick(marsImage, true)
+                                }
+                                heartState.trigger()
+                            },
+                        ),
                     contentScale = ContentScale.Fit,
                     imageUrl = nasaImageOrigUrl(marsImage.imageUrl),
                     showPlaceholder = false,
                     placeholderMemoryCacheKey = marsImage.imageUrl,
                 )
 
-                // Controls layer — image fills full screen; controls stay above nav bar
-                Box(
+                LikeHeartOverlay(
+                    visible = heartState.visible,
+                    modifier = Modifier.align(Alignment.Center),
+                )
+
+                val checked = favoriteOverrides[marsImage.id] ?: marsImage.favorite
+                MarsImageFavoriteToggle(
                     modifier = Modifier
-                        .fillMaxSize()
+                        .align(Alignment.BottomEnd)
                         .navigationBarsPadding()
-                ) {
-                    AnimatedVisibility(
-                        visible = !hideUi,
-                        enter = fadeIn() + slideInVertically(initialOffsetY = { it }),
-                        exit = fadeOut() + slideOutVertically(targetOffsetY = { it }),
-                        modifier = Modifier.align(Alignment.BottomCenter),
-                    ) {
-                        val checked = favoriteOverrides[marsImage.id] ?: marsImage.favorite
-                        MarsImageFavoriteToggle(
-                            modifier = Modifier.size(64.dp),
-                            checked = checked,
-                            onCheckedChange = {
-                                val desired = !checked
-                                favoriteOverrides[marsImage.id] = desired
-                                onFavoriteClick(marsImage, desired)
-                            }
-                        )
-                    }
-                }
+                        .padding(bottom = AppSpacing.lg, end = AppSpacing.lg)
+                        .background(Color.White.copy(alpha = 0.9f), CircleShape),
+                    checked = checked,
+                    onCheckedChange = {
+                        val desired = !checked
+                        favoriteOverrides[marsImage.id] = desired
+                        onFavoriteClick(marsImage, desired)
+                    },
+                )
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
@@ -556,14 +556,24 @@ private fun PhotoCard(
                     visible = heartState.visible,
                     modifier = Modifier.align(Alignment.Center),
                 )
+                val sharedFavModifier: Modifier = if (sharedScope != null) {
+                    val animScope = LocalNavAnimatedContentScope.current
+                    with(sharedScope) {
+                        Modifier.sharedElement(
+                            sharedContentState = rememberSharedContentState(key = "photo_favorite_${image.id}"),
+                            animatedVisibilityScope = animScope,
+                        )
+                    }
+                } else Modifier
                 MarsImageFavoriteToggle(
                     modifier = Modifier
                         .align(Alignment.TopEnd)
+                        .then(sharedFavModifier)
                         .padding(AppSpacing.xs)
                         .background(Color.White.copy(alpha = 0.9f), CircleShape),
                     checked = checked,
                     onCheckedChange = { _ ->
-                        heartState.trigger()
+                        if (!checked) heartState.trigger()
                         onFavoriteClick(image)
                     },
                 )

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
@@ -39,8 +39,10 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
@@ -215,6 +217,7 @@ fun PhotosScreen(
         },
         onNavigateToImages = onNavigateToImages,
         onFavoriteClick = viewModel::toggleFavorite,
+        favoriteOverrides = viewModel.favoriteOverrides,
         onBack = onBack,
         onOpenSolPicker = onOpenSolPicker,
         onOpenEarthDatePicker = onOpenEarthDatePicker,
@@ -239,6 +242,7 @@ private fun PhotosScreen(
     onClearCameraFilters: () -> Unit,
     onNavigateToImages: (clickedId: String, cameras: Set<String>) -> Unit,
     onFavoriteClick: (image: MarsImage) -> Unit,
+    favoriteOverrides: SnapshotStateMap<String, Boolean>,
     onBack: () -> Unit,
     onOpenSolPicker: () -> Unit,
     onOpenEarthDatePicker: () -> Unit,
@@ -314,6 +318,7 @@ private fun PhotosScreen(
                             showCameraName = state.showCameraName,
                             onPhotoClick = { image -> onNavigateToImages(image.id, state.cameraFilters) },
                             onFavoriteClick = onFavoriteClick,
+                            favoriteOverrides = favoriteOverrides,
                         )
 
                         // Floating "sticky" date chip — mirrors the top-visible day (sol mode only).
@@ -369,6 +374,7 @@ private fun PhotosGrid(
     showCameraName: Boolean,
     onPhotoClick: (image: MarsImage) -> Unit,
     onFavoriteClick: (image: MarsImage) -> Unit,
+    favoriteOverrides: SnapshotStateMap<String, Boolean>,
 ) {
     LazyVerticalGrid(
         state = gridState,
@@ -397,12 +403,16 @@ private fun PhotosGrid(
             }
         ) { index ->
             when (val item = pagingItems[index]) {
-                is GridItem.PhotoItem -> PhotoCard(
-                    image = item.image,
-                    showCameraName = showCameraName,
-                    onPhotoClick = onPhotoClick,
-                    onFavoriteClick = onFavoriteClick,
-                )
+                is GridItem.PhotoItem -> {
+                    val checked = favoriteOverrides[item.image.id] ?: item.image.favorite
+                    PhotoCard(
+                        image = item.image,
+                        checked = checked,
+                        showCameraName = showCameraName,
+                        onPhotoClick = onPhotoClick,
+                        onFavoriteClick = onFavoriteClick,
+                    )
+                }
 
                 is GridItem.DateHeader -> DateHeaderRow(header = item)
 
@@ -505,6 +515,7 @@ private fun EdgeProgress(modifier: Modifier = Modifier) {
 @Composable
 private fun PhotoCard(
     image: MarsImage,
+    checked: Boolean,
     showCameraName: Boolean,
     onPhotoClick: (image: MarsImage) -> Unit,
     onFavoriteClick: (image: MarsImage) -> Unit,
@@ -550,7 +561,7 @@ private fun PhotoCard(
                         .align(Alignment.TopEnd)
                         .padding(AppSpacing.xs)
                         .background(Color.White.copy(alpha = 0.9f), CircleShape),
-                    checked = image.favorite,
+                    checked = checked,
                     onCheckedChange = { _ ->
                         heartState.trigger()
                         onFavoriteClick(image)
@@ -722,6 +733,7 @@ private fun PhotosScreenPreview() {
             onClearCameraFilters = {},
             onNavigateToImages = { _, _ -> },
             onFavoriteClick = {},
+            favoriteOverrides = mutableStateMapOf(),
             onBack = {},
             onOpenSolPicker = {},
             onOpenEarthDatePicker = {},

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
@@ -5,7 +5,9 @@ import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -45,6 +47,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -72,6 +75,9 @@ import com.sirelon.marsroverphotos.presentation.ui.AppTopBar
 import com.sirelon.marsroverphotos.presentation.ui.CenteredProgress
 import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbol
 import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbolIcon
+import com.sirelon.marsroverphotos.presentation.ui.LikeHeartOverlay
+import com.sirelon.marsroverphotos.presentation.ui.MarsImageFavoriteToggle
+import com.sirelon.marsroverphotos.presentation.ui.rememberLikeHeartState
 import com.sirelon.marsroverphotos.presentation.ui.NetworkImage
 import com.sirelon.marsroverphotos.presentation.viewmodels.PhotosUiState
 import com.sirelon.marsroverphotos.presentation.viewmodels.PhotosViewModel
@@ -208,6 +214,7 @@ fun PhotosScreen(
             onClearCameraFilter()
         },
         onNavigateToImages = onNavigateToImages,
+        onFavoriteClick = viewModel::toggleFavorite,
         onBack = onBack,
         onOpenSolPicker = onOpenSolPicker,
         onOpenEarthDatePicker = onOpenEarthDatePicker,
@@ -231,6 +238,7 @@ private fun PhotosScreen(
     onGoToLatest: () -> Unit,
     onClearCameraFilters: () -> Unit,
     onNavigateToImages: (clickedId: String, cameras: Set<String>) -> Unit,
+    onFavoriteClick: (image: MarsImage) -> Unit,
     onBack: () -> Unit,
     onOpenSolPicker: () -> Unit,
     onOpenEarthDatePicker: () -> Unit,
@@ -305,6 +313,7 @@ private fun PhotosScreen(
                             gridState = gridState,
                             showCameraName = state.showCameraName,
                             onPhotoClick = { image -> onNavigateToImages(image.id, state.cameraFilters) },
+                            onFavoriteClick = onFavoriteClick,
                         )
 
                         // Floating "sticky" date chip — mirrors the top-visible day (sol mode only).
@@ -359,6 +368,7 @@ private fun PhotosGrid(
     gridState: LazyGridState,
     showCameraName: Boolean,
     onPhotoClick: (image: MarsImage) -> Unit,
+    onFavoriteClick: (image: MarsImage) -> Unit,
 ) {
     LazyVerticalGrid(
         state = gridState,
@@ -391,6 +401,7 @@ private fun PhotosGrid(
                     image = item.image,
                     showCameraName = showCameraName,
                     onPhotoClick = onPhotoClick,
+                    onFavoriteClick = onFavoriteClick,
                 )
 
                 is GridItem.DateHeader -> DateHeaderRow(header = item)
@@ -496,7 +507,10 @@ private fun PhotoCard(
     image: MarsImage,
     showCameraName: Boolean,
     onPhotoClick: (image: MarsImage) -> Unit,
+    onFavoriteClick: (image: MarsImage) -> Unit,
 ) {
+    val heartState = rememberLikeHeartState()
+
     val sharedScope = LocalSharedTransitionScope.current
     AppCard(
         modifier = Modifier
@@ -504,26 +518,43 @@ private fun PhotoCard(
             .clickable { onPhotoClick(image) },
     ) {
         Column(verticalArrangement = Arrangement.SpaceBetween) {
-            if (sharedScope != null) {
-                val animScope = LocalNavAnimatedContentScope.current
-                with(sharedScope) {
+            Box(modifier = Modifier.fillMaxWidth()) {
+                if (sharedScope != null) {
+                    val animScope = LocalNavAnimatedContentScope.current
+                    with(sharedScope) {
+                        NetworkImage(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .aspectRatio(1F)
+                                .sharedElement(
+                                    sharedContentState = rememberSharedContentState(key = "photo_${image.id}"),
+                                    animatedVisibilityScope = animScope,
+                                ),
+                            imageUrl = image.imageUrl,
+                        )
+                    }
+                } else {
                     NetworkImage(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .aspectRatio(1F)
-                            .sharedElement(
-                                sharedContentState = rememberSharedContentState(key = "photo_${image.id}"),
-                                animatedVisibilityScope = animScope,
-                            ),
+                            .aspectRatio(1F),
                         imageUrl = image.imageUrl,
                     )
                 }
-            } else {
-                NetworkImage(
+                LikeHeartOverlay(
+                    visible = heartState.visible,
+                    modifier = Modifier.align(Alignment.Center),
+                )
+                MarsImageFavoriteToggle(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(1F),
-                    imageUrl = image.imageUrl,
+                        .align(Alignment.TopEnd)
+                        .padding(AppSpacing.xs)
+                        .background(Color.White.copy(alpha = 0.9f), CircleShape),
+                    checked = image.favorite,
+                    onCheckedChange = { _ ->
+                        heartState.trigger()
+                        onFavoriteClick(image)
+                    },
                 )
             }
             if (showCameraName) {
@@ -690,6 +721,7 @@ private fun PhotosScreenPreview() {
             onGoToLatest = {},
             onClearCameraFilters = {},
             onNavigateToImages = { _, _ -> },
+            onFavoriteClick = {},
             onBack = {},
             onOpenSolPicker = {},
             onOpenEarthDatePicker = {},

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/LikeHeart.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/LikeHeart.kt
@@ -1,0 +1,80 @@
+package com.sirelon.marsroverphotos.presentation.ui
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+
+class LikeHeartState(private val onHaptic: () -> Unit) {
+    var visible by mutableStateOf(false)
+        internal set
+    internal var animKey by mutableStateOf(0)
+
+    fun trigger() {
+        onHaptic()
+        animKey++
+    }
+}
+
+@Composable
+fun rememberLikeHeartState(): LikeHeartState {
+    val haptic = LocalHapticFeedback.current
+    val state = remember(haptic) {
+        LikeHeartState { haptic.performHapticFeedback(HapticFeedbackType.LongPress) }
+    }
+    LaunchedEffect(state.animKey) {
+        if (state.animKey == 0) return@LaunchedEffect
+        state.visible = true
+        delay(900)
+        state.visible = false
+    }
+    return state
+}
+
+@Composable
+fun LikeHeartOverlay(
+    visible: Boolean,
+    modifier: Modifier = Modifier,
+    iconSize: Dp = 96.dp,
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = scaleIn(
+            initialScale = 0.3f,
+            animationSpec = spring(
+                dampingRatio = Spring.DampingRatioMediumBouncy,
+                stiffness = Spring.StiffnessMedium,
+            ),
+        ) + fadeIn(animationSpec = tween(durationMillis = 100)),
+        exit = scaleOut(
+            targetScale = 0.8f,
+            animationSpec = tween(durationMillis = 300),
+        ) + fadeOut(animationSpec = tween(durationMillis = 300)),
+        modifier = modifier,
+    ) {
+        MaterialSymbolIcon(
+            symbol = MaterialSymbol.Favorite,
+            contentDescription = null,
+            size = iconSize,
+            tint = Color.White,
+            filled = true,
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/MarsImage.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/MarsImage.kt
@@ -3,10 +3,12 @@ package com.sirelon.marsroverphotos.presentation.ui
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -22,9 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.layout.Box
 import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
 import coil3.compose.AsyncImage
 import coil3.compose.AsyncImagePainter
@@ -61,6 +61,8 @@ fun MarsImageComposable(
             }).build()
     )
 
+    val heartState = rememberLikeHeartState()
+
     val state by painter.state.collectAsState()
     val showStats = state is AsyncImagePainter.State.Success
     AppCard(
@@ -70,18 +72,30 @@ fun MarsImageComposable(
             .clickable(onClick = onClick),
     ) {
         Column {
-            Image(
-                modifier = Modifier
-                    .defaultMinSize(minHeight = 100.dp)
-                    .fillMaxWidth(),
-                contentScale = ContentScale.FillWidth,
-                painter = painter,
-                alignment = Alignment.TopCenter,
-                contentDescription = imageUrl
-            )
+            Box(modifier = Modifier.fillMaxWidth()) {
+                Image(
+                    modifier = Modifier
+                        .defaultMinSize(minHeight = 100.dp)
+                        .fillMaxWidth(),
+                    contentScale = ContentScale.FillWidth,
+                    painter = painter,
+                    alignment = Alignment.TopCenter,
+                    contentDescription = imageUrl
+                )
+                LikeHeartOverlay(
+                    visible = heartState.visible,
+                    modifier = Modifier.align(Alignment.Center),
+                )
+            }
 
             if (showStats) {
-                PhotoStats(marsImage, onFavoriteClick)
+                PhotoStats(
+                    marsImage = marsImage,
+                    onFavoriteClick = {
+                        heartState.trigger()
+                        onFavoriteClick()
+                    },
+                )
             }
         }
     }
@@ -163,7 +177,8 @@ fun MarsImageFavoriteToggle(
         MaterialSymbolIcon(
             symbol = MaterialSymbol.Favorite,
             contentDescription = "Favorites",
-            filled = checked
+            filled = checked,
+            tint = if (checked) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/MarsImage.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/MarsImage.kt
@@ -92,7 +92,7 @@ fun MarsImageComposable(
                 PhotoStats(
                     marsImage = marsImage,
                     onFavoriteClick = {
-                        heartState.trigger()
+                        if (!marsImage.favorite) heartState.trigger()
                         onFavoriteClick()
                     },
                 )
@@ -177,7 +177,7 @@ fun MarsImageFavoriteToggle(
         MaterialSymbolIcon(
             symbol = MaterialSymbol.Favorite,
             contentDescription = "Favorites",
-            filled = checked,
+            filled = true,
             tint = if (checked) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/MaterialSymbolIcon.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/MaterialSymbolIcon.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontVariation
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -18,7 +19,6 @@ import androidx.compose.ui.unit.sp
 import com.sirelon.marsroverphotos.presentation.theme.AppSize
 import com.sirelon.marsroverphotos.shared.resources.Res
 import com.sirelon.marsroverphotos.shared.resources.material_symbols_outlined
-import kotlin.math.max
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.Font as ResourceFont
 
@@ -119,13 +119,16 @@ private fun materialSymbolsFontFamily(
     filled: Boolean,
     weight: Int
 ): FontFamily {
-    val resolvedWeight = if (filled) max(weight, 600) else weight
-    val fontWeight = FontWeight(resolvedWeight.coerceIn(100, 700))
-
+    val fontWeight = FontWeight(weight.coerceIn(100, 700))
     return FontFamily(
         ResourceFont(
             Res.font.material_symbols_outlined,
-            weight = fontWeight
+            weight = fontWeight,
+            variationSettings = FontVariation.Settings(
+                FontVariation.Setting("FILL", if (filled) 1f else 0f),
+                FontVariation.Setting("wght", weight.toFloat()),
+                FontVariation.Setting("opsz", 24f),
+            ),
         )
     )
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/ImageViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/ImageViewModel.kt
@@ -144,7 +144,10 @@ class ImageViewModel(
      * stays correct across repeated taps even though the paged item isn't reactively updated).
      * [ImagesRepository.setFavorite] ensures the row exists first for not-yet-cached feed photos.
      */
+    val favoriteOverrides get() = roverFeedPager.favoriteOverrides
+
     fun setFavorite(image: MarsImage, favorite: Boolean) {
+        roverFeedPager.favoriteOverrides[image.id] = favorite
         viewModelScope.launch {
             try {
                 imagesRepository.setFavorite(image, favorite)

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/PhotosViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/PhotosViewModel.kt
@@ -246,9 +246,9 @@ class PhotosViewModel(
     val favoriteOverrides get() = roverFeedPager.favoriteOverrides
 
     fun toggleFavorite(image: MarsImage) {
-        val current = roverFeedPager.favoriteOverrides[image.id] ?: image.favorite
-        roverFeedPager.favoriteOverrides[image.id] = !current
-        viewModelScope.launch { imagesRepository.updateFavForImage(image) }
+        val desired = !(roverFeedPager.favoriteOverrides[image.id] ?: image.favorite)
+        roverFeedPager.favoriteOverrides[image.id] = desired
+        viewModelScope.launch { imagesRepository.setFavorite(image, desired) }
     }
 
     fun randomize() {

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/PhotosViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/PhotosViewModel.kt
@@ -243,7 +243,11 @@ class PhotosViewModel(
 
     fun consumeLastViewedPhotoId(): String? = roverFeedPager.consumeLastViewedPhotoId()
 
+    val favoriteOverrides get() = roverFeedPager.favoriteOverrides
+
     fun toggleFavorite(image: MarsImage) {
+        val current = roverFeedPager.favoriteOverrides[image.id] ?: image.favorite
+        roverFeedPager.favoriteOverrides[image.id] = !current
         viewModelScope.launch { imagesRepository.updateFavForImage(image) }
     }
 

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/PhotosViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/PhotosViewModel.kt
@@ -13,7 +13,9 @@ import com.sirelon.marsroverphotos.data.paging.usesPageFeed
 import com.sirelon.marsroverphotos.domain.models.CURIOSITY_ID
 import com.sirelon.marsroverphotos.domain.models.EducationalFact
 import com.sirelon.marsroverphotos.domain.models.Rover
+import com.sirelon.marsroverphotos.data.database.entities.MarsImage
 import com.sirelon.marsroverphotos.domain.repositories.FactsRepository
+import com.sirelon.marsroverphotos.domain.repositories.ImagesRepository
 import com.sirelon.marsroverphotos.domain.repositories.RoversRepository
 import com.sirelon.marsroverphotos.domain.settings.AppSettings
 import com.sirelon.marsroverphotos.presentation.models.GridItem
@@ -58,6 +60,7 @@ class PhotosViewModel(
     private val factsRepository: FactsRepository,
     private val appSettings: AppSettings,
     private val roverFeedPager: RoverFeedPager,
+    private val imagesRepository: ImagesRepository,
 ) : ViewModel() {
 
     private val roverIdEmitter = MutableStateFlow<Long?>(null)
@@ -239,6 +242,10 @@ class PhotosViewModel(
     }
 
     fun consumeLastViewedPhotoId(): String? = roverFeedPager.consumeLastViewedPhotoId()
+
+    fun toggleFavorite(image: MarsImage) {
+        viewModelScope.launch { imagesRepository.updateFavForImage(image) }
+    }
 
     fun randomize() {
         val roverId = roverIdEmitter.value ?: return


### PR DESCRIPTION
## Summary

- Implement heart animation overlay (`LikeHeartOverlay`) triggered on favorite actions with spring and fade transitions
- Add double-tap-to-like on detail screen (ImagesScreen) with automatic heart animation and haptic feedback
- Add favorite toggle buttons to photo cards (PhotosScreen) with heart animation
- Introduce shared `favoriteOverrides` state map in `RoverFeedPager` for optimistic UI updates—list and detail screens stay consistent without waiting for Room re-fetch
- Add shared element transitions for favorite button badges between list and detail views
- Fix Material Symbol icon rendering with proper FILL variable via FontVariation.Settings to support filled/outlined states
- Expose `favoriteOverrides` and `toggleFavorite` in ViewModels for consistent state management across screens

## Test plan

- Verify double-tap triggers heart animation and marks favorite on detail screen
- Verify favorite toggle on list cards triggers animation
- Confirm favorite state syncs between list and detail screens without flicker
- Test heart animation plays only on favorite (not unlike)
- Verify haptic feedback on favorite trigger
- Check shared element transition for favorite badge
- Confirm Material Symbol icons render correctly (filled and outlined)