### PR TITLE
Pagination overhaul: popular-feed fixes, page-keyed Spirit/Opportunity feed with random anchor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,9 @@ Feature screens and view models live in `shared/src/commonMain/kotlin/com/sirelo
 
 The KMP migration is complete. The legacy `app/` module has been deleted.
 
+## Photo Feed & Data Sources
+The heart of the app is the shared rover photo feed in `shared/.../data/paging/`: an app-singleton `RoverFeedPager` exposes one cached `PagingData` stream collected by both the list grid and the fullscreen viewer, with a per-rover `FeedMode` seam — sol-keyed (`SolPagingSource`: Curiosity, Perseverance, InSight) vs page-keyed with a random anchor (`ImagesSearchPagingSource`: Spirit, Opportunity). The class KDocs there document the non-obvious invariants (continuation pages, anchor resolution, write-through cache merge rules) — read them before touching paging. Data-source constraints: the classic `api.nasa.gov/mars-photos` API is permanently dead; Spirit/Opportunity only exist in the curated images.nasa.gov library (no raw archive API); each rover's source is mapped in the repository/network layer.
+
 ## Dependency Versions
 Beta, alpha, and RC dependency versions are acceptable in this project. Prefer the version that unlocks a needed multiplatform capability over waiting for a stable release (e.g., `lifecycle-viewmodel-navigation3` requires `2.11.0+` for the iOS/Desktop/Web ViewModelStore Nav3 APIs; `2.10.0` was Android-only). When pinning a pre-release, record why it is required so the choice stays revisitable, but do not reject a pre-release on stability grounds alone.
 
@@ -21,7 +24,11 @@ Beta, alpha, and RC dependency versions are acceptable in this project. Prefer t
 - `./gradlew :shared:desktopTest` — run the shared KMP/common tests on the desktop JVM target.
 - `./gradlew connectedDebugAndroidTest` — launch instrumentation tests on an attached emulator or device.
 - `./gradlew detekt` — lint and autocorrect according to `config/detekt/detekt.yml`.
+- `./gradlew :shared:compileAndroidMain` — quick Android-target compile check of shared code (AGP 9 KMP task naming; there is no `compileDebugKotlinAndroid` on `:shared`).
 Run commands from the repository root so the Gradle wrapper can supply the pinned toolchain.
+
+### iOS dev builds
+The Xcode project consumes a prebuilt framework from `shared/build/XCFrameworks/debug/shared.xcframework` — in a fresh clone/worktree (or after any shared-code change) run `./gradlew :shared:assembleSharedDebugXCFramework` before building the iOS app, or Xcode fails with "There is no XCFramework found". `iosApp/iosApp/GoogleService-Info.plist` is gitignored; copy it from an existing checkout or Firebase console, otherwise the build fails on a missing input file.
 
 ## Versioning
 The app version lives in **one place**: `buildSrc/src/main/kotlin/AppVersion.kt` (`name` = marketing version, `code` = build number). Android (`androidApp/build.gradle.kts`) and Desktop (`desktopApp/build.gradle.kts`) read it directly at build time. iOS can't read Kotlin, so it's kept in sync via Gradle tasks (group `versioning`, defined in `gradle/versioning.gradle.kts`):
@@ -45,7 +52,7 @@ Reuse the `App*` components in `presentation/ui/` before adding new ones; prefer
 updated**: when you add a reusable component, a token, or learn a UI gotcha, record it there.
 
 ## Testing Guidelines
-Place unit specs in `shared/src/commonTest` (or `androidTest` for Android-instrumented tests), mirroring the source package and ending class names with `*Test`. Use JUnit4 and Mockito-Kotlin for Android tests. Compose UI or Room integration checks belong in `androidApp/src/androidTest` and should describe the scenario in the test name. Cover paging boundaries, offline caching, and error flows whenever you touch those areas.
+Place unit specs in `shared/src/commonTest` (or `androidTest` for Android-instrumented tests), mirroring the source package and ending class names with `*Test`. Common tests use `kotlin.test` + `kotlinx-coroutines-test` with hand-rolled fakes (see `data/paging/Fakes.kt`) — no mocking library in commonTest; JUnit4 and Mockito-Kotlin apply to Android-instrumented tests only. Paging behavior should be verified at two levels: `PagingSource.load()` unit tests, plus `TestPager` (androidx.paging:paging-testing, KMP) for Pager-level invariants like continuation pages and end-of-pagination. Compose UI or Room integration checks belong in `androidApp/src/androidTest` and should describe the scenario in the test name. Cover paging boundaries, offline caching, and error flows whenever you touch those areas.
 
 ## Commit & Pull Request Guidelines
 Follow the existing history with concise imperative subject lines under ~70 characters (e.g., `Fix release build`). Keep functional changes grouped per commit. Pull requests need a short summary, call out UI or API changes, link issues, and attach emulator screenshots or recordings when visuals move. Confirm `assembleDebug`, `testDebugUnitTest`, `:shared:desktopTest`, and `detekt` succeed before requesting review.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -150,6 +150,7 @@ lifecycle-runtime-compose-multiplatform = { module = "org.jetbrains.androidx.lif
 # Paging Multiplatform
 paging-common = { module = "androidx.paging:paging-common", version.ref = "paging" }
 paging-compose = { module = "androidx.paging:paging-compose", version.ref = "paging" }
+paging-testing = { module = "androidx.paging:paging-testing", version.ref = "paging" }
 
 navigation3-runtime = { group = "androidx.navigation3", name = "navigation3-runtime", version.ref = "navigation3" }
 navigation3-ui = { group = "org.jetbrains.androidx.navigation3", name = "navigation3-ui", version.ref = "navigation3" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -176,6 +176,8 @@ kotlin {
             @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
             implementation(libs.kotlin.test.annotations.common)
             implementation(libs.kotlinx.coroutines.test)
+            // TestPager for pager-level integration tests (KMP since paging 3.3.0)
+            implementation(libs.paging.testing)
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/dao/ImagesDao.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/dao/ImagesDao.kt
@@ -8,7 +8,7 @@ import androidx.room3.Query
 import androidx.room3.Transaction
 import androidx.room3.Update
 import com.sirelon.marsroverphotos.data.database.entities.MarsImage
-import com.sirelon.marsroverphotos.data.database.entities.StatsUpdate
+import com.sirelon.marsroverphotos.data.database.entities.PopularUpdate
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -21,7 +21,10 @@ interface ImagesDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertImages(images: List<MarsImage>): List<Long>
 
-    @Query("SELECT * FROM images WHERE id IN (:ids) ORDER BY `order` ASC")
+    // `order` is not unique (it restarts per sol / per popular batch), so every ordered query
+    // adds `id` as a tiebreaker — offset-based paging over a non-deterministic tie order can
+    // duplicate or skip items across page boundaries.
+    @Query("SELECT * FROM images WHERE id IN (:ids) ORDER BY `order` ASC, id ASC")
     fun getImagesByIds(ids: List<String>): Flow<List<MarsImage>>
 
     @Query("SELECT * FROM images")
@@ -34,26 +37,31 @@ interface ImagesDao {
     suspend fun updateFavorite(id: String, favorite: Boolean, counter: Long)
 
     @Update(entity = MarsImage::class)
-    suspend fun updateStats(stats: StatsUpdate)
+    suspend fun updatePopular(update: PopularUpdate)
 
     @Query("SELECT * FROM images WHERE id IN (:ids)")
     suspend fun loadImagesByIds(ids: List<String>): List<MarsImage>
 
-    @Query("SELECT * FROM images WHERE favorite = 1 ORDER BY `order` ASC")
+    @Query("SELECT * FROM images WHERE favorite = 1 ORDER BY `order` ASC, id ASC")
     fun loadFavoriteImages(): Flow<List<MarsImage>>
 
-    @Query("SELECT * FROM images WHERE popular = 1 ORDER BY `order` ASC")
+    @Query("SELECT * FROM images WHERE popular = 1 ORDER BY `order` ASC, id ASC")
     fun loadPopularImages(): Flow<List<MarsImage>>
 
     // room-paging supports all KMP targets since room3 3.0.0-alpha05 (b/339934824)
-    @Query("SELECT * FROM images WHERE favorite = 1 ORDER BY `order` ASC")
+    @Query("SELECT * FROM images WHERE favorite = 1 ORDER BY `order` ASC, id ASC")
     fun loadFavoritePagedSource(): PagingSource<Int, MarsImage>
 
-    @Query("SELECT * FROM images WHERE popular = 1 ORDER BY `order` ASC")
+    @Query("SELECT * FROM images WHERE popular = 1 ORDER BY `order` ASC, id ASC")
     fun loadPopularPagedSource(): PagingSource<Int, MarsImage>
 
-    @Query("DELETE FROM images WHERE popular = 1")
-    suspend fun deleteAllPopular()
+    /**
+     * Resets the popular flag on a REFRESH instead of deleting rows: deleting would drop
+     * favorited photos and rows cached by the sol feed. Flag-reset preserves them;
+     * [deleteNonUserImagesBeyondCount] handles cleanup of no-longer-referenced rows.
+     */
+    @Query("UPDATE images SET popular = 0 WHERE popular = 1")
+    suspend fun clearPopularFlags()
 
     /**
      * Evicts cached (non-favorite, non-popular) images, keeping the [keepCount] most-recently

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/entities/MarsImage.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/entities/MarsImage.kt
@@ -40,11 +40,14 @@ data class MarsImage(
 }
 
 /**
- * Helper class for updating stats only
+ * Helper class for marking an existing row as popular: updates the popular flag,
+ * the ranking order and stats without touching the rest of the row.
  */
-class StatsUpdate(
+class PopularUpdate(
     @PrimaryKey
     val id: String,
+    val popular: Boolean,
+    val order: Int,
     @Embedded(prefix = "counter_")
     val stats: MarsImage.Stats
 )

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/network/NasaApi.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/network/NasaApi.kt
@@ -31,12 +31,15 @@ internal class NasaApi(private val ktor: HttpClient) {
         q: String,
         page: Int,
         pageSize: Int = 100,
+        keywords: String? = null,
     ): NasaImagesSearchResponse {
         return ktor.get("https://images-api.nasa.gov/search") {
             parameter("q", q)
             parameter("media_type", "image")
             parameter("page", page)
             parameter("page_size", pageSize)
+            // Ktor drops null parameters, so keywords is only sent when provided.
+            parameter("keywords", keywords)
         }.body()
     }
 

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/network/RestApi.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/network/RestApi.kt
@@ -118,7 +118,8 @@ class RestApi {
         query: String,
         page: Int,
         pageSize: Int = 100,
-    ): NasaImagesSearchResponse = nasaApi.searchImages(query, page, pageSize)
+        keywords: String? = null,
+    ): NasaImagesSearchResponse = nasaApi.searchImages(query, page, pageSize, keywords)
 
     suspend fun getPerseveranceLatestPhotos(count: Int = 1): List<MarsImage> {
         val response = nasaApi.getPerseveranceRawImages(count = count)

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/FeedMode.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/FeedMode.kt
@@ -26,11 +26,19 @@ sealed interface FeedMode {
 fun Long.usesPageFeed(): Boolean = this == SPIRIT_ID || this == OPPORTUNITY_ID
 
 /**
- * Returns the images.nasa.gov search query for this page-feed rover.
+ * Returns the images.nasa.gov search query for this page-feed rover. Combined with
+ * [MER_KEYWORDS] for precision, the bare rover name yields the largest relevant gallery
+ * (Spirit: 434 vs 267 hits for "Spirit rover", verified 2026-06-12).
  * Only valid for rover IDs where [usesPageFeed] is true.
  */
 fun Long.pageQuery(): String = when (this) {
-    SPIRIT_ID -> "Spirit rover"
-    OPPORTUNITY_ID -> "Opportunity rover"
+    SPIRIT_ID -> "Spirit"
+    OPPORTUNITY_ID -> "Opportunity"
     else -> error("pageQuery() called for non-page-feed rover id=$this")
 }
+
+/**
+ * images.nasa.gov `keywords` filter sent with every page-feed search. Keeps the broad
+ * [pageQuery] precise — "Spirit"/"Opportunity" alone match unrelated media.
+ */
+const val MER_KEYWORDS = "Mars Exploration Rover"

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/FeedMode.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/FeedMode.kt
@@ -14,7 +14,12 @@ sealed interface FeedMode {
         val cameras: Set<String>,
     ) : FeedMode
 
-    data class Page(val query: String, val shuffleSeed: Long? = null) : FeedMode
+    /**
+     * Page-keyed feed (Spirit/Opportunity). [anchorPage] is the 1-based API page to open at;
+     * null lets the paging source pick a random page — the page-feed counterpart of the sol
+     * feed's random-sol anchor.
+     */
+    data class Page(val query: String, val anchorPage: Int? = null) : FeedMode
 }
 
 /** Returns true when this rover id should use a page-keyed feed instead of the sol-keyed feed. */

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/ImagesSearchPagingSource.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/ImagesSearchPagingSource.kt
@@ -120,7 +120,14 @@ class ImagesSearchPagingSource(
             val persisted = imagesDao
                 .loadImagesByIds(networkPhotos.map { it.id })
                 .associateBy { it.id }
-            networkPhotos.map { persisted[it.id] ?: it }
+            // Merge ONLY user state (favorite + stats) from Room onto the network photo. The
+            // insert is IGNORE, so persisted rows keep whatever `order` they were first cached
+            // with (possibly an older page size or query) — serving them whole would corrupt
+            // the order-derived page math (chip, getRefreshKey, viewer restore).
+            networkPhotos.map { network ->
+                val row = persisted[network.id] ?: return@map network
+                network.copy(favorite = row.favorite, stats = row.stats)
+            }
         } catch (e: Exception) {
             Logger.e("ImagesSearchPagingSource", e) { "Write-through cache failed; serving network" }
             networkPhotos

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/ImagesSearchPagingSource.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/ImagesSearchPagingSource.kt
@@ -5,38 +5,44 @@ import androidx.paging.PagingState
 import com.sirelon.marsroverphotos.data.database.dao.ImagesDao
 import com.sirelon.marsroverphotos.data.database.entities.MarsImage
 import com.sirelon.marsroverphotos.utils.Logger
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 import kotlin.random.Random
 
 /**
- * [PagingSource] for Spirit/Opportunity: loads ALL images.nasa.gov search results in a single
- * [load] call (datasets are tiny: Spirit ~258, Opportunity ~523 images; 3–6 pages of 100).
+ * Page-keyed [PagingSource] for Spirit/Opportunity, backed by the images.nasa.gov /search API
+ * ([PAGE_SIZE] results per page; the API has no server-side sort parameter, so items appear in
+ * API order — [MarsImage.order] encodes the global position `(page-1)*PAGE_SIZE + indexInPage`,
+ * stamped by the [fetchPage] caller).
  *
- * The images.nasa.gov /search API has no server-side sort parameter; ordering is client-side:
- *   - Default ([shuffleSeed] == null): newest-first by earthDate (ISO-8601 string, lexicographic desc).
- *   - Shuffled ([shuffleSeed] != null): deterministic random order using the given seed, so the
- *     list and detail pager stay consistent across the same shuffle invocation.
+ * The key is the 1-based API page number: APPEND walks page+1, PREPEND walks page-1, so a feed
+ * anchored mid-dataset grows in both directions — mirroring the sol feed's random-anchor UX.
  *
- * Returns a single [LoadResult.Page] with prevKey = null and nextKey = null. Write-through cache
- * and favorite/stats merge mirror [SolPagingSource].
+ * Refresh resolves its anchor in priority order:
+ *  1. `params.key` — Paging re-centering after invalidation (see [getRefreshKey]);
+ *  2. [anchorPage] — an explicit page jump from the picker;
+ *  3. a random page. Picking one needs the total page count: [totalHitsHint] (cached by
+ *     [RoverFeedPager] from a previous fetch) avoids any extra request; without it, page 1 is
+ *     fetched first just to learn `totalHits` and is reused as the result when the random pick
+ *     lands on page 1.
+ *
+ * An explicit anchor is clamped against [totalHitsHint] when available; without a hint, a stale
+ * anchor beyond the dataset simply yields an empty terminal page (the picker bounds its input by
+ * the cached total, so this is a cold-start edge case only).
+ *
+ * Empty fetches always end pagination (both keys null) — an empty page with a live key would
+ * make Paging 3 re-trigger the same load in a loop. [onTotalHits] reports the dataset size after
+ * every fetch so the caller can cache it and feed the page picker. Write-through cache and
+ * favorite/stats merge mirror [SolPagingSource].
  *
  * @param fetchPage Async function that fetches one page. Receives the 1-based page number
  *                  and returns a [PageResult]. Decoupled from the network layer for testability.
- * @param shuffleSeed If non-null, shuffle the collected images using this seed instead of date sort.
- * @param cachedImages If non-null, skip the network fetch entirely and apply sort/shuffle to this
- *                     pre-loaded list. Set by [RoverFeedPager] after the first fetch so reshuffles
- *                     are instant.
- * @param onAllImagesFetched Called with the merged image list after a real network fetch completes.
- *                           Not called when [cachedImages] is used. Use to populate the caller's cache.
  */
 class ImagesSearchPagingSource(
-    private val pageSize: Int = PAGE_SIZE,
     private val imagesDao: ImagesDao,
-    private val shuffleSeed: Long? = null,
-    private val cachedImages: List<MarsImage>? = null,
-    private val onAllImagesFetched: ((List<MarsImage>) -> Unit)? = null,
+    private val anchorPage: Int? = null,
+    private val totalHitsHint: Int? = null,
+    private val onTotalHits: ((Int) -> Unit)? = null,
+    private val random: Random = Random.Default,
+    private val pageSize: Int = PAGE_SIZE,
     private val fetchPage: suspend (page: Int) -> PageResult,
 ) : PagingSource<Int, MarsImage>() {
 
@@ -45,47 +51,65 @@ class ImagesSearchPagingSource(
         val totalHits: Int,
     )
 
-    override fun getRefreshKey(state: PagingState<Int, MarsImage>): Int? = null
+    /** Refresh re-centers on the page of the item closest to the current scroll anchor. */
+    override fun getRefreshKey(state: PagingState<Int, MarsImage>): Int? {
+        val anchor = state.anchorPosition ?: return null
+        return state.closestItemToPosition(anchor)?.order?.let { it / pageSize + 1 }
+    }
 
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, MarsImage> {
         return try {
-            val merged = if (cachedImages != null) {
-                cachedImages
-            } else {
-                val first = fetchPage(1)
-                val totalPages = if (first.totalHits > 0)
-                    ((first.totalHits + pageSize - 1) / pageSize).coerceAtMost(MAX_PAGES)
-                else 1
-                val allImages = if (totalPages <= 1) {
-                    first.images
-                } else {
-                    coroutineScope {
-                        // Fetch the remaining pages concurrently. A failure on ANY page propagates
-                        // (awaitAll rethrows, coroutineScope cancels the siblings) so the whole load
-                        // fails with LoadResult.Error and the UI can retry — rather than silently
-                        // serving a partial dataset with a page missing.
-                        val rest = (2..totalPages).map { p -> async { fetchPage(p).images } }
-                        first.images + rest.awaitAll().flatten()
-                    }
-                }
-                if (totalPages >= MAX_PAGES) {
-                    Logger.w("ImagesSearchPagingSource") { "Safety cap reached; truncating at ${allImages.size} images" }
-                }
-                cacheAndMerge(allImages).also { onAllImagesFetched?.invoke(it) }
+            when (params) {
+                is LoadParams.Refresh -> loadRefresh(params.key)
+                is LoadParams.Append -> loadPage(params.key)
+                is LoadParams.Prepend -> loadPage(params.key)
             }
-            val ordered = if (shuffleSeed != null) {
-                merged.shuffled(Random(shuffleSeed))
-            } else {
-                merged.sortedByDescending { it.earthDate }
-            }
-            LoadResult.Page(data = ordered, prevKey = null, nextKey = null)
         } catch (e: Exception) {
-            Logger.e("ImagesSearchPagingSource", e) { "Error loading all pages" }
+            Logger.e("ImagesSearchPagingSource", e) { "Error loading page" }
             LoadResult.Error(e)
         }
     }
 
+    private suspend fun loadRefresh(key: Int?): LoadResult<Int, MarsImage> {
+        val requested = key ?: anchorPage
+        if (requested != null) {
+            val clamped = totalHitsHint
+                ?.let { requested.coerceIn(1, totalPages(it)) }
+                ?: requested.coerceAtLeast(1)
+            return loadPage(clamped)
+        }
+        // Random anchor: the total page count must be known to pick one. Use the cached hint
+        // when available; otherwise bootstrap with page 1 (reused as the result if the pick
+        // lands on page 1), so a cold start costs at most one extra request.
+        var bootstrap: PageResult? = null
+        val totalHits = totalHitsHint ?: fetchPage(1).also { bootstrap = it }.totalHits
+        val totalPages = totalPages(totalHits)
+        val target = if (totalPages <= 1) 1 else random.nextInt(1, totalPages + 1)
+        val result = bootstrap.takeIf { target == 1 } ?: fetchPage(target)
+        return result.toLoadPage(target)
+    }
+
+    private suspend fun loadPage(page: Int): LoadResult<Int, MarsImage> =
+        fetchPage(page).toLoadPage(page)
+
+    private suspend fun PageResult.toLoadPage(page: Int): LoadResult.Page<Int, MarsImage> {
+        onTotalHits?.invoke(totalHits)
+        val data = cacheAndMerge(images)
+        // An empty fetch (stale anchor beyond the dataset, or no results at all) ends
+        // pagination in both directions — never hand Paging an empty page with a live key.
+        if (data.isEmpty()) return LoadResult.Page(data = data, prevKey = null, nextKey = null)
+        return LoadResult.Page(
+            data = data,
+            prevKey = (page - 1).takeIf { it >= 1 },
+            nextKey = (page + 1).takeIf { it <= totalPages(totalHits) },
+        )
+    }
+
+    private fun totalPages(totalHits: Int): Int =
+        if (totalHits <= 0) 1 else (totalHits + pageSize - 1) / pageSize
+
     private suspend fun cacheAndMerge(networkPhotos: List<MarsImage>): List<MarsImage> {
+        if (networkPhotos.isEmpty()) return networkPhotos
         return try {
             imagesDao.insertImages(networkPhotos)
             try {
@@ -105,9 +129,8 @@ class ImagesSearchPagingSource(
 
     companion object {
         /** Single source of truth for the images.nasa.gov page size — also used by
-         *  [RoverFeedPager]'s paging config / startIndex math and PhotosViewModel's page jump. */
+         *  [RoverFeedPager]'s paging config / startIndex math and the viewer's page restore. */
         internal const val PAGE_SIZE = 100
         private const val CACHE_KEEP_LIMIT = 2000
-        private const val MAX_PAGES = 50
     }
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/ImagesSearchPagingSource.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/ImagesSearchPagingSource.kt
@@ -128,9 +128,13 @@ class ImagesSearchPagingSource(
     }
 
     companion object {
-        /** Single source of truth for the images.nasa.gov page size — also used by
-         *  [RoverFeedPager]'s paging config / startIndex math and the viewer's page restore. */
-        internal const val PAGE_SIZE = 100
+        /**
+         * Page size requested from images.nasa.gov (the API allows up to 100). Small pages make
+         * the page picker and random anchor meaningful on these curated datasets (~434/565
+         * photos → ~44/57 pages). Single source of truth — also used by [RoverFeedPager]'s
+         * paging config / startIndex math and the viewer's page restore.
+         */
+        internal const val PAGE_SIZE = 10
         private const val CACHE_KEEP_LIMIT = 2000
     }
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/ImagesSearchPagingSource.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/ImagesSearchPagingSource.kt
@@ -103,8 +103,10 @@ class ImagesSearchPagingSource(
         }
     }
 
-    private companion object {
-        private const val PAGE_SIZE = 100
+    companion object {
+        /** Single source of truth for the images.nasa.gov page size — also used by
+         *  [RoverFeedPager]'s paging config / startIndex math and PhotosViewModel's page jump. */
+        internal const val PAGE_SIZE = 100
         private const val CACHE_KEEP_LIMIT = 2000
         private const val MAX_PAGES = 50
     }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/PopularRemoteMediator.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/PopularRemoteMediator.kt
@@ -6,7 +6,7 @@ import androidx.paging.PagingState
 import androidx.paging.RemoteMediator
 import com.sirelon.marsroverphotos.data.database.dao.ImagesDao
 import com.sirelon.marsroverphotos.data.database.entities.MarsImage
-import com.sirelon.marsroverphotos.data.database.entities.StatsUpdate
+import com.sirelon.marsroverphotos.data.database.entities.PopularUpdate
 import com.sirelon.marsroverphotos.platform.IFirebasePhotos
 import com.sirelon.marsroverphotos.utils.Logger
 
@@ -22,20 +22,11 @@ class PopularRemoteMediator(
     private val dao: ImagesDao
 ) : RemoteMediator<Int, MarsImage>() {
 
-    private var isFirstLoad = true
-
     override suspend fun initialize(): InitializeAction {
-        return if (isFirstLoad) {
-            isFirstLoad = false
-            // Need to refresh cached data from network; returning
-            // LAUNCH_INITIAL_REFRESH here will also block RemoteMediator's
-            // APPEND and PREPEND from running until REFRESH succeeds.
-            InitializeAction.LAUNCH_INITIAL_REFRESH
-        } else {
-            // Cached data is up-to-date, so there is no need to re-fetch
-            // from the network.
-            InitializeAction.SKIP_INITIAL_REFRESH
-        }
+        // A fresh mediator is created per Pager, so always refresh cached data from
+        // network; returning LAUNCH_INITIAL_REFRESH here will also block RemoteMediator's
+        // APPEND and PREPEND from running until REFRESH succeeds.
+        return InitializeAction.LAUNCH_INITIAL_REFRESH
     }
 
     override suspend fun load(
@@ -54,39 +45,47 @@ class PopularRemoteMediator(
         loadType: LoadType,
         state: PagingState<Int, MarsImage>
     ): MediatorResult {
-        // Calculate how many items are already in the database
-        val alreadyInDb = state.pages.sumOf { it.data.size } + 1
-
         // Don't prepend - popular photos are only appended
         if (loadType == LoadType.PREPEND) {
             return MediatorResult.Success(endOfPaginationReached = true)
         }
 
-        try {
-            val loadSize = state.config.pageSize
-            val lastPhotoId = state.lastItemOrNull()?.id
+        val refresh = loadType == LoadType.REFRESH
 
-            // Load popular photos from Firebase
-            val list = firebasePhotos.loadPopularPhotos(loadSize, lastPhotoId)
-                .mapIndexed { index, firebasePhoto ->
-                    firebasePhoto.toMarsImage(index + alreadyInDb)
-                }
+        // REFRESH restarts ranking from the top; only APPEND continues the Firebase
+        // cursor after the last loaded item and offsets `order` by what's already loaded.
+        val lastPhotoId = if (refresh) null else state.lastItemOrNull()?.id
+        val orderOffset = if (refresh) 1 else state.pages.sumOf { it.data.size } + 1
 
-            val rowIds = dao.insertImages(list)
-            val indexedIds = rowIds.mapIndexed { index, rowId -> rowId to index }
-            val grouped = indexedIds.groupBy { it.first == -1L }
+        val loadSize = state.config.pageSize
 
-            // Update stats for photos that already exist (insert returned -1)
-            val toUpdate = grouped[true]?.map { list[it.second] }
-            toUpdate?.forEach { photo ->
-                dao.updateStats(StatsUpdate(photo.id, photo.stats))
+        // Load popular photos from Firebase
+        val list = firebasePhotos.loadPopularPhotos(loadSize, lastPhotoId)
+            .mapIndexed { index, firebasePhoto ->
+                firebasePhoto.toMarsImage(index + orderOffset)
             }
 
-            val endOfPaginationReached = list.isEmpty()
-            return MediatorResult.Success(endOfPaginationReached)
-        } catch (e: Exception) {
-            Logger.e("PopularRemoteMediator", e) { "Error in loadSync" }
-            return MediatorResult.Error(e)
+        if (refresh) {
+            // Reset stale popular flags so photos that dropped off Firebase's popular
+            // list don't stay popular forever and stale rows don't collide with this
+            // batch's order values 1..N. Flag-reset instead of delete: deleting would
+            // drop favorited photos and rows cached by the sol feed.
+            dao.clearPopularFlags()
         }
+
+        val rowIds = dao.insertImages(list)
+        val indexedIds = rowIds.mapIndexed { index, rowId -> rowId to index }
+        val grouped = indexedIds.groupBy { it.first == -1L }
+
+        // Rows that already exist (insert returned -1, e.g. cached by the sol feed with
+        // popular = 0) are IGNOREd by the insert, so apply the popular flag, the fresh
+        // ranking order and stats via a partial update.
+        val toUpdate = grouped[true]?.map { list[it.second] }
+        toUpdate?.forEach { photo ->
+            dao.updatePopular(PopularUpdate(photo.id, photo.popular, photo.order, photo.stats))
+        }
+
+        val endOfPaginationReached = list.isEmpty()
+        return MediatorResult.Success(endOfPaginationReached)
     }
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/RoverFeedPager.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/RoverFeedPager.kt
@@ -149,7 +149,7 @@ class RoverFeedPager(
                             },
                             fetchPage = { page ->
                                 val response = restApi.searchImages(query, page)
-                                val startIndex = (page - 1) * 100
+                                val startIndex = (page - 1) * ImagesSearchPagingSource.PAGE_SIZE
                                 ImagesSearchPagingSource.PageResult(
                                     images = response.toMarsImages(startIndex),
                                     totalHits = response.collection.metadata?.totalHits ?: 0,
@@ -166,6 +166,10 @@ class RoverFeedPager(
         .cachedIn(appScope)
 
     fun setFeed(roverId: Long, mode: FeedMode) {
+        // A rebuilt feed creates a new PagingSource that re-merges favorite state from Room, so
+        // any optimistic overrides are stale/redundant — clear them to keep the map from growing.
+        // setFeed is only called from main-thread ViewModel code, so this mutation is safe.
+        favoriteOverrides.clear()
         val params = Params(roverId = roverId, mode = mode)
         latestParams = params
         paramsFlow.tryEmit(params)
@@ -179,9 +183,9 @@ class RoverFeedPager(
             enablePlaceholders = false,
         )
         private val pageSearchConfig = PagingConfig(
-            pageSize = 100,
+            pageSize = ImagesSearchPagingSource.PAGE_SIZE,
             prefetchDistance = 20,
-            initialLoadSize = 100,
+            initialLoadSize = ImagesSearchPagingSource.PAGE_SIZE,
             enablePlaceholders = false,
         )
     }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/RoverFeedPager.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/RoverFeedPager.kt
@@ -61,17 +61,16 @@ class RoverFeedPager(
     /** Latest params, for synchronous reads by callers. Mutated only from [setFeed] (main thread). */
     private var latestParams: Params? = null
 
-    // In-memory cache of the full result list from images.nasa.gov, keyed by query string.
-    // Populated after the first network fetch for a query; subsequent reshuffles (same query,
-    // new seed) reorder this list instantly without any network round-trip.
-    private val pageCache = mutableMapOf<String, List<MarsImage>>()
+    // Last-seen totalHits per images.nasa.gov query. Lets a rebuilt page feed pick a random
+    // anchor page (and clamp explicit ones) without a bootstrap request to learn the dataset size.
+    private val totalHitsCache = mutableMapOf<String, Int>()
 
     /** Current feed params, or null until [setFeed] is first called. */
     val currentParams: Params? get() = latestParams
 
     private val _totalPagePhotos = MutableStateFlow(0)
 
-    /** Total photos loaded for page-mode rovers (Spirit/Opportunity). 0 until the first fetch completes. */
+    /** Dataset size (API totalHits) for page-mode rovers (Spirit/Opportunity). 0 until the first fetch. */
     val totalPagePhotosFlow: StateFlow<Int> = _totalPagePhotos.asStateFlow()
 
     private val _currentRoverId = MutableStateFlow<Long?>(null)
@@ -133,19 +132,18 @@ class RoverFeedPager(
                 ).flow
                 is FeedMode.Page -> Pager(
                     config = pageSearchConfig,
-                    initialKey = 1,
+                    // initialKey stays null — the source resolves the anchor itself
+                    // (explicit mode.anchorPage, else a random page).
                     pagingSourceFactory = {
                         val query = mode.query
-                        val shuffleSeed = mode.shuffleSeed
-                        val cachedImages = pageCache[query]
-                        _totalPagePhotos.value = cachedImages?.size ?: 0
+                        _totalPagePhotos.value = totalHitsCache[query] ?: 0
                         ImagesSearchPagingSource(
                             imagesDao = imagesDao,
-                            shuffleSeed = shuffleSeed,
-                            cachedImages = cachedImages,
-                            onAllImagesFetched = { images ->
-                                pageCache[query] = images
-                                _totalPagePhotos.value = images.size
+                            anchorPage = mode.anchorPage,
+                            totalHitsHint = totalHitsCache[query],
+                            onTotalHits = { hits ->
+                                totalHitsCache[query] = hits
+                                _totalPagePhotos.value = hits
                             },
                             fetchPage = { page ->
                                 val response = restApi.searchImages(query, page)

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/RoverFeedPager.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/RoverFeedPager.kt
@@ -146,7 +146,7 @@ class RoverFeedPager(
                                 _totalPagePhotos.value = hits
                             },
                             fetchPage = { page ->
-                                val response = restApi.searchImages(query, page)
+                                val response = restApi.searchImages(query, page, keywords = MER_KEYWORDS)
                                 val startIndex = (page - 1) * ImagesSearchPagingSource.PAGE_SIZE
                                 ImagesSearchPagingSource.PageResult(
                                     images = response.toMarsImages(startIndex),

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/RoverFeedPager.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/RoverFeedPager.kt
@@ -146,7 +146,12 @@ class RoverFeedPager(
                                 _totalPagePhotos.value = hits
                             },
                             fetchPage = { page ->
-                                val response = restApi.searchImages(query, page, keywords = MER_KEYWORDS)
+                                val response = restApi.searchImages(
+                                    query = query,
+                                    page = page,
+                                    pageSize = ImagesSearchPagingSource.PAGE_SIZE,
+                                    keywords = MER_KEYWORDS,
+                                )
                                 val startIndex = (page - 1) * ImagesSearchPagingSource.PAGE_SIZE
                                 ImagesSearchPagingSource.PageResult(
                                     images = response.toMarsImages(startIndex),

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/SolPagingSource.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/SolPagingSource.kt
@@ -229,7 +229,12 @@ class SolPagingSource(
             val persisted = imagesDao
                 .loadImagesByIds(networkPhotos.map { it.id })
                 .associateBy { it.id }
-            networkPhotos.map { persisted[it.id] ?: it }
+            // Merge ONLY user state (favorite + stats) from Room — the rest of the row may be
+            // stale (the insert is IGNORE, so e.g. `order` keeps its first-cached value).
+            networkPhotos.map { network ->
+                val row = persisted[network.id] ?: return@map network
+                network.copy(favorite = row.favorite, stats = row.stats)
+            }
         } catch (e: Exception) {
             Logger.e("SolPagingSource", e) { "Write-through cache failed; serving network photos" }
             networkPhotos

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/SolPagingSource.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/SolPagingSource.kt
@@ -55,6 +55,15 @@ class SolPagingSource(
     /** Inserts since the last cache eviction; eviction runs only every [EVICT_EVERY_N_LOADS]. */
     private var loadsSinceEviction = 0
 
+    /**
+     * Sols already probed and found empty, so re-scans over the same gap (e.g. a PREPEND walking
+     * back through sols a Refresh already probed) skip them without re-firing a network request.
+     * Safe per-instance only: [cameras] is fixed for the lifetime of a PagingSource (a filter
+     * change builds a new source), so "empty" here means "no photos matching THIS camera set" —
+     * a sol that is empty for one filter may have photos for another, but never for this instance.
+     */
+    private val knownEmptySols = HashSet<Long>()
+
     /** Refresh re-centers on the sol of the item closest to the current scroll anchor. */
     override fun getRefreshKey(state: PagingState<Long, MarsImage>): Long? {
         val anchor = state.anchorPosition ?: return null
@@ -144,12 +153,19 @@ class SolPagingSource(
 
     /**
      * Walks [step] sols from [startSol] toward the rover bound, returning the first sol that has
-     * (camera-filtered) photos. Capped at [budget] network probes per call.
+     * (camera-filtered) photos. Capped at [budget] network probes per call; sols memoized in
+     * [knownEmptySols] are skipped for free.
      */
     private suspend fun findDay(startSol: Long, step: Int, budget: Int = scanBudget): FindResult {
         var sol = startSol
         var probes = 0
         while (sol in minSol..maxSol) {
+            // Memoized empty sols are skipped without a network probe and without spending budget;
+            // the loop stays bounded because the sol range minSol..maxSol is finite.
+            if (sol in knownEmptySols) {
+                sol += step
+                continue
+            }
             if (probes >= budget) return FindResult.Exhausted(sol)
             // Fetch the whole sol (camera = null) and filter in-memory, so the empty-sol skip is
             // camera-aware for every rover — Perseverance/Insight raw APIs ignore the camera param.
@@ -160,6 +176,7 @@ class SolPagingSource(
             if (photos.isNotEmpty()) {
                 return FindResult.Found(Day(sol, cacheAndMerge(photos)))
             }
+            knownEmptySols += sol
             sol += step
         }
         return FindResult.End

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/DateJumpPickerScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/DateJumpPickerScreen.kt
@@ -80,6 +80,7 @@ fun DateJumpPickerScreen(
             PageContent(
                 totalPagePhotos = uiState.totalPagePhotos,
                 maxPage = uiState.totalPages,
+                currentPage = viewModel.visiblePage.collectAsStateWithLifecycle().value,
                 onDismiss = onDismiss,
                 onConfirm = { page ->
                     viewModel.loadByPage(page)
@@ -230,10 +231,12 @@ private fun EarthDateRow(
 private fun PageContent(
     totalPagePhotos: Int,
     maxPage: Int,
+    currentPage: Int,
     onDismiss: () -> Unit,
     onConfirm: (page: Int) -> Unit,
 ) {
-    var selectedPage by remember { mutableIntStateOf(1) }
+    // Pre-select the page currently on screen (clamped — totalHits may still be loading).
+    var selectedPage by remember { mutableIntStateOf(currentPage.coerceIn(1, maxPage)) }
 
     Column(
         modifier = Modifier

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/DateJumpPickerScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/DateJumpPickerScreen.kt
@@ -1,5 +1,6 @@
 package com.sirelon.marsroverphotos.presentation.screens
 
+import com.sirelon.marsroverphotos.data.paging.ImagesSearchPagingSource
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -232,7 +233,8 @@ private fun PageContent(
     onConfirm: (page: Int) -> Unit,
 ) {
     val maxPage = remember(totalPagePhotos) {
-        if (totalPagePhotos > 0) (totalPagePhotos + 99) / 100 else 1
+        val pageSize = ImagesSearchPagingSource.PAGE_SIZE
+        if (totalPagePhotos > 0) (totalPagePhotos + pageSize - 1) / pageSize else 1
     }
     var selectedPage by remember { mutableIntStateOf(1) }
 

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/DateJumpPickerScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/DateJumpPickerScreen.kt
@@ -1,6 +1,5 @@
 package com.sirelon.marsroverphotos.presentation.screens
 
-import com.sirelon.marsroverphotos.data.paging.ImagesSearchPagingSource
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -80,6 +79,7 @@ fun DateJumpPickerScreen(
         } else {
             PageContent(
                 totalPagePhotos = uiState.totalPagePhotos,
+                maxPage = uiState.totalPages,
                 onDismiss = onDismiss,
                 onConfirm = { page ->
                     viewModel.loadByPage(page)
@@ -229,13 +229,10 @@ private fun EarthDateRow(
 @Composable
 private fun PageContent(
     totalPagePhotos: Int,
+    maxPage: Int,
     onDismiss: () -> Unit,
     onConfirm: (page: Int) -> Unit,
 ) {
-    val maxPage = remember(totalPagePhotos) {
-        val pageSize = ImagesSearchPagingSource.PAGE_SIZE
-        if (totalPagePhotos > 0) (totalPagePhotos + pageSize - 1) / pageSize else 1
-    }
     var selectedPage by remember { mutableIntStateOf(1) }
 
     Column(

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
@@ -43,7 +43,6 @@ import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshots.SnapshotStateMap
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
@@ -93,7 +92,6 @@ import coil3.SingletonImageLoader
 import coil3.compose.LocalPlatformContext
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
@@ -137,7 +135,6 @@ fun PhotosScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val pagingItems = viewModel.gridItemsFlow.collectAsLazyPagingItems()
     val gridState = rememberLazyGridState()
-    val scope = rememberCoroutineScope()
 
     // Scroll to top whenever the feed is re-anchored (sol/date pick, randomize, go-to-latest,
     // camera filter change). Without this the grid keeps its previous scroll offset and the
@@ -145,13 +142,6 @@ fun PhotosScreen(
     LaunchedEffect(viewModel) {
         viewModel.scrollToTopEvents.collect {
             gridState.scrollToItem(0)
-        }
-    }
-
-    // Scroll to a specific item index for page-mode rovers (Spirit/Opportunity page jump).
-    LaunchedEffect(viewModel) {
-        viewModel.scrollToItemEvents.collect { index ->
-            gridState.scrollToItem(index)
         }
     }
 
@@ -216,12 +206,8 @@ fun PhotosScreen(
         state = state,
         pagingItems = pagingItems,
         gridState = gridState,
-        onRandomize = {
-            viewModel.randomize()
-            // Scroll to top so the reshuffled order is immediately visible. Only for page-mode
-            // rovers (Spirit/Opportunity) where showSolControls is false; sol rovers are unchanged.
-            if (!state.showSolControls) scope.launch { gridState.scrollToItem(0) }
-        },
+        // Re-anchoring (random sol or random page) emits scrollToTopEvents, collected above.
+        onRandomize = viewModel::randomize,
         onGoToLatest = viewModel::goToLatest,
         onClearCameraFilters = {
             viewModel.setCameraFilters(emptySet())

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -149,16 +148,21 @@ fun PhotosScreen(
     }
 
     // Keep the floating chip + pickers in sync with the top-visible day (sol mode) or
-    // top-visible API page (page mode) as the user scrolls.
+    // top-visible API page (page mode). The sol/page is computed INSIDE snapshotFlow so the
+    // flow also re-emits when the underlying page data changes — after a page jump the grid
+    // stays pinned at index 0 while new data replaces old, so an index-only flow would never
+    // fire and the chip would keep the pre-jump value.
     val currentPagingItems = rememberUpdatedState(pagingItems)
-    var visiblePage by remember { mutableIntStateOf(1) }
+    val visiblePage by viewModel.visiblePage.collectAsStateWithLifecycle()
     LaunchedEffect(gridState) {
-        snapshotFlow { gridState.firstVisibleItemIndex }
-            .collect { index ->
-                val items = currentPagingItems.value
-                solAtIndex(items, index)?.let(viewModel::onVisibleSolChanged)
-                pageAtIndex(items, index)?.let { visiblePage = it }
-            }
+        snapshotFlow {
+            val items = currentPagingItems.value
+            val index = gridState.firstVisibleItemIndex
+            solAtIndex(items, index) to pageAtIndex(items, index)
+        }.collect { (sol, page) ->
+            sol?.let(viewModel::onVisibleSolChanged)
+            page?.let(viewModel::onVisiblePageChanged)
+        }
     }
 
     // Prefetch images for items just beyond the visible grid window so they are

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/PhotosScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -64,6 +65,7 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemContentType
 import androidx.paging.compose.itemKey
 import com.sirelon.marsroverphotos.data.database.entities.MarsImage
+import com.sirelon.marsroverphotos.data.paging.ImagesSearchPagingSource
 import com.sirelon.marsroverphotos.domain.models.EducationalFact
 import com.sirelon.marsroverphotos.presentation.models.GridItem
 import com.sirelon.marsroverphotos.presentation.ui.AppCard
@@ -86,6 +88,7 @@ import com.sirelon.marsroverphotos.shared.resources.Res
 import com.sirelon.marsroverphotos.shared.resources.did_you_know
 import com.sirelon.marsroverphotos.shared.resources.educational_fact
 import com.sirelon.marsroverphotos.shared.resources.no_photos_title
+import com.sirelon.marsroverphotos.shared.resources.page_of_fmt
 import com.sirelon.marsroverphotos.shared.resources.tap_to_retry
 import com.sirelon.marsroverphotos.utils.formatDisplayDate
 import coil3.SingletonImageLoader
@@ -145,12 +148,16 @@ fun PhotosScreen(
         }
     }
 
-    // Keep the floating chip + pickers in sync with the top-visible day as the user scrolls.
+    // Keep the floating chip + pickers in sync with the top-visible day (sol mode) or
+    // top-visible API page (page mode) as the user scrolls.
     val currentPagingItems = rememberUpdatedState(pagingItems)
+    var visiblePage by remember { mutableIntStateOf(1) }
     LaunchedEffect(gridState) {
         snapshotFlow { gridState.firstVisibleItemIndex }
             .collect { index ->
-                solAtIndex(currentPagingItems.value, index)?.let(viewModel::onVisibleSolChanged)
+                val items = currentPagingItems.value
+                solAtIndex(items, index)?.let(viewModel::onVisibleSolChanged)
+                pageAtIndex(items, index)?.let { visiblePage = it }
             }
     }
 
@@ -206,6 +213,7 @@ fun PhotosScreen(
         state = state,
         pagingItems = pagingItems,
         gridState = gridState,
+        currentPage = visiblePage,
         // Re-anchoring (random sol or random page) emits scrollToTopEvents, collected above.
         onRandomize = viewModel::randomize,
         onGoToLatest = viewModel::goToLatest,
@@ -234,6 +242,7 @@ private fun PhotosScreen(
     state: PhotosUiState,
     pagingItems: LazyPagingItems<GridItem>,
     gridState: LazyGridState,
+    currentPage: Int,
     onRandomize: () -> Unit,
     onGoToLatest: () -> Unit,
     onClearCameraFilters: () -> Unit,
@@ -317,17 +326,20 @@ private fun PhotosScreen(
                             favoriteOverrides = favoriteOverrides,
                         )
 
-                        // Floating "sticky" date chip — mirrors the top-visible day (sol mode only).
-                        if (state.showSolControls) {
-                            FloatingDateChip(
-                                sol = state.sol,
-                                earthDate = state.earthDate,
-                                onOpenDateJumpPicker = onOpenDateJumpPicker,
-                                modifier = Modifier
-                                    .align(Alignment.TopCenter)
-                                    .padding(top = AppSpacing.sm)
-                            )
-                        }
+                        // Floating "sticky" chip — mirrors the top-visible day (sol mode) or
+                        // API page (page mode); both open the jump picker.
+                        FloatingJumpChip(
+                            text = if (state.showSolControls) {
+                                if (state.earthDate.isNotBlank()) "Sol ${state.sol} · ${state.earthDate}"
+                                else "Sol ${state.sol}"
+                            } else {
+                                stringResource(Res.string.page_of_fmt, currentPage, state.totalPages)
+                            },
+                            onOpenDateJumpPicker = onOpenDateJumpPicker,
+                            modifier = Modifier
+                                .align(Alignment.TopCenter)
+                                .padding(top = AppSpacing.sm)
+                        )
 
                         // Refresh progress (e.g. after randomize) shown at the top when old items
                         // are still visible. Prepend and append progress shown at edges while scrolling.
@@ -448,9 +460,8 @@ private fun DateHeaderRow(
 }
 
 @Composable
-private fun FloatingDateChip(
-    sol: Long,
-    earthDate: String,
+private fun FloatingJumpChip(
+    text: String,
     onOpenDateJumpPicker: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -468,7 +479,7 @@ private fun FloatingDateChip(
             horizontalArrangement = Arrangement.spacedBy(6.dp)
         ) {
             Text(
-                text = if (earthDate.isNotBlank()) "Sol $sol · $earthDate" else "Sol $sol",
+                text = text,
                 style = MaterialTheme.typography.labelLarge,
                 maxLines = 1,
             )
@@ -671,6 +682,15 @@ private val GridItem.contentType: String
  * Sol of the day at (or just above) [index] — used to drive the floating header. For a
  * [GridItem.FactItem] (no sol of its own) it scans backward to the nearest photo/header.
  */
+/** Maps the top-visible photo back to its 1-based API page ([MarsImage.order] encodes the
+ *  global index). Only meaningful in page mode — sol-mode `order` is a per-sol index. */
+private fun pageAtIndex(pagingItems: LazyPagingItems<GridItem>, index: Int): Int? {
+    if (pagingItems.itemCount == 0) return null
+    val item = pagingItems.peek(index.coerceIn(0, pagingItems.itemCount - 1))
+    val photo = item as? GridItem.PhotoItem ?: return null
+    return photo.image.order / ImagesSearchPagingSource.PAGE_SIZE + 1
+}
+
 private fun solAtIndex(pagingItems: LazyPagingItems<GridItem>, index: Int): Long? {
     if (pagingItems.itemCount == 0) return null
     var i = index.coerceIn(0, pagingItems.itemCount - 1)
@@ -720,6 +740,7 @@ private fun PhotosScreenPreview() {
             ),
             pagingItems = pagingItems,
             gridState = rememberLazyGridState(),
+            currentPage = 1,
             onRandomize = {},
             onGoToLatest = {},
             onClearCameraFilters = {},

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/ImageViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/ImageViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import com.sirelon.marsroverphotos.data.database.entities.MarsImage
 import com.sirelon.marsroverphotos.data.paging.FeedMode
+import com.sirelon.marsroverphotos.data.paging.ImagesSearchPagingSource
 import com.sirelon.marsroverphotos.data.paging.RoverFeedPager
 import com.sirelon.marsroverphotos.data.paging.pageQuery
 import com.sirelon.marsroverphotos.data.paging.usesPageFeed
@@ -27,7 +28,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
-import kotlin.random.Random
 
 /**
  * ViewModel for the fullscreen image viewer.
@@ -116,11 +116,18 @@ class ImageViewModel(
 
         if (roverId.usesPageFeed()) {
             if (current?.roverId == roverId && current.mode is FeedMode.Page) return
-            // The original shuffle seed isn't persisted, so a fresh shuffle matches the list's default behavior.
-            roverFeedPager.setFeed(
-                roverId = roverId,
-                mode = FeedMode.Page(roverId.pageQuery(), shuffleSeed = Random.nextLong()),
-            )
+            viewModelScope.launch {
+                // Anchor at the page containing the photo being viewed (MarsImage.order encodes
+                // its global API index); if it isn't cached, fall back to a random page like the
+                // list's default behavior.
+                val anchorPage = selectedId
+                    ?.let { imagesRepository.loadImages(listOf(it)).first().firstOrNull()?.order }
+                    ?.let { it / ImagesSearchPagingSource.PAGE_SIZE + 1 }
+                roverFeedPager.setFeed(
+                    roverId = roverId,
+                    mode = FeedMode.Page(roverId.pageQuery(), anchorPage = anchorPage),
+                )
+            }
             return
         }
 

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/ImageViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/ImageViewModel.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import kotlin.random.Random
 
 /**
  * ViewModel for the fullscreen image viewer.
@@ -115,7 +116,11 @@ class ImageViewModel(
 
         if (roverId.usesPageFeed()) {
             if (current?.roverId == roverId && current.mode is FeedMode.Page) return
-            roverFeedPager.setFeed(roverId = roverId, mode = FeedMode.Page(roverId.pageQuery()))
+            // The original shuffle seed isn't persisted, so a fresh shuffle matches the list's default behavior.
+            roverFeedPager.setFeed(
+                roverId = roverId,
+                mode = FeedMode.Page(roverId.pageQuery(), shuffleSeed = Random.nextLong()),
+            )
             return
         }
 

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/PhotosViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/PhotosViewModel.kt
@@ -10,7 +10,6 @@ import androidx.paging.insertSeparators
 import androidx.paging.map as pagingMap
 import com.sirelon.marsroverphotos.data.database.entities.MarsImage
 import com.sirelon.marsroverphotos.data.paging.FeedMode
-import com.sirelon.marsroverphotos.data.paging.ImagesSearchPagingSource
 import com.sirelon.marsroverphotos.data.paging.RoverFeedPager
 import com.sirelon.marsroverphotos.data.paging.pageQuery
 import com.sirelon.marsroverphotos.data.paging.usesPageFeed
@@ -47,7 +46,7 @@ import kotlin.random.Random
 
 /**
  * ViewModel for the photos screen — an infinite bidirectional feed paged by sol (sol mode) or
- * a forward-only page-numbered search feed (page mode for Spirit/Opportunity).
+ * by API page number anchored at a random page (page mode for Spirit/Opportunity).
  *
  * The feed lives in the shared [RoverFeedPager]. This ViewModel:
  *  - selects [FeedMode] per rover,
@@ -81,13 +80,6 @@ class PhotosViewModel(
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
     val scrollToTopEvents: SharedFlow<Unit> = _scrollToTopEvents.asSharedFlow()
-
-    private val _scrollToItemEmitter = MutableSharedFlow<Int>(
-        extraBufferCapacity = 1,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST,
-    )
-    /** Emitted by [loadByPage] for page-mode rovers; the grid scrolls to the given item index. */
-    val scrollToItemEvents: SharedFlow<Int> = _scrollToItemEmitter.asSharedFlow()
 
     private var dateUtil: RoverDateUtil? = null
 
@@ -218,8 +210,8 @@ class PhotosViewModel(
                 }
             }
             // Page-feed rovers (Spirit/Opportunity) are handled synchronously in setRoverId so
-            // the fresh shuffle is set before any compose frame renders, making the stale
-            // cachedIn(appScope) replay invisible.
+            // the fresh random-page anchor is set before any compose frame renders, making the
+            // stale cachedIn(appScope) replay invisible.
         }
     }
 
@@ -307,10 +299,11 @@ class PhotosViewModel(
         }
     }
 
-    /** Scrolls the grid to the start of the given page (1-based). No-op in sol mode. */
+    /** Re-anchors the page feed at the given page (1-based). No-op in sol mode. */
     fun loadByPage(page: Int) {
-        val index = (page - 1).coerceAtLeast(0) * ImagesSearchPagingSource.PAGE_SIZE
-        _scrollToItemEmitter.tryEmit(index)
+        val roverId = roverIdEmitter.value ?: return
+        if (!roverId.usesPageFeed()) return
+        applyPageFeed(roverId, anchorPage = page)
     }
 
     /** Converts an Earth date (epoch millis) to the nearest sol. Returns 0 if dateUtil is not ready. */
@@ -361,10 +354,11 @@ class PhotosViewModel(
         Clock.System.now().toEpochMilliseconds()
     }
 
-    private fun applyPageFeed(roverId: Long) {
+    /** [anchorPage] = explicit 1-based page to open at; null lets the source pick a random one. */
+    private fun applyPageFeed(roverId: Long, anchorPage: Int? = null) {
         roverFeedPager.setFeed(
             roverId = roverId,
-            mode = FeedMode.Page(roverId.pageQuery(), shuffleSeed = Random.nextLong()),
+            mode = FeedMode.Page(roverId.pageQuery(), anchorPage = anchorPage),
         )
         _scrollToTopEvents.tryEmit(Unit)
     }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/PhotosViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/PhotosViewModel.kt
@@ -10,6 +10,7 @@ import androidx.paging.insertSeparators
 import androidx.paging.map as pagingMap
 import com.sirelon.marsroverphotos.data.database.entities.MarsImage
 import com.sirelon.marsroverphotos.data.paging.FeedMode
+import com.sirelon.marsroverphotos.data.paging.ImagesSearchPagingSource
 import com.sirelon.marsroverphotos.data.paging.RoverFeedPager
 import com.sirelon.marsroverphotos.data.paging.pageQuery
 import com.sirelon.marsroverphotos.data.paging.usesPageFeed
@@ -308,7 +309,7 @@ class PhotosViewModel(
 
     /** Scrolls the grid to the start of the given page (1-based). No-op in sol mode. */
     fun loadByPage(page: Int) {
-        val index = (page - 1).coerceAtLeast(0) * PAGE_SIZE
+        val index = (page - 1).coerceAtLeast(0) * ImagesSearchPagingSource.PAGE_SIZE
         _scrollToItemEmitter.tryEmit(index)
     }
 
@@ -410,7 +411,6 @@ class PhotosViewModel(
     private companion object {
         private const val FACT_POOL_SIZE = 15
         private const val FACT_EVERY_N_DAYS = 3L
-        private const val PAGE_SIZE = 100
 
         /**
          * Emitted by [gridItemsFlow] while the shared pager still points at the previous rover, so

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/PhotosViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/PhotosViewModel.kt
@@ -10,6 +10,7 @@ import androidx.paging.insertSeparators
 import androidx.paging.map as pagingMap
 import com.sirelon.marsroverphotos.data.database.entities.MarsImage
 import com.sirelon.marsroverphotos.data.paging.FeedMode
+import com.sirelon.marsroverphotos.data.paging.ImagesSearchPagingSource
 import com.sirelon.marsroverphotos.data.paging.RoverFeedPager
 import com.sirelon.marsroverphotos.data.paging.pageQuery
 import com.sirelon.marsroverphotos.data.paging.usesPageFeed
@@ -215,9 +216,19 @@ class PhotosViewModel(
         }
     }
 
+    /**
+     * Rover id this instance has already anchored the page feed for. The screen's
+     * `LaunchedEffect(roverId)` re-fires [setRoverId] every time it re-enters composition
+     * (back from the fullscreen viewer or a picker), and re-anchoring there would jump the
+     * feed to a new random page under the user. Only a fresh ViewModel — a genuine screen
+     * open — applies the random anchor.
+     */
+    private var pageFeedAppliedFor: Long? = null
+
     fun setRoverId(roverId: Long) {
         roverIdEmitter.tryEmit(roverId)
-        if (roverId.usesPageFeed()) {
+        if (roverId.usesPageFeed() && pageFeedAppliedFor != roverId) {
+            pageFeedAppliedFor = roverId
             // Apply immediately — before the compose frame renders — so the cached (stale)
             // PagingData from the previous session is replaced before the UI sees it.
             applyPageFeed(roverId)
@@ -437,6 +448,13 @@ data class PhotosUiState(
     val showCameraName: Boolean = true,
     /** False for page-mode rovers (Spirit/Opportunity) — hides sol nav, date picker, camera filter. */
     val showSolControls: Boolean = true,
-    /** Total photos loaded for page-mode rovers. 0 until the first fetch completes. */
+    /** Dataset size (API totalHits) for page-mode rovers. 0 until the first fetch completes. */
     val totalPagePhotos: Int = 0,
-)
+) {
+    /** Total API pages for page-mode rovers (≥ 1), derived from [totalPagePhotos]. */
+    val totalPages: Int
+        get() {
+            val pageSize = ImagesSearchPagingSource.PAGE_SIZE
+            return if (totalPagePhotos > 0) (totalPagePhotos + pageSize - 1) / pageSize else 1
+        }
+}

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/PhotosViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/PhotosViewModel.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
@@ -70,6 +71,11 @@ class PhotosViewModel(
 
     /** Top-visible sol — drives the floating header chip and the Sol/Earth pickers (sol mode only). */
     private val visibleSolEmitter = MutableStateFlow<Long?>(null)
+
+    private val visiblePageEmitter = MutableStateFlow(1)
+
+    /** Top-visible API page — drives the floating chip and the page picker (page mode only). */
+    val visiblePage: StateFlow<Int> = visiblePageEmitter.asStateFlow()
 
     /**
      * Fires every time the feed is re-anchored (date/sol picker, randomize, go-to-latest, camera
@@ -268,6 +274,12 @@ class PhotosViewModel(
         visibleSolEmitter.value = sol
     }
 
+    /** No-op in sol mode (sol-feed `order` is a per-sol index, not a page position). */
+    fun onVisiblePageChanged(page: Int) {
+        if (roverIdEmitter.value?.usesPageFeed() != true) return
+        visiblePageEmitter.value = page
+    }
+
     fun consumeLastViewedPhotoId(): String? = roverFeedPager.consumeLastViewedPhotoId()
 
     val favoriteOverrides get() = roverFeedPager.favoriteOverrides
@@ -367,6 +379,9 @@ class PhotosViewModel(
 
     /** [anchorPage] = explicit 1-based page to open at; null lets the source pick a random one. */
     private fun applyPageFeed(roverId: Long, anchorPage: Int? = null) {
+        // Eager chip update for explicit jumps; a random anchor stays unknown until the page
+        // loads, at which point the grid reports it back via [onVisiblePageChanged].
+        anchorPage?.let { visiblePageEmitter.value = it }
         roverFeedPager.setFeed(
             roverId = roverId,
             mode = FeedMode.Page(roverId.pageQuery(), anchorPage = anchorPage),

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/utils/NasaImageUrl.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/utils/NasaImageUrl.kt
@@ -1,0 +1,41 @@
+package com.sirelon.marsroverphotos.utils
+
+/**
+ * Derives the full-resolution URL from a NASA Image Library preview href.
+ *
+ * Search result links end in a size token: `~thumb`, `~small`, `~medium`, or `~large` followed
+ * by the file extension. The `~orig` asset (same path, same extension) is the full-res version.
+ * If no known size token is found the href is returned as-is (no blind replacement).
+ *
+ * Examples:
+ *   `…/PIA05040~small.jpg`  → `…/PIA05040~orig.jpg`
+ *   `…/PIA05040~thumb.jpg`  → `…/PIA05040~orig.jpg`
+ *   `…/PIA05040~large.jpg`  → `…/PIA05040~orig.jpg`
+ *   `…/PIA05040.jpg`        → `…/PIA05040.jpg` (unchanged)
+ */
+internal fun nasaImageOrigUrl(href: String): String {
+    val match = SIZE_TOKEN_REGEX.find(href) ?: return href
+    val ext = match.groupValues[2]
+    return href.substring(0, match.range.first) + "~orig.$ext"
+}
+
+/**
+ * Derives the lightweight `~small` URL from a NASA Image Library preview href.
+ *
+ * Any known size token (`~thumb`, `~small`, `~medium`, `~large`) is replaced with `~small`.
+ * If no known size token is found the href is returned as-is.
+ *
+ * Storing `~small` in [com.sirelon.marsroverphotos.data.database.entities.MarsImage.imageUrl]
+ * keeps the grid fast; call [nasaImageOrigUrl] on the stored value to recover the full-res URL
+ * for the detail viewer.
+ */
+internal fun nasaImageSmallUrl(href: String): String {
+    val match = SIZE_TOKEN_REGEX.find(href) ?: return href
+    val ext = match.groupValues[2]
+    return href.substring(0, match.range.first) + "~small.$ext"
+}
+
+private val SIZE_TOKEN_REGEX = Regex(
+    "~(thumb|small|medium|large)\\.(jpg|jpeg|png)$",
+    RegexOption.IGNORE_CASE,
+)

--- a/shared/src/commonTest/kotlin/com/sirelon/marsroverphotos/data/paging/Fakes.kt
+++ b/shared/src/commonTest/kotlin/com/sirelon/marsroverphotos/data/paging/Fakes.kt
@@ -3,7 +3,7 @@ package com.sirelon.marsroverphotos.data.paging
 import androidx.paging.PagingSource
 import com.sirelon.marsroverphotos.data.database.dao.ImagesDao
 import com.sirelon.marsroverphotos.data.database.entities.MarsImage
-import com.sirelon.marsroverphotos.data.database.entities.StatsUpdate
+import com.sirelon.marsroverphotos.data.database.entities.PopularUpdate
 import com.sirelon.marsroverphotos.domain.models.PhotosQueryRequest
 import com.sirelon.marsroverphotos.domain.repositories.PhotosRepository
 import kotlinx.coroutines.flow.Flow
@@ -54,12 +54,12 @@ class FakeImagesDao(
     override fun getAllImages(): Flow<List<MarsImage>> = emptyFlow()
     override suspend fun update(item: MarsImage) = Unit
     override suspend fun updateFavorite(id: String, favorite: Boolean, counter: Long) = Unit
-    override suspend fun updateStats(stats: StatsUpdate) = Unit
+    override suspend fun updatePopular(update: PopularUpdate) = Unit
     override fun loadFavoriteImages(): Flow<List<MarsImage>> = emptyFlow()
     override fun loadPopularImages(): Flow<List<MarsImage>> = emptyFlow()
     override fun loadFavoritePagedSource(): PagingSource<Int, MarsImage> = TODO("unused")
     override fun loadPopularPagedSource(): PagingSource<Int, MarsImage> = TODO("unused")
-    override suspend fun deleteAllPopular() = Unit
+    override suspend fun clearPopularFlags() = Unit
 }
 
 /** Builds a [MarsImage] for a sol with the given id and optional camera. */

--- a/shared/src/commonTest/kotlin/com/sirelon/marsroverphotos/data/paging/ImagesSearchPagingSourceTest.kt
+++ b/shared/src/commonTest/kotlin/com/sirelon/marsroverphotos/data/paging/ImagesSearchPagingSourceTest.kt
@@ -1,8 +1,11 @@
 package com.sirelon.marsroverphotos.data.paging
 
+import androidx.paging.PagingConfig
 import androidx.paging.PagingSource
+import androidx.paging.PagingState
 import com.sirelon.marsroverphotos.data.database.entities.MarsImage
 import kotlinx.coroutines.test.runTest
+import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -11,265 +14,204 @@ import kotlin.test.assertTrue
 
 class ImagesSearchPagingSourceTest {
 
+    /** 450 hits at pageSize 100 → 5 pages; page N carries items "pN_1".."pN_100" (page 5: 50). */
+    private val totalHits = 450
+
+    private fun pageResult(page: Int, totalHits: Int = this.totalHits): ImagesSearchPagingSource.PageResult {
+        val count = (totalHits - (page - 1) * 100).coerceIn(0, 100)
+        return ImagesSearchPagingSource.PageResult(
+            images = (1..count).map { marsImage("p${page}_$it", 0L).copy(order = (page - 1) * 100 + it - 1) },
+            totalHits = totalHits,
+        )
+    }
+
+    /** Source over the 5-page dataset; [fetchedPages] records every network page request. */
     private fun source(
-        pages: Map<Int, ImagesSearchPagingSource.PageResult>,
+        anchorPage: Int? = null,
+        totalHitsHint: Int? = null,
+        random: Random = Random(0),
         dao: FakeImagesDao = FakeImagesDao(),
-        shuffleSeed: Long? = null,
+        onTotalHits: ((Int) -> Unit)? = null,
+        fetchedPages: MutableList<Int> = mutableListOf(),
+        fetch: suspend (page: Int) -> ImagesSearchPagingSource.PageResult = { pageResult(it) },
     ): ImagesSearchPagingSource = ImagesSearchPagingSource(
-        pageSize = 100,
         imagesDao = dao,
-        shuffleSeed = shuffleSeed,
-        fetchPage = { page -> pages[page] ?: ImagesSearchPagingSource.PageResult(emptyList(), 0) },
+        anchorPage = anchorPage,
+        totalHitsHint = totalHitsHint,
+        onTotalHits = onTotalHits,
+        random = random,
+        fetchPage = { page ->
+            fetchedPages += page
+            fetch(page)
+        },
     )
 
     private fun page(result: PagingSource.LoadResult<Int, MarsImage>) =
         assertIs<PagingSource.LoadResult.Page<Int, MarsImage>>(result)
 
-    private fun imageWithDate(id: String, date: String): MarsImage =
-        marsImage(id, 0L).copy(earthDate = date)
+    private fun refresh(key: Int? = null) = PagingSource.LoadParams.Refresh(key, 100, false)
 
-    // 1. Fetch-all: a two-page dataset is loaded in a single load() call.
+    // 1. Refresh with an explicit anchor fetches exactly that page, with real directional keys.
     @Test
-    fun fetchAll_loadsAllPages() = runTest {
-        val src = source(
-            mapOf(
-                1 to ImagesSearchPagingSource.PageResult(
-                    images = (1..100).map { marsImage("p1_img$it", 0L) },
-                    totalHits = 150,
-                ),
-                2 to ImagesSearchPagingSource.PageResult(
-                    images = (1..50).map { marsImage("p2_img$it", 0L) },
-                    totalHits = 150,
-                ),
-            )
-        )
+    fun refresh_explicitAnchorFetchesThatPage() = runTest {
+        val fetched = mutableListOf<Int>()
+        val p = page(source(anchorPage = 2, fetchedPages = fetched).load(refresh()))
 
-        val p = page(src.load(PagingSource.LoadParams.Refresh(null, 100, false)))
-        assertEquals(150, p.data.size)
+        assertEquals(listOf(2), fetched)
+        assertEquals(100, p.data.size)
+        assertEquals("p2_1", p.data.first().id)
+        assertEquals(1, p.prevKey)
+        assertEquals(3, p.nextKey)
     }
 
-    // 2. nextKey is always null — single-page result, no incremental paging.
+    // 2. A refresh key (Paging re-centering after invalidation) takes priority over the anchor.
     @Test
-    fun load_nextKeyIsAlwaysNull() = runTest {
-        val src = source(
-            mapOf(1 to ImagesSearchPagingSource.PageResult(
-                images = (1..100).map { marsImage("img$it", 0L) },
-                totalHits = 200,
-            ))
-        )
-        val p = page(src.load(PagingSource.LoadParams.Refresh(null, 100, false)))
-        assertNull(p.nextKey)
+    fun refresh_keyTakesPriorityOverAnchor() = runTest {
+        val fetched = mutableListOf<Int>()
+        page(source(anchorPage = 2, fetchedPages = fetched).load(refresh(key = 4)))
+        assertEquals(listOf(4), fetched)
     }
 
-    // 3. prevKey is always null.
+    // 3. Random anchor with a cached totalHits hint: a single fetch, straight to the picked page.
     @Test
-    fun load_prevKeyIsAlwaysNull() = runTest {
-        val src = source(mapOf(1 to ImagesSearchPagingSource.PageResult(listOf(marsImage("x", 0L)), 1)))
-        val p = page(src.load(PagingSource.LoadParams.Refresh(null, 100, false)))
-        assertNull(p.prevKey)
-    }
-
-    // 4. Default sort: newest-first by earthDate (ISO-8601 lexicographic descending, blank last).
-    @Test
-    fun fetchAll_defaultSortIsNewestFirst() = runTest {
-        val pages = mapOf(1 to ImagesSearchPagingSource.PageResult(
-            images = listOf(
-                imageWithDate("old", "2010-01-01T00:00:00Z"),
-                imageWithDate("new", "2020-06-15T00:00:00Z"),
-                imageWithDate("mid", "2015-03-10T00:00:00Z"),
-                imageWithDate("blank", ""),
-            ),
-            totalHits = 4,
-        ))
-        val p = page(source(pages).load(PagingSource.LoadParams.Refresh(null, 100, false)))
-        assertEquals(listOf("new", "mid", "old", "blank"), p.data.map { it.id })
-    }
-
-    // 5. Shuffle: same seed → same order (deterministic).
-    @Test
-    fun fetchAll_shuffleWithSeedIsDeterministic() = runTest {
-        val images = (1..20).map { marsImage("img$it", 0L) }
-        val pages = mapOf(1 to ImagesSearchPagingSource.PageResult(images, totalHits = 20))
+    fun refresh_randomAnchorWithHint_singleFetch() = runTest {
         val seed = 42L
+        val expectedPage = Random(seed).nextInt(1, 6) // same draw the source will make over 5 pages
+        val fetched = mutableListOf<Int>()
 
-        val p1 = page(source(pages, shuffleSeed = seed).load(PagingSource.LoadParams.Refresh(null, 100, false)))
-        val p2 = page(source(pages, shuffleSeed = seed).load(PagingSource.LoadParams.Refresh(null, 100, false)))
-
-        assertEquals(p1.data.map { it.id }, p2.data.map { it.id })
-    }
-
-    // 6. Shuffle: different seeds produce different orders (with overwhelming probability for 20 items).
-    @Test
-    fun fetchAll_differentSeedsProduceDifferentOrders() = runTest {
-        val images = (1..20).map { marsImage("img$it", 0L) }
-        val pages = mapOf(1 to ImagesSearchPagingSource.PageResult(images, totalHits = 20))
-
-        val p1 = page(source(pages, shuffleSeed = 1L).load(PagingSource.LoadParams.Refresh(null, 100, false)))
-        val p2 = page(source(pages, shuffleSeed = 999L).load(PagingSource.LoadParams.Refresh(null, 100, false)))
-
-        assertTrue(p1.data.map { it.id } != p2.data.map { it.id })
-    }
-
-    // 7. Shuffle does not change total item count.
-    @Test
-    fun fetchAll_shufflePreservesItemCount() = runTest {
-        val images = (1..50).map { marsImage("img$it", 0L) }
-        val pages = mapOf(1 to ImagesSearchPagingSource.PageResult(images, totalHits = 50))
-        val p = page(source(pages, shuffleSeed = 7L).load(PagingSource.LoadParams.Refresh(null, 100, false)))
-        assertEquals(50, p.data.size)
-    }
-
-    // 8. Short last page ends the fetch-all loop before totalHits is reached.
-    @Test
-    fun fetchAll_shortLastPageStopsLooping() = runTest {
-        val src = source(
-            mapOf(
-                1 to ImagesSearchPagingSource.PageResult(
-                    images = (1..100).map { marsImage("p1_$it", 0L) },
-                    totalHits = 130,
-                ),
-                2 to ImagesSearchPagingSource.PageResult(
-                    images = (1..30).map { marsImage("p2_$it", 0L) },
-                    totalHits = 130,
-                ),
-            )
+        val p = page(
+            source(totalHitsHint = totalHits, random = Random(seed), fetchedPages = fetched)
+                .load(refresh())
         )
-        val p = page(src.load(PagingSource.LoadParams.Refresh(null, 100, false)))
-        assertEquals(130, p.data.size)
-        assertNull(p.nextKey)
+
+        assertEquals(listOf(expectedPage), fetched)
+        assertEquals("p${expectedPage}_1", p.data.first().id)
     }
 
-    // 9. Empty first page → empty result with no keys.
+    // 4. Random anchor without a hint bootstraps page 1 to learn totalHits, then fetches the target.
     @Test
-    fun fetchAll_emptyResultReturnsEmptyPage() = runTest {
-        val src = source(mapOf(1 to ImagesSearchPagingSource.PageResult(emptyList(), 0)))
-        val p = page(src.load(PagingSource.LoadParams.Refresh(null, 100, false)))
-        assertTrue(p.data.isEmpty())
-        assertNull(p.nextKey)
-        assertNull(p.prevKey)
+    fun refresh_randomAnchorWithoutHint_bootstrapsPage1() = runTest {
+        // Pick a seed whose draw over 5 pages lands beyond page 1, so the bootstrap isn't reused.
+        val seed = (1L..100L).first { Random(it).nextInt(1, 6) > 1 }
+        val expectedPage = Random(seed).nextInt(1, 6)
+        val fetched = mutableListOf<Int>()
+
+        val p = page(source(random = Random(seed), fetchedPages = fetched).load(refresh()))
+
+        assertEquals(listOf(1, expectedPage), fetched)
+        assertEquals("p${expectedPage}_1", p.data.first().id)
     }
 
-    // 10. Write-through: insertImages called and persisted favorite merged back.
+    // 5. Single-page dataset: the bootstrap result is reused — exactly one fetch.
+    @Test
+    fun refresh_singlePageDataset_reusesBootstrap() = runTest {
+        val fetched = mutableListOf<Int>()
+        val p = page(
+            source(fetchedPages = fetched, fetch = { pageResult(it, totalHits = 80) })
+                .load(refresh())
+        )
+
+        assertEquals(listOf(1), fetched)
+        assertEquals(80, p.data.size)
+        assertNull(p.prevKey)
+        assertNull(p.nextKey)
+    }
+
+    // 6. Append fetches the requested page with both directional keys.
+    @Test
+    fun append_fetchesPageWithKeys() = runTest {
+        val p = page(source().load(PagingSource.LoadParams.Append(3, 100, false)))
+        assertEquals("p3_1", p.data.first().id)
+        assertEquals(2, p.prevKey)
+        assertEquals(4, p.nextKey)
+    }
+
+    // 7. Last page: nextKey is null, prepend stays open.
+    @Test
+    fun lastPage_nextKeyNull() = runTest {
+        val p = page(source().load(PagingSource.LoadParams.Append(5, 100, false)))
+        assertEquals(50, p.data.size)
+        assertEquals(4, p.prevKey)
+        assertNull(p.nextKey)
+    }
+
+    // 8. First page: prevKey is null, append stays open.
+    @Test
+    fun firstPage_prevKeyNull() = runTest {
+        val p = page(source().load(PagingSource.LoadParams.Prepend(1, 100, false)))
+        assertNull(p.prevKey)
+        assertEquals(2, p.nextKey)
+    }
+
+    // 9. An empty fetch ends pagination in both directions — never an empty page with a live key.
+    @Test
+    fun emptyFetch_returnsTerminalPage() = runTest {
+        val p = page(
+            source(anchorPage = 7, fetch = { ImagesSearchPagingSource.PageResult(emptyList(), 0) })
+                .load(refresh())
+        )
+        assertTrue(p.data.isEmpty())
+        assertNull(p.prevKey)
+        assertNull(p.nextKey)
+    }
+
+    // 10. An explicit anchor beyond the dataset is clamped against the totalHits hint.
+    @Test
+    fun refresh_anchorClampedToHintRange() = runTest {
+        val fetched = mutableListOf<Int>()
+        page(
+            source(anchorPage = 99, totalHitsHint = totalHits, fetchedPages = fetched)
+                .load(refresh())
+        )
+        assertEquals(listOf(5), fetched)
+    }
+
+    // 11. Write-through: insertImages called and persisted favorite merged back.
     @Test
     fun load_writesThroughAndMergesPersistedFavorite() = runTest {
         val network = marsImage("favImg", 0L, favorite = 0)
         val persisted = marsImage("favImg", 0L, favorite = 1)
         val dao = FakeImagesDao(persistedById = mapOf("favImg" to persisted))
-        val src = ImagesSearchPagingSource(
-            pageSize = 100,
-            imagesDao = dao,
-            fetchPage = { ImagesSearchPagingSource.PageResult(listOf(network), totalHits = 1) },
+        val src = source(
+            anchorPage = 1,
+            dao = dao,
+            fetch = { ImagesSearchPagingSource.PageResult(listOf(network), totalHits = 1) },
         )
 
-        val p = page(src.load(PagingSource.LoadParams.Refresh(null, 100, false)))
-        assertEquals(1, p.data.size)
+        val p = page(src.load(refresh()))
         assertEquals(1L, p.data.first().stats.favorite)
         assertTrue(dao.insertedIds.contains("favImg"))
     }
 
-    // 11. Network error propagates as LoadResult.Error.
+    // 12. Network error propagates as LoadResult.Error.
     @Test
     fun load_networkErrorProducesErrorResult() = runTest {
-        val src = ImagesSearchPagingSource(
-            pageSize = 100,
-            imagesDao = FakeImagesDao(),
-            fetchPage = { throw RuntimeException("network failure") },
-        )
-        val result = src.load(PagingSource.LoadParams.Refresh(null, 100, false))
+        val src = source(anchorPage = 1, fetch = { throw RuntimeException("network failure") })
+        val result = src.load(refresh())
         assertIs<PagingSource.LoadResult.Error<Int, MarsImage>>(result)
     }
 
-    // 12. Safety cap: loop stops after 50 pages when the API never signals end-of-data.
-    //     Uses pageSize=2 for efficiency: 50 pages × 2 items = 100 items total.
+    // 13. onTotalHits reports the dataset size after every fetch.
     @Test
-    fun fetchAll_stopsAtMaxPagesCap() = runTest {
-        val src = ImagesSearchPagingSource(
-            pageSize = 2,
-            imagesDao = FakeImagesDao(),
-            fetchPage = { page ->
-                ImagesSearchPagingSource.PageResult(
-                    images = listOf(marsImage("pg${page}_a", 0L), marsImage("pg${page}_b", 0L)),
-                    totalHits = 99999,
-                )
-            },
-        )
-        val p = page(src.load(PagingSource.LoadParams.Refresh(null, 2, false)))
-        assertEquals(100, p.data.size)   // 50 pages × 2 items/page
-        assertNull(p.nextKey)
+    fun load_reportsTotalHits() = runTest {
+        var reported = -1
+        page(source(anchorPage = 2, onTotalHits = { reported = it }).load(refresh()))
+        assertEquals(totalHits, reported)
     }
 
-    // 13. Cache hit: when cachedImages is provided, fetchPage is never called.
+    // 14. getRefreshKey maps the anchor item's global order back to its API page.
     @Test
-    fun load_cacheHit_skipsNetwork() = runTest {
-        var fetchCallCount = 0
-        val cached = (1..5).map { marsImage("cached$it", 0L) }
-        val src = ImagesSearchPagingSource(
-            pageSize = 100,
-            imagesDao = FakeImagesDao(),
-            cachedImages = cached,
-            fetchPage = { _ ->
-                fetchCallCount++
-                ImagesSearchPagingSource.PageResult(emptyList(), 0)
-            },
+    fun getRefreshKey_mapsAnchorItemOrderToPage() = runTest {
+        val src = source()
+        val item = marsImage("x", 0L).copy(order = 250) // global index 250 → page 3
+        val state = PagingState(
+            pages = listOf(
+                PagingSource.LoadResult.Page(data = listOf(item), prevKey = 2, nextKey = 4)
+            ),
+            anchorPosition = 0,
+            config = PagingConfig(pageSize = 100),
+            leadingPlaceholderCount = 0,
         )
-        val p = page(src.load(PagingSource.LoadParams.Refresh(null, 100, false)))
-        assertEquals(0, fetchCallCount)
-        assertEquals(cached.size, p.data.size)
-    }
-
-    // 14. onAllImagesFetched is invoked with merged images after a network fetch.
-    @Test
-    fun load_networkFetch_callsOnAllImagesFetched() = runTest {
-        val images = (1..3).map { marsImage("n$it", 0L) }
-        var captured: List<MarsImage>? = null
-        val src = ImagesSearchPagingSource(
-            pageSize = 100,
-            imagesDao = FakeImagesDao(),
-            onAllImagesFetched = { captured = it },
-            fetchPage = { ImagesSearchPagingSource.PageResult(images, totalHits = 3) },
-        )
-        src.load(PagingSource.LoadParams.Refresh(null, 100, false))
-        assertEquals(3, captured?.size)
-    }
-
-    // 15. Cache hit: onAllImagesFetched is NOT called (no network fetch happened).
-    @Test
-    fun load_cacheHit_doesNotCallOnAllImagesFetched() = runTest {
-        var callCount = 0
-        val cached = listOf(marsImage("c1", 0L))
-        val src = ImagesSearchPagingSource(
-            pageSize = 100,
-            imagesDao = FakeImagesDao(),
-            cachedImages = cached,
-            onAllImagesFetched = { callCount++ },
-            fetchPage = { ImagesSearchPagingSource.PageResult(emptyList(), 0) },
-        )
-        src.load(PagingSource.LoadParams.Refresh(null, 100, false))
-        assertEquals(0, callCount)
-    }
-
-    // 16. Cache + shuffle: different seeds applied to the same cached list produce different orders.
-    @Test
-    fun load_cacheHit_differentSeedsDifferentOrders() = runTest {
-        val cached = (1..20).map { marsImage("c$it", 0L) }
-        val p1 = page(
-            ImagesSearchPagingSource(
-                pageSize = 100,
-                imagesDao = FakeImagesDao(),
-                cachedImages = cached,
-                shuffleSeed = 1L,
-                fetchPage = { ImagesSearchPagingSource.PageResult(emptyList(), 0) },
-            ).load(PagingSource.LoadParams.Refresh(null, 100, false))
-        )
-        val p2 = page(
-            ImagesSearchPagingSource(
-                pageSize = 100,
-                imagesDao = FakeImagesDao(),
-                cachedImages = cached,
-                shuffleSeed = 999L,
-                fetchPage = { ImagesSearchPagingSource.PageResult(emptyList(), 0) },
-            ).load(PagingSource.LoadParams.Refresh(null, 100, false))
-        )
-        assertTrue(p1.data.map { it.id } != p2.data.map { it.id })
+        assertEquals(3, src.getRefreshKey(state))
     }
 }

--- a/shared/src/commonTest/kotlin/com/sirelon/marsroverphotos/data/paging/ImagesSearchPagingSourceTest.kt
+++ b/shared/src/commonTest/kotlin/com/sirelon/marsroverphotos/data/paging/ImagesSearchPagingSourceTest.kt
@@ -25,7 +25,11 @@ class ImagesSearchPagingSourceTest {
         )
     }
 
-    /** Source over the 5-page dataset; [fetchedPages] records every network page request. */
+    /**
+     * Source over the 5-page dataset; [fetchedPages] records every network page request.
+     * pageSize is pinned to 100 — the fixtures encode 100-per-page math, and the paging logic
+     * under test is independent of the production PAGE_SIZE value.
+     */
     private fun source(
         anchorPage: Int? = null,
         totalHitsHint: Int? = null,
@@ -40,6 +44,7 @@ class ImagesSearchPagingSourceTest {
         totalHitsHint = totalHitsHint,
         onTotalHits = onTotalHits,
         random = random,
+        pageSize = 100,
         fetchPage = { page ->
             fetchedPages += page
             fetch(page)

--- a/shared/src/commonTest/kotlin/com/sirelon/marsroverphotos/data/paging/ImagesSearchPagingSourceTest.kt
+++ b/shared/src/commonTest/kotlin/com/sirelon/marsroverphotos/data/paging/ImagesSearchPagingSourceTest.kt
@@ -171,20 +171,25 @@ class ImagesSearchPagingSourceTest {
         assertEquals(listOf(5), fetched)
     }
 
-    // 11. Write-through: insertImages called and persisted favorite merged back.
+    // 11. Write-through: insertImages called; ONLY user state (favorite/stats) is merged from
+    //     the persisted row — `order` must stay network-fresh, because the IGNORE insert leaves
+    //     rows with whatever order they were first cached under (older page size or query),
+    //     which would corrupt the order-derived page math (chip, getRefreshKey, viewer restore).
     @Test
-    fun load_writesThroughAndMergesPersistedFavorite() = runTest {
-        val network = marsImage("favImg", 0L, favorite = 0)
-        val persisted = marsImage("favImg", 0L, favorite = 1)
-        val dao = FakeImagesDao(persistedById = mapOf("favImg" to persisted))
+    fun load_mergesOnlyUserStateFromPersistedRow() = runTest {
+        val network = marsImage("favImg", 0L, favorite = 0).copy(order = 430, favorite = false)
+        val stale = marsImage("favImg", 0L, favorite = 1).copy(order = 245, favorite = true)
+        val dao = FakeImagesDao(persistedById = mapOf("favImg" to stale))
         val src = source(
             anchorPage = 1,
             dao = dao,
             fetch = { ImagesSearchPagingSource.PageResult(listOf(network), totalHits = 1) },
         )
 
-        val p = page(src.load(refresh()))
-        assertEquals(1L, p.data.first().stats.favorite)
+        val merged = page(src.load(refresh())).data.first()
+        assertEquals(1L, merged.stats.favorite)   // user state: from Room
+        assertTrue(merged.favorite)               // user state: from Room
+        assertEquals(430, merged.order)           // network-fresh, NOT the stale 245
         assertTrue(dao.insertedIds.contains("favImg"))
     }
 

--- a/shared/src/commonTest/kotlin/com/sirelon/marsroverphotos/data/paging/SolPagingSourcePagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/sirelon/marsroverphotos/data/paging/SolPagingSourcePagerTest.kt
@@ -1,0 +1,108 @@
+package com.sirelon.marsroverphotos.data.paging
+
+import androidx.paging.PagingConfig
+import androidx.paging.PagingSource
+import androidx.paging.testing.TestPager
+import com.sirelon.marsroverphotos.data.database.entities.MarsImage
+import com.sirelon.marsroverphotos.domain.models.CURIOSITY_ID
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Pager-level integration tests via [TestPager]. The [SolPagingSource] design relies on Paging 3
+ * re-enqueuing APPEND/PREPEND after an empty page with a non-null key (the "continuation page"
+ * mechanism for gaps longer than one scan budget) — these tests prove the key chain actually
+ * carries a real pager across such a gap, and that a terminal page ends pagination.
+ */
+class SolPagingSourcePagerTest {
+
+    // Mirrors the production PagingConfig (RoverPhotosRepository / photos feed).
+    private val config = PagingConfig(pageSize = 20, prefetchDistance = 10, enablePlaceholders = false)
+
+    private fun source(
+        solToPhotos: Map<Long, List<MarsImage>>,
+        maxSol: Long,
+        initialSol: Long = 0,
+    ): SolPagingSource = SolPagingSource(
+        photosRepository = FakePhotosRepository(solToPhotos),
+        imagesDao = FakeImagesDao(),
+        roverId = CURIOSITY_ID,
+        cameras = emptySet(),
+        initialSol = initialSol,
+        minSol = 0,
+        maxSol = maxSol,
+    )
+
+    private fun page(result: PagingSource.LoadResult<Long, MarsImage>?) =
+        assertIs<PagingSource.LoadResult.Page<Long, MarsImage>>(result)
+
+    // 1. A gap LONGER than one unfiltered scan budget (300 sols): photos at sol 0 and sol 350.
+    // The pager must step through the continuation page(s) and reach sol 350 without stalling.
+    @Test
+    fun append_stepsThroughContinuationPagesAcrossLongGap() = runTest {
+        val pager = TestPager(
+            config,
+            source(
+                solToPhotos = mapOf(
+                    0L to listOf(marsImage("start", 0)),
+                    350L to listOf(marsImage("far", 350)),
+                ),
+                maxSol = 1000,
+            ),
+        )
+
+        // Refresh lands on sol 0.
+        val refreshed = page(pager.refresh())
+        assertEquals(listOf("start"), refreshed.data.map { it.id })
+
+        // Append until photos arrive; the loop bound proves we don't stall or spin.
+        var appends = 0
+        var found: PagingSource.LoadResult.Page<Long, MarsImage>? = null
+        while (found == null && appends < 5) {
+            val p = page(pager.append())
+            appends++
+            if (p.data.isNotEmpty()) found = p
+        }
+        // One continuation page (budget hit at sol 301) + the page that finds sol 350.
+        assertEquals(2, appends)
+        assertEquals(listOf("far"), found?.data?.map { it.id })
+
+        // Keep appending: continuation pages walk the rest of the range (651, 951) until the
+        // maxSol bound yields a terminal page, after which TestPager stops appending entirely.
+        var last: PagingSource.LoadResult.Page<Long, MarsImage>? = null
+        var tailAppends = 0
+        while (tailAppends < 10) {
+            val r = pager.append() ?: break
+            last = page(r)
+            tailAppends++
+        }
+        assertEquals(3, tailAppends)
+        assertTrue(last!!.data.isEmpty())
+        assertNull(last.nextKey)
+    }
+
+    // 2. Terminal page ends pagination: nothing after sol 0 within bounds -> empty page with a
+    // null nextKey, and TestPager returns null for any further append.
+    @Test
+    fun append_terminalPageEndsPagination() = runTest {
+        val pager = TestPager(
+            config,
+            source(solToPhotos = mapOf(0L to listOf(marsImage("only", 0))), maxSol = 50),
+        )
+
+        val refreshed = page(pager.refresh())
+        assertEquals(listOf("only"), refreshed.data.map { it.id })
+
+        // Scan 1..50 reaches the bound within budget -> terminal page.
+        val terminal = page(pager.append())
+        assertTrue(terminal.data.isEmpty())
+        assertNull(terminal.nextKey)
+
+        // A null nextKey ends pagination: TestPager refuses further appends.
+        assertNull(pager.append())
+    }
+}

--- a/shared/src/commonTest/kotlin/com/sirelon/marsroverphotos/data/paging/SolPagingSourceTest.kt
+++ b/shared/src/commonTest/kotlin/com/sirelon/marsroverphotos/data/paging/SolPagingSourceTest.kt
@@ -178,6 +178,34 @@ class SolPagingSourceTest {
         assertEquals(listOf("f"), dao.insertedIds)
     }
 
+    // 8. Memoized empty sols: a Prepend over the gap a Refresh already scanned must not re-probe
+    // the same sols (one network request per known-empty sol would be wasted otherwise).
+    @Test
+    fun prepend_skipsSolsAlreadyProbedEmpty() = runTest {
+        // Refresh anchored at sol 5 scans sols 5..14 empty, then finds photos at sol 15.
+        val photos = mapOf(15L to listOf(marsImage("g", 15)))
+        val repo = FakePhotosRepository(photos)
+        val src = source(photos, initialSol = 5, minSol = 0, maxSol = 100, repo = repo)
+
+        val refreshed = page(src.load(PagingSource.LoadParams.Refresh(null, 5, false)))
+        assertEquals(listOf("g"), refreshed.data.map { it.id })
+        assertEquals((5L..15L).toList(), repo.probedSols.toList())
+        val probesAfterRefresh = repo.probedSols.size
+
+        // Prepend walks back from sol 14 through the very gap the refresh just probed.
+        val prepended = page(src.load(PagingSource.LoadParams.Prepend(14L, 5, false)))
+
+        // Sols 5..14 are memoized empty: only the not-yet-probed sols 4..0 cost a request.
+        val prependProbes = repo.probedSols.drop(probesAfterRefresh)
+        assertEquals(listOf(4L, 3L, 2L, 1L, 0L), prependProbes)
+        // No sol is ever probed twice across the lifetime of the source.
+        assertEquals(repo.probedSols.size, repo.probedSols.distinct().size)
+        // The walk reached minSol without photos -> terminal page.
+        assertTrue(prepended.data.isEmpty())
+        assertNull(prepended.prevKey)
+        assertNull(prepended.nextKey)
+    }
+
     // Optional: filtered feed using a real Curiosity camera name.
     @Test
     fun append_filteredFeedReturnsOnlyMatchingCamera() = runTest {


### PR DESCRIPTION
## Summary

Full pagination review + fixes across the three feeds, then a rework of the Spirit/Opportunity feed into true page-keyed paging with a random anchor (sol-feed-style UX).

### Popular feed (PopularRemoteMediator)
- Rows already cached by the sol feed now actually become popular: conflict rows get `popular=1`, fresh ranking `order`, and stats via a `PopularUpdate` partial update (previously only stats were touched, so those photos never appeared)
- REFRESH resets stale popular flags (`clearPopularFlags`) instead of never clearing; Firebase cursor only used on APPEND
- Dead `isFirstLoad`/double try-catch removed; dead `StatsUpdate`/`updateStats` deleted

### Sol feed (SolPagingSource)
- Probed-empty sols are memoized per source instance — prepend/refresh over the same gap no longer re-fires duplicate network probes
- New `TestPager`-based integration tests (paging-testing, KMP) prove continuation pages across long gaps don't stall and terminal pages end pagination

### Spirit/Opportunity: page-keyed feed with random anchor
- `ImagesSearchPagingSource` reworked from load-everything-at-once into a true page-keyed `PagingSource`: opening one of these rovers anchors at a **random page**; append/prepend grow the feed in both directions; the page picker re-anchors; the viewer restore anchors at the viewed photo's page
- Richer gallery: `q=<rover>&keywords=Mars Exploration Rover` (Spirit 434 vs 267 photos), page size 10 → ~44/57 pages, floating "Page X of Y" chip (the page-feed counterpart of the sol chip) opens the jump picker with the current page pre-selected
- Shuffle machinery removed (replaced by the random anchor)

### Correctness fixes found during on-device verification
- Write-through cache now merges ONLY user state (favorite + stats) from Room — whole-row merge served stale `order` values from older page sizes/queries, corrupting all order-derived page math ("25 of 44" on the last page)
- Page chip recomputes when page data changes, not just on scroll-index changes (a jump pins the grid at index 0 while data swaps underneath)
- Back-from-viewer no longer re-anchors at a new random page (anchor applied once per ViewModel)
- `ORDER BY \`order\``: added `id` tiebreaker (non-unique order + offset paging can duplicate/skip rows)
- Restored `NasaImageUrl.kt` — referenced by 5 files but never committed; recovered from the main worktree

## Test plan
- 70+ shared tests green (`:shared:desktopTest`), including 14 new page-keyed source tests, 3 new sol-feed tests, and 2 TestPager integration tests
- Verified on a physical iPhone: random anchor, bidirectional scrolling, page chip consistency, picker preselection, first/last-page jumps, viewer round-trip position restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)