### PR TITLE
Add Dependabot config for weekly Gradle dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Adds `.github/dependabot.yml` to enable automated Dependabot pull requests for Gradle dependencies on a weekly (Monday) schedule, with a limit of 10 open PRs at a time. This allows Dependabot to open fix PRs for the 36 existing vulnerability alerts (15 high, 18 moderate, 3 low) rather than only reporting them. Previously there was no Dependabot config file, so alerts were surfaced but no automated remediation PRs were created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)