### PR TITLE
Add rover ID tracking to images and consolidate database config

### DIFF
--- a/androidApp/src/main/kotlin/com/sirelon/marsroverphotos/widget/MarsPhotoWidgetWorker.kt
+++ b/androidApp/src/main/kotlin/com/sirelon/marsroverphotos/widget/MarsPhotoWidgetWorker.kt
@@ -116,7 +116,7 @@ public class MarsPhotoWidgetWorker(
             CURIOSITY_ID -> api.getCuriosityLatestPhotos().firstOrNull()
             SPIRIT_ID, OPPORTUNITY_ID ->
                 api.searchImages(roverId.pageQuery(), 1, 1, keywords = MER_KEYWORDS)
-                    .toMarsImages().firstOrNull()
+                    .toMarsImages(roverId = roverId).firstOrNull()
             else -> api.getCuriosityLatestPhotos().firstOrNull()
         }
     }

--- a/shared/src/androidMain/kotlin/com/sirelon/marsroverphotos/platform/DatabaseBuilder.android.kt
+++ b/shared/src/androidMain/kotlin/com/sirelon/marsroverphotos/platform/DatabaseBuilder.android.kt
@@ -21,6 +21,5 @@ actual fun getDatabaseBuilder(): RoomDatabase.Builder<AppDataBase> {
 
     val dbPath = context.getDatabasePath("mars-rover-photos-database").absolutePath
     return Room.databaseBuilder<AppDataBase>(name = dbPath)
-        .fallbackToDestructiveMigration(false)
-        .addMigrations(AppDataBase.migration7To8, AppDataBase.migration8To9)
+        .configureCommon()
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/AppDataBase.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/AppDataBase.kt
@@ -26,7 +26,7 @@ expect object AppDataBaseConstructor : RoomDatabaseConstructor<AppDataBase>
  */
 @Database(
     entities = [Rover::class, MarsImage::class, FactDisplay::class],
-    version = 9,
+    version = 10,
     exportSchema = false
 )
 @ConstructedBy(AppDataBaseConstructor::class)
@@ -52,6 +52,12 @@ abstract class AppDataBase : RoomDatabase() {
                 connection.execSQL(
                     "CREATE TABLE IF NOT EXISTS `fact_displays` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `factId` TEXT NOT NULL, `displayTimestamp` INTEGER NOT NULL, `sessionId` TEXT NOT NULL)"
                 )
+            }
+        }
+
+        val migration9To10 = object : Migration(9, 10) {
+            override suspend fun migrate(connection: SQLiteConnection) {
+                connection.execSQL("ALTER TABLE images ADD COLUMN roverId INTEGER NOT NULL DEFAULT 0")
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/entities/MarsImage.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/database/entities/MarsImage.kt
@@ -18,6 +18,8 @@ data class MarsImage(
     val imageUrl: String,
     val earthDate: String,
 
+    val roverId: Long = 0L,
+
     @Embedded(prefix = "camera_")
     val camera: RoverCamera?,
 

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/network/Mappers.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/network/Mappers.kt
@@ -36,7 +36,7 @@ private val MSL_INSTRUMENT_ALIASES = mapOf(
  * Mapper functions for converting network models to database entities.
  */
 
-fun List<MarsPhoto>.mapToUi(): List<MarsImage> {
+fun List<MarsPhoto>.mapToUi(roverId: Long): List<MarsImage> {
     return mapIndexed { index, marsPhoto ->
         // It's okay to use not correct data for favorite and popular with Stats,
         // 'cause if these images already in database, we'll ignore replacing them.
@@ -46,6 +46,7 @@ fun List<MarsPhoto>.mapToUi(): List<MarsImage> {
             name = marsPhoto.name,
             imageUrl = marsPhoto.imageUrl,
             earthDate = marsPhoto.earthDate,
+            roverId = roverId,
             camera = marsPhoto.camera,
             favorite = false,
             popular = false,
@@ -57,7 +58,7 @@ fun List<MarsPhoto>.mapToUi(): List<MarsImage> {
     }
 }
 
-fun List<PerseverancePhotoItemResponse>.preveranceToUI(): List<MarsImage> {
+fun List<PerseverancePhotoItemResponse>.preveranceToUI(roverId: Long): List<MarsImage> {
     return mapIndexed { index, response ->
         // It's okay to use not correct data for favorite and popular with Stats,
         // 'cause if these images already in database, we'll ignore replacing them.
@@ -67,6 +68,7 @@ fun List<PerseverancePhotoItemResponse>.preveranceToUI(): List<MarsImage> {
             name = response.name,
             imageUrl = response.imageSourceResponse?.image() ?: "",
             earthDate = response.earthDate ?: "",
+            roverId = roverId,
             camera = response.camera?.toUI(),
             favorite = false,
             popular = false,
@@ -99,7 +101,7 @@ fun PerseveranceCameraResponse.toUI(): RoverCamera {
  * If the item link does not end in `~thumb.jpg` the href is used as-is (no blind replacement).
  * [startIndex] offsets [MarsImage.order] so rows from different pages don't collide on `order`.
  */
-fun NasaImagesSearchResponse.toMarsImages(startIndex: Int = 0): List<MarsImage> =
+fun NasaImagesSearchResponse.toMarsImages(startIndex: Int = 0, roverId: Long = 0L): List<MarsImage> =
     collection.items.mapIndexedNotNull { localIdx, item ->
         val data = item.data.firstOrNull() ?: return@mapIndexedNotNull null
         val thumbHref = item.links
@@ -113,6 +115,7 @@ fun NasaImagesSearchResponse.toMarsImages(startIndex: Int = 0): List<MarsImage> 
             name = data.title,
             imageUrl = smallUrl,
             earthDate = data.dateCreated.orEmpty(),
+            roverId = roverId,
             camera = null,
             favorite = false,
             popular = false,
@@ -129,7 +132,7 @@ fun NasaImagesSearchResponse.toMarsImages(startIndex: Int = 0): List<MarsImage> 
  * which matches Curiosity's CameraSpec.name values so the existing filterByCameras logic works
  * unchanged. The camera [fullName][RoverCamera.fullName] retains the full instrument string.
  */
-fun List<MarsPhoto>.mapToUiMsl(): List<MarsImage> {
+fun List<MarsPhoto>.mapToUiMsl(roverId: Long): List<MarsImage> {
     return mapIndexed { index, marsPhoto ->
         MarsImage(
             id = marsPhoto.id,
@@ -137,6 +140,7 @@ fun List<MarsPhoto>.mapToUiMsl(): List<MarsImage> {
             name = marsPhoto.name,
             imageUrl = marsPhoto.imageUrl,
             earthDate = marsPhoto.earthDate,
+            roverId = roverId,
             camera = marsPhoto.instrument?.let { instrument ->
                 val token = instrument.mslInstrumentToken()
                 val hash = instrument.hashCode()

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/network/Mappers.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/network/Mappers.kt
@@ -99,9 +99,10 @@ fun PerseveranceCameraResponse.toUI(): RoverCamera {
  *
  * Full-res URL is derived from the preview thumbnail: `~thumb.jpg` suffix → `~orig.jpg`.
  * If the item link does not end in `~thumb.jpg` the href is used as-is (no blind replacement).
+ * [roverId] identifies the MER rover that owns the curated library image.
  * [startIndex] offsets [MarsImage.order] so rows from different pages don't collide on `order`.
  */
-fun NasaImagesSearchResponse.toMarsImages(startIndex: Int = 0, roverId: Long = 0L): List<MarsImage> =
+fun NasaImagesSearchResponse.toMarsImages(roverId: Long, startIndex: Int = 0): List<MarsImage> =
     collection.items.mapIndexedNotNull { localIdx, item ->
         val data = item.data.firstOrNull() ?: return@mapIndexedNotNull null
         val thumbHref = item.links

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/network/RestApi.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/network/RestApi.kt
@@ -82,12 +82,12 @@ class RestApi {
             INSIGHT_ID -> {
                 val response = nasaApi.getRawImages("insight", from = "$sol:sol", to = "$sol:sol")
                 response.total?.let { _insightTotalImages.value = it }
-                response.list.mapToUi()
+                response.list.mapToUi(query.roverId)
             }
 
             CURIOSITY_ID -> {
                 nasaApi.getRawImages("msl", from = "$sol:sol", to = "$sol:sol")
-                    .list.mapToUiMsl()
+                    .list.mapToUiMsl(query.roverId)
             }
 
             else -> throw IllegalArgumentException("Unsupported rover id: ${query.roverId}")
@@ -97,15 +97,15 @@ class RestApi {
     private suspend fun loadPerseverance(query: PhotosQueryRequest): List<MarsImage> {
         val response = nasaApi.getPerseveranceRawImages(sol = "${query.sol}:sol:in")
         _perseveranceTotalImages.value = response.totalImages
-        return response.photos.preveranceToUI()
+        return response.photos.preveranceToUI(query.roverId)
     }
 
     suspend fun getInsightLatestPhotos(): List<MarsImage> {
-        return nasaApi.getRawImages("insight").list.mapToUi()
+        return nasaApi.getRawImages("insight").list.mapToUi(INSIGHT_ID)
     }
 
     suspend fun getCuriosityLatestPhotos(): List<MarsImage> {
-        return nasaApi.getRawImages("msl").list.mapToUiMsl()
+        return nasaApi.getRawImages("msl").list.mapToUiMsl(CURIOSITY_ID)
     }
 
     /** Returns the latest Curiosity sol from the MSL raw feed (feed is ordered newest-first). */
@@ -124,6 +124,6 @@ class RestApi {
     suspend fun getPerseveranceLatestPhotos(count: Int = 1): List<MarsImage> {
         val response = nasaApi.getPerseveranceRawImages(count = count)
         _perseveranceTotalImages.value = response.totalImages
-        return response.photos.preveranceToUI()
+        return response.photos.preveranceToUI(PERSEVERANCE_ID)
     }
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/RoverFeedPager.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/RoverFeedPager.kt
@@ -154,7 +154,7 @@ class RoverFeedPager(
                                 )
                                 val startIndex = (page - 1) * ImagesSearchPagingSource.PAGE_SIZE
                                 ImagesSearchPagingSource.PageResult(
-                                    images = response.toMarsImages(startIndex, p.roverId),
+                                    images = response.toMarsImages(roverId = p.roverId, startIndex = startIndex),
                                     totalHits = response.collection.metadata?.totalHits ?: 0,
                                 )
                             },

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/RoverFeedPager.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/data/paging/RoverFeedPager.kt
@@ -154,7 +154,7 @@ class RoverFeedPager(
                                 )
                                 val startIndex = (page - 1) * ImagesSearchPagingSource.PAGE_SIZE
                                 ImagesSearchPagingSource.PageResult(
-                                    images = response.toMarsImages(startIndex),
+                                    images = response.toMarsImages(startIndex, p.roverId),
                                     totalHits = response.collection.metadata?.totalHits ?: 0,
                                 )
                             },

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/domain/models/FirebasePhoto.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/domain/models/FirebasePhoto.kt
@@ -17,7 +17,8 @@ data class FirebasePhoto(
     var scaleCounter: Long,
     var saveCounter: Long,
     var shareCounter: Long,
-    var favoriteCounter: Long
+    var favoriteCounter: Long,
+    val roverId: Long = 0L
 ) {
 
     constructor(photo: MarsImage) : this(
@@ -31,6 +32,7 @@ data class FirebasePhoto(
         saveCounter = 0,
         shareCounter = 0,
         favoriteCounter = 0,
+        roverId = photo.roverId,
     )
 
     /**
@@ -44,6 +46,7 @@ data class FirebasePhoto(
         name = name,
         imageUrl = imageUrl,
         earthDate = earthDate,
+        roverId = roverId,
         camera = null, // Camera info not stored in Firebase
         favorite = false, // Favorite status managed locally
         popular = true,

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/platform/DatabaseBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/platform/DatabaseBuilder.kt
@@ -12,3 +12,15 @@ import com.sirelon.marsroverphotos.data.database.AppDataBase
  * - Web: In-memory or IndexedDB-based builder
  */
 expect fun getDatabaseBuilder(): RoomDatabase.Builder<AppDataBase>
+
+/**
+ * Shared database configuration: migrations and fallback policy.
+ * Called by each platform's [getDatabaseBuilder] so migration registrations live in one place.
+ */
+fun RoomDatabase.Builder<AppDataBase>.configureCommon(): RoomDatabase.Builder<AppDataBase> = this
+    .fallbackToDestructiveMigration(false)
+    .addMigrations(
+        AppDataBase.migration7To8,
+        AppDataBase.migration8To9,
+        AppDataBase.migration9To10,
+    )

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/platform/FirebasePhotosImpl.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/platform/FirebasePhotosImpl.kt
@@ -132,7 +132,8 @@ class FirebasePhotosImpl : IFirebasePhotos {
             "scaleCounter" to photo.scaleCounter,
             "saveCounter" to photo.saveCounter,
             "shareCounter" to photo.shareCounter,
-            "favoriteCounter" to photo.favoriteCounter
+            "favoriteCounter" to photo.favoriteCounter,
+            "roverId" to photo.roverId
         )
         photosCollection().document(photo.id).set(data, merge = true)
     }
@@ -148,5 +149,6 @@ private fun DocumentSnapshot.toFirebasePhoto() = FirebasePhoto(
     scaleCounter = get<Long>("scaleCounter") ?: 0L,
     saveCounter = get<Long>("saveCounter") ?: 0L,
     shareCounter = get<Long>("shareCounter") ?: 0L,
-    favoriteCounter = get<Long>("favoriteCounter") ?: 0L
+    favoriteCounter = get<Long>("favoriteCounter") ?: 0L,
+    roverId = get<Long>("roverId") ?: 0L
 )

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/platform/FirebasePhotosImpl.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/platform/FirebasePhotosImpl.kt
@@ -114,7 +114,11 @@ class FirebasePhotosImpl : IFirebasePhotos {
 
     private suspend fun getOrCreate(image: MarsImage): FirebasePhoto {
         val doc = photosCollection().document(image.id).get()
-        return if (doc.exists) doc.toFirebasePhoto() else image.toFirebasePhoto()
+        return if (doc.exists) {
+            doc.toFirebasePhoto().withBackfilledRoverId(image.roverId)
+        } else {
+            image.toFirebasePhoto()
+        }
     }
 
     override suspend fun deletePhoto(photoId: String) {
@@ -152,3 +156,7 @@ private fun DocumentSnapshot.toFirebasePhoto() = FirebasePhoto(
     favoriteCounter = get<Long>("favoriteCounter") ?: 0L,
     roverId = get<Long>("roverId") ?: 0L
 )
+
+private fun FirebasePhoto.withBackfilledRoverId(roverId: Long): FirebasePhoto {
+    return if (this.roverId == 0L && roverId != 0L) copy(roverId = roverId) else this
+}

--- a/shared/src/commonTest/kotlin/com/sirelon/marsroverphotos/data/network/MslCameraMappingTest.kt
+++ b/shared/src/commonTest/kotlin/com/sirelon/marsroverphotos/data/network/MslCameraMappingTest.kt
@@ -52,7 +52,7 @@ class MslCameraMappingTest {
             fakeMarsPhoto(id = "d", instrument = null),
         )
 
-        val images = photos.mapToUiMsl()
+        val images = photos.mapToUiMsl(roverId = 5L)
 
         assertEquals("MAST", images[0].camera?.name)
         assertEquals("MAST_RIGHT", images[0].camera?.fullName)
@@ -66,7 +66,7 @@ class MslCameraMappingTest {
     fun mapToUiMsl_cameraNameMatchesCuriosityFilter() {
         // Simulate the filterByCameras name-equality check: cam.name.equals(filter, ignoreCase = true)
         val photos = listOf(fakeMarsPhoto(id = "x", instrument = "MAST_RIGHT"))
-        val images = photos.mapToUiMsl()
+        val images = photos.mapToUiMsl(roverId = 5L)
         val cam = images.first().camera!!
 
         assertEquals(true, cam.name.equals("MAST", ignoreCase = true))

--- a/shared/src/commonTest/kotlin/com/sirelon/marsroverphotos/data/network/NasaImageSmallUrlTest.kt
+++ b/shared/src/commonTest/kotlin/com/sirelon/marsroverphotos/data/network/NasaImageSmallUrlTest.kt
@@ -5,6 +5,7 @@ import com.sirelon.marsroverphotos.data.network.models.NasaImagesItem
 import com.sirelon.marsroverphotos.data.network.models.NasaImagesItemData
 import com.sirelon.marsroverphotos.data.network.models.NasaImagesItemLink
 import com.sirelon.marsroverphotos.data.network.models.NasaImagesSearchResponse
+import com.sirelon.marsroverphotos.domain.models.SPIRIT_ID
 import com.sirelon.marsroverphotos.utils.nasaImageOrigUrl
 import com.sirelon.marsroverphotos.utils.nasaImageSmallUrl
 import kotlin.test.Test
@@ -85,7 +86,7 @@ class NasaImageSmallUrlTest {
     fun toMarsImages_storesSmallUrl() {
         val thumbHref = "https://images-assets.nasa.gov/image/PIA05040/PIA05040~thumb.jpg"
         val response = fakeResponse(thumbHref)
-        val images = response.toMarsImages()
+        val images = response.toMarsImages(roverId = SPIRIT_ID)
         assertEquals(1, images.size)
         assertTrue(
             images[0].imageUrl.contains("~small."),
@@ -97,11 +98,18 @@ class NasaImageSmallUrlTest {
     fun toMarsImages_origUrlRecoverable() {
         val thumbHref = "https://images-assets.nasa.gov/image/PIA05040/PIA05040~thumb.jpg"
         val response = fakeResponse(thumbHref)
-        val imageUrl = response.toMarsImages()[0].imageUrl
+        val imageUrl = response.toMarsImages(roverId = SPIRIT_ID)[0].imageUrl
         assertEquals(
             "https://images-assets.nasa.gov/image/PIA05040/PIA05040~orig.jpg",
             nasaImageOrigUrl(imageUrl),
         )
+    }
+
+    @Test
+    fun toMarsImages_storesRoverId() {
+        val response = fakeResponse("https://images-assets.nasa.gov/image/PIA05040/PIA05040~thumb.jpg")
+        val image = response.toMarsImages(roverId = SPIRIT_ID).single()
+        assertEquals(SPIRIT_ID, image.roverId)
     }
 
     // ── helpers ────────────────────────────────────────────────────────────────

--- a/shared/src/desktopMain/kotlin/com/sirelon/marsroverphotos/platform/DatabaseBuilder.desktop.kt
+++ b/shared/src/desktopMain/kotlin/com/sirelon/marsroverphotos/platform/DatabaseBuilder.desktop.kt
@@ -16,6 +16,5 @@ actual fun getDatabaseBuilder(): RoomDatabase.Builder<AppDataBase> {
 
     return Room.databaseBuilder<AppDataBase>(name = dbPath)
         .setDriver(BundledSQLiteDriver())
-        .fallbackToDestructiveMigration(false)
-        .addMigrations(AppDataBase.migration7To8, AppDataBase.migration8To9)
+        .configureCommon()
 }

--- a/shared/src/iosMain/kotlin/com/sirelon/marsroverphotos/platform/DatabaseBuilder.ios.kt
+++ b/shared/src/iosMain/kotlin/com/sirelon/marsroverphotos/platform/DatabaseBuilder.ios.kt
@@ -30,6 +30,5 @@ actual fun getDatabaseBuilder(): RoomDatabase.Builder<AppDataBase> {
         name = dbPath
     )
         .setDriver(NativeSQLiteDriver())
-        .fallbackToDestructiveMigration(false)
-        .addMigrations(AppDataBase.migration7To8, AppDataBase.migration8To9)
+        .configureCommon()
 }


### PR DESCRIPTION
## Summary

- Add `roverId` field to `MarsImage` entity to track which rover each image came from
- Create database migration (9→10) that adds the `roverId` column to the `images` table
- Update all photo mappers to accept and populate the rover ID when converting network responses
- Consolidate repeated migration setup logic across platform-specific database builders into a shared `configureCommon()` function
- Update Firebase photo serialization to store and restore rover ID

## Why

Rover ID tracking enables better image organization, filtering, and source attribution. Consolidating database configuration reduces duplication across Android, iOS, and desktop platforms and makes migration updates easier to maintain going forward.