### PR TITLE
Mission Info redesign: adaptive layout, hero image, timeline, shared bounds

### DIFF
--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -23,6 +23,9 @@ dependencies {
 
     // Compose Desktop
     implementation(compose.desktop.currentOs)
+
+    // Main dispatcher for desktop (Swing event loop)
+    implementation(libs.kotlinx.coroutines.swing)
 }
 
 compose.desktop {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -118,6 +118,7 @@ kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version
 kotlin-test-annotations-common = { module = "org.jetbrains.kotlin:kotlin-test-annotations-common", version.ref = "kotlin" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlin-collections-immutable" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlin-serialization" }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/di/NavigationModule.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/di/NavigationModule.kt
@@ -101,7 +101,15 @@ val navigationModule = module {
                         camera = cameraAbbrev
                     )
                 )
-            }
+            },
+            onBrowsePhotos = {
+                navigator.navigate(
+                    AppDestination.Photos(
+                        roverId = destination.roverId,
+                        camera = null,
+                    )
+                )
+            },
         )
     }
 

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/domain/models/Rover.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/domain/models/Rover.kt
@@ -41,6 +41,8 @@ data class Rover(
     val maxDate: String,
 
     @SerialName(value = "total_photos")
-    val totalPhotos: Int
-)
+    val totalPhotos: Int,
+) {
+    val isActive: Boolean get() = status.equals("active", ignoreCase = true)
+}
 

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/domain/models/mission/RoverMissionFacts.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/domain/models/mission/RoverMissionFacts.kt
@@ -1,10 +1,12 @@
 package com.sirelon.marsroverphotos.domain.models.mission
 
+import androidx.compose.runtime.Immutable
 import kotlinx.serialization.Serializable
 
 /**
  * Data class representing mission facts for a rover stored in Firestore.
  */
+@Immutable
 @Serializable
 data class RoverMissionFacts(
     val roverId: Long = 0,

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppNavigator.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/navigation/AppNavigator.kt
@@ -1,5 +1,6 @@
 package com.sirelon.marsroverphotos.presentation.navigation
 
+import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.runtime.staticCompositionLocalOf
@@ -50,3 +51,7 @@ val LocalAppNavigator = staticCompositionLocalOf<AppNavigator> {
 // sharedPhoto/sharedFavorite without a SharedTransitionLayout (the modifiers no-op when it's null).
 @OptIn(ExperimentalSharedTransitionApi::class)
 val LocalSharedTransitionScope = staticCompositionLocalOf<SharedTransitionScope?> { null }
+
+// Provided by screens that run their own AnimatedContent layout transition (e.g. Mission Info
+// compact ↔ expanded). Null-defaulted so sharedRoverImage/sharedRoverName no-op in previews.
+val LocalMissionLayoutAnimatedVisibilityScope = staticCompositionLocalOf<AnimatedVisibilityScope?> { null }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/MissionInfoExpandedLayout.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/MissionInfoExpandedLayout.kt
@@ -71,6 +71,7 @@ internal fun ExpandedLayout(
                     rover = state.rover,
                     aspectRatio = 4f / 3f,
                     modifier = Modifier
+                        .fillMaxWidth()
                         .sharedRoverImage(state.rover.id)
                         .clip(MaterialTheme.shapes.large),
                 )
@@ -83,7 +84,7 @@ internal fun ExpandedLayout(
                     earthDaysActive = state.earthDaysActive,
                 )
             }
-            state.missionFacts?.funFacts?.firstOrNull()?.let { fact ->
+            state.missionFacts?.funFacts?.randomOrNull()?.let { fact ->
                 item { FunFact(text = fact, modifier = Modifier.sharedRoverFunFact(state.rover.id)) }
             }
         }
@@ -128,12 +129,12 @@ internal fun ExpandedLayout(
 // ── Left panel composables ────────────────────────────────────────────────────
 
 @Composable
-private fun RoverIdentity(state: MissionInfoState) {
+private fun RoverIdentity(state: MissionInfoState, modifier: Modifier = Modifier) {
     val baseStyle = MaterialTheme.typography.headlineMedium
     val nameStyle = remember(baseStyle) {
         baseStyle.copy(fontWeight = FontWeight.ExtraBold, letterSpacing = (-0.8).sp)
     }
-    Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
         Text(
             text = state.rover.name,
             style = nameStyle,
@@ -148,7 +149,7 @@ private fun RoverIdentity(state: MissionInfoState) {
 }
 
 @Composable
-private fun StatsListTable(totalPhotos: Int, daysActive: Long, earthDaysActive: Long) {
+private fun StatsListTable(totalPhotos: Int, daysActive: Long, earthDaysActive: Long, modifier: Modifier = Modifier) {
     val rows = remember(totalPhotos, daysActive, earthDaysActive) {
         listOf(
             "Total Photos" to formatThousands(totalPhotos),
@@ -156,7 +157,7 @@ private fun StatsListTable(totalPhotos: Int, daysActive: Long, earthDaysActive: 
             "Earth Days"   to formatThousands(earthDaysActive),
         )
     }
-    AppOutlinedCard {
+    AppOutlinedCard(modifier = modifier) {
         rows.forEachIndexed { i, (label, value) ->
             Row(
                 modifier = Modifier
@@ -184,12 +185,12 @@ private fun StatsListTable(totalPhotos: Int, daysActive: Long, earthDaysActive: 
 // ── Right panel composables ───────────────────────────────────────────────────
 
 @Composable
-private fun ExpeditionLogHeader() {
+private fun ExpeditionLogHeader(modifier: Modifier = Modifier) {
     val baseStyle = MaterialTheme.typography.headlineSmall
     val titleStyle = remember(baseStyle) {
         baseStyle.copy(fontWeight = FontWeight.ExtraBold, letterSpacing = (-0.5).sp)
     }
-    Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.xs)) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(AppSpacing.xs)) {
         SectionLabel("Expedition Log")
         Text(
             text = "Mission Overview",
@@ -200,8 +201,8 @@ private fun ExpeditionLogHeader() {
 }
 
 @Composable
-private fun DesktopLogSection(title: String, content: @Composable () -> Unit) {
-    Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.lg)) {
+private fun DesktopLogSection(title: String, modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(AppSpacing.lg)) {
         Text(text = title, style = AppTypography.sectionHeader, color = MaterialTheme.colorScheme.tertiary)
         HorizontalDivider()
         content()
@@ -209,14 +210,14 @@ private fun DesktopLogSection(title: String, content: @Composable () -> Unit) {
 }
 
 @Composable
-private fun DesktopTimeline(milestones: ImmutableList<TimelineMilestone>, status: String) {
+private fun DesktopTimeline(milestones: ImmutableList<TimelineMilestone>, status: String, modifier: Modifier = Modifier) {
     val activeDotColor   = MaterialTheme.colorScheme.secondary
     val inactiveDotColor = MaterialTheme.colorScheme.secondaryContainer
     val activeIconTint   = MaterialTheme.colorScheme.onSecondary
     val inactiveIconTint = MaterialTheme.colorScheme.onSecondaryContainer
     val connectorColor   = MaterialTheme.colorScheme.outlineVariant
 
-    Column {
+    Column(modifier = modifier) {
         milestones.forEachIndexed { i, milestone ->
             val isCurrent = milestone.type == MilestoneType.CURRENT || milestone.type == MilestoneType.END
             val isLast = i == milestones.size - 1

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/MissionInfoExpandedLayout.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/MissionInfoExpandedLayout.kt
@@ -37,6 +37,12 @@ import com.sirelon.marsroverphotos.presentation.ui.BadgeRow
 import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbol
 import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbolIcon
 import com.sirelon.marsroverphotos.presentation.ui.StatusBadge
+import com.sirelon.marsroverphotos.presentation.ui.sharedRoverBadge
+import com.sirelon.marsroverphotos.presentation.ui.sharedRoverCameras
+import com.sirelon.marsroverphotos.presentation.ui.sharedRoverFunFact
+import com.sirelon.marsroverphotos.presentation.ui.sharedRoverImage
+import com.sirelon.marsroverphotos.presentation.ui.sharedRoverName
+import com.sirelon.marsroverphotos.presentation.ui.sharedRoverObjectives
 import com.sirelon.marsroverphotos.presentation.viewmodels.MilestoneType
 import com.sirelon.marsroverphotos.presentation.viewmodels.MissionInfoState
 import com.sirelon.marsroverphotos.presentation.viewmodels.TimelineMilestone
@@ -64,7 +70,9 @@ internal fun ExpandedLayout(
                 RoverImageCard(
                     rover = state.rover,
                     aspectRatio = 4f / 3f,
-                    modifier = Modifier.clip(MaterialTheme.shapes.large),
+                    modifier = Modifier
+                        .sharedRoverImage(state.rover.id)
+                        .clip(MaterialTheme.shapes.large),
                 )
             }
             item { RoverIdentity(state) }
@@ -76,7 +84,7 @@ internal fun ExpandedLayout(
                 )
             }
             state.missionFacts?.funFacts?.firstOrNull()?.let { fact ->
-                item { FunFact(text = fact) }
+                item { FunFact(text = fact, modifier = Modifier.sharedRoverFunFact(state.rover.id)) }
             }
         }
 
@@ -102,14 +110,14 @@ internal fun ExpandedLayout(
             if (state.missionFacts?.objectives?.isNotEmpty() == true) {
                 item {
                     DesktopLogSection("Mission Objectives") {
-                        V1Objectives(objectives = state.missionFacts.objectives)
+                        V1Objectives(objectives = state.missionFacts.objectives, modifier = Modifier.sharedRoverObjectives(state.rover.id))
                     }
                 }
             }
             if (state.cameras.isNotEmpty()) {
                 item {
                     DesktopLogSection("Cameras & Instruments") {
-                        CamerasGrid(cameras = state.cameras, onCameraClick = onCameraClick)
+                        CamerasGrid(cameras = state.cameras, onCameraClick = onCameraClick, modifier = Modifier.sharedRoverCameras(state.rover.id))
                     }
                 }
             }
@@ -130,8 +138,9 @@ private fun RoverIdentity(state: MissionInfoState) {
             text = state.rover.name,
             style = nameStyle,
             color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.sharedRoverName(state.rover.id),
         )
-        BadgeRow {
+        BadgeRow(modifier = Modifier.sharedRoverBadge(state.rover.id)) {
             if (state.rover.isActive) StatusBadge("Active", activeStatusColor())
             else AppBadge(state.rover.status.replaceFirstChar { it.uppercaseChar() })
         }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/MissionInfoExpandedLayout.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/MissionInfoExpandedLayout.kt
@@ -1,0 +1,274 @@
+package com.sirelon.marsroverphotos.presentation.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import com.sirelon.marsroverphotos.presentation.theme.AppSize
+import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
+import com.sirelon.marsroverphotos.presentation.theme.AppTypography
+import com.sirelon.marsroverphotos.presentation.theme.activeStatusColor
+import com.sirelon.marsroverphotos.presentation.ui.AppBadge
+import com.sirelon.marsroverphotos.presentation.ui.AppOutlinedCard
+import com.sirelon.marsroverphotos.presentation.ui.BadgeRow
+import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbol
+import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbolIcon
+import com.sirelon.marsroverphotos.presentation.ui.StatusBadge
+import com.sirelon.marsroverphotos.presentation.viewmodels.MilestoneType
+import com.sirelon.marsroverphotos.presentation.viewmodels.MissionInfoState
+import com.sirelon.marsroverphotos.presentation.viewmodels.TimelineMilestone
+import com.sirelon.marsroverphotos.utils.formatThousands
+import kotlinx.collections.immutable.ImmutableList
+
+// ── Expanded 2-panel layout ───────────────────────────────────────────────────
+
+@Composable
+internal fun ExpandedLayout(
+    state: MissionInfoState,
+    onCameraClick: (String) -> Unit,
+    onBrowsePhotos: () -> Unit,
+) {
+    Row(modifier = Modifier.fillMaxSize()) {
+        // ── Left panel — rover portrait + identity + stats + fun fact ──────
+        LazyColumn(
+            modifier = Modifier
+                .weight(0.38f)
+                .fillMaxHeight(),
+            contentPadding = PaddingValues(AppSpacing.xl),
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.xl),
+        ) {
+            item {
+                RoverImageCard(
+                    rover = state.rover,
+                    aspectRatio = 4f / 3f,
+                    modifier = Modifier.clip(MaterialTheme.shapes.large),
+                )
+            }
+            item { RoverIdentity(state) }
+            item {
+                StatsListTable(
+                    totalPhotos = state.rover.totalPhotos,
+                    daysActive = state.daysActive,
+                    earthDaysActive = state.earthDaysActive,
+                )
+            }
+            state.missionFacts?.funFacts?.firstOrNull()?.let { fact ->
+                item { FunFact(text = fact) }
+            }
+        }
+
+        VerticalDivider()
+
+        // ── Right panel — expedition log ───────────────────────────────────
+        LazyColumn(
+            modifier = Modifier
+                .weight(0.62f)
+                .fillMaxHeight(),
+            contentPadding = PaddingValues(
+                horizontal = AppSpacing.x3l,
+                vertical = AppSpacing.xxl,
+            ),
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.xxl),
+        ) {
+            item { ExpeditionLogHeader() }
+            item {
+                DesktopLogSection("Mission Timeline") {
+                    DesktopTimeline(milestones = state.timelineMilestones, status = state.rover.status)
+                }
+            }
+            if (state.missionFacts?.objectives?.isNotEmpty() == true) {
+                item {
+                    DesktopLogSection("Mission Objectives") {
+                        V1Objectives(objectives = state.missionFacts.objectives)
+                    }
+                }
+            }
+            if (state.cameras.isNotEmpty()) {
+                item {
+                    DesktopLogSection("Cameras & Instruments") {
+                        CamerasGrid(cameras = state.cameras, onCameraClick = onCameraClick)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── Left panel composables ────────────────────────────────────────────────────
+
+@Composable
+private fun RoverIdentity(state: MissionInfoState) {
+    val baseStyle = MaterialTheme.typography.headlineMedium
+    val nameStyle = remember(baseStyle) {
+        baseStyle.copy(fontWeight = FontWeight.ExtraBold, letterSpacing = (-0.8).sp)
+    }
+    Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
+        Text(
+            text = state.rover.name,
+            style = nameStyle,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        BadgeRow {
+            if (state.rover.isActive) StatusBadge("Active", activeStatusColor())
+            else AppBadge(state.rover.status.replaceFirstChar { it.uppercaseChar() })
+        }
+    }
+}
+
+@Composable
+private fun StatsListTable(totalPhotos: Int, daysActive: Long, earthDaysActive: Long) {
+    val rows = remember(totalPhotos, daysActive, earthDaysActive) {
+        listOf(
+            "Total Photos" to formatThousands(totalPhotos),
+            "Sols on Mars" to formatThousands(daysActive),
+            "Earth Days"   to formatThousands(earthDaysActive),
+        )
+    }
+    AppOutlinedCard {
+        rows.forEachIndexed { i, (label, value) ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = AppSpacing.lg, vertical = AppSpacing.md),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = label,
+                    style = AppTypography.bodySecondary,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = value,
+                    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+            if (i < rows.size - 1) HorizontalDivider()
+        }
+    }
+}
+
+// ── Right panel composables ───────────────────────────────────────────────────
+
+@Composable
+private fun ExpeditionLogHeader() {
+    val baseStyle = MaterialTheme.typography.headlineSmall
+    val titleStyle = remember(baseStyle) {
+        baseStyle.copy(fontWeight = FontWeight.ExtraBold, letterSpacing = (-0.5).sp)
+    }
+    Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.xs)) {
+        SectionLabel("Expedition Log")
+        Text(
+            text = "Mission Overview",
+            style = titleStyle,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+@Composable
+private fun DesktopLogSection(title: String, content: @Composable () -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.lg)) {
+        Text(text = title, style = AppTypography.sectionHeader, color = MaterialTheme.colorScheme.tertiary)
+        HorizontalDivider()
+        content()
+    }
+}
+
+@Composable
+private fun DesktopTimeline(milestones: ImmutableList<TimelineMilestone>, status: String) {
+    val activeDotColor   = MaterialTheme.colorScheme.secondary
+    val inactiveDotColor = MaterialTheme.colorScheme.secondaryContainer
+    val activeIconTint   = MaterialTheme.colorScheme.onSecondary
+    val inactiveIconTint = MaterialTheme.colorScheme.onSecondaryContainer
+    val connectorColor   = MaterialTheme.colorScheme.outlineVariant
+
+    Column {
+        milestones.forEachIndexed { i, milestone ->
+            val isCurrent = milestone.type == MilestoneType.CURRENT || milestone.type == MilestoneType.END
+            val isLast = i == milestones.size - 1
+            val dotColor = if (isCurrent) activeDotColor  else inactiveDotColor
+            val iconTint = if (isCurrent) activeIconTint  else inactiveIconTint
+
+            Row {
+                Column(
+                    modifier = Modifier.width(AppSpacing.xxl),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(AppSpacing.xl)
+                            .clip(CircleShape)
+                            .background(dotColor),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        val iconSymbol = when (milestone.type) {
+                            MilestoneType.LAUNCH  -> MaterialSymbol.Rocket
+                            MilestoneType.LANDING -> MaterialSymbol.FlightLand
+                            MilestoneType.CURRENT -> MaterialSymbol.Star
+                            MilestoneType.END     -> MaterialSymbol.Flag
+                        }
+                        MaterialSymbolIcon(
+                            symbol = iconSymbol,
+                            contentDescription = null,
+                            tint = iconTint,
+                            size = AppSize.iconInline,
+                        )
+                    }
+                    if (!isLast) {
+                        Box(
+                            modifier = Modifier
+                                .width(AppSize.hairline * 2)
+                                .height(AppSpacing.x3l)
+                                .background(connectorColor)
+                        )
+                    }
+                }
+                Spacer(Modifier.width(AppSpacing.lg))
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(bottom = if (!isLast) AppSpacing.xl else AppSpacing.xs),
+                ) {
+                    SectionLabel(milestone.label)
+                    Text(
+                        text = milestone.date,
+                        style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold),
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    milestone.sol?.let {
+                        Text(
+                            text = "Sol $it",
+                            style = AppTypography.bodySecondary,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/MissionInfoSections.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/MissionInfoSections.kt
@@ -65,6 +65,12 @@ import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbol
 import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbolIcon
 import com.sirelon.marsroverphotos.presentation.ui.StatusBadge
 import com.sirelon.marsroverphotos.presentation.ui.painter
+import com.sirelon.marsroverphotos.presentation.ui.sharedRoverBadge
+import com.sirelon.marsroverphotos.presentation.ui.sharedRoverCameras
+import com.sirelon.marsroverphotos.presentation.ui.sharedRoverFunFact
+import com.sirelon.marsroverphotos.presentation.ui.sharedRoverImage
+import com.sirelon.marsroverphotos.presentation.ui.sharedRoverName
+import com.sirelon.marsroverphotos.presentation.ui.sharedRoverObjectives
 import com.sirelon.marsroverphotos.presentation.viewmodels.MilestoneType
 import com.sirelon.marsroverphotos.presentation.viewmodels.MissionInfoState
 import com.sirelon.marsroverphotos.presentation.viewmodels.TimelineMilestone
@@ -133,7 +139,7 @@ internal fun MissionInfoContent(
                 ) {
                     SectionHeader("Cameras & Instruments")
                     if (isMediumPlus) {
-                        CamerasGrid(cameras = state.cameras, onCameraClick = onCameraClick)
+                        CamerasGrid(cameras = state.cameras, onCameraClick = onCameraClick, modifier = Modifier.sharedRoverCameras(state.rover.id))
                     } else {
                         V1CamerasAccordion(cameras = state.cameras, onCameraClick = onCameraClick)
                     }
@@ -167,6 +173,7 @@ internal fun MissionInfoContent(
                             V1Objectives(
                                 objectives = state.missionFacts.objectives,
                                 twoCol = isMediumPlus,
+                                modifier = Modifier.sharedRoverObjectives(state.rover.id),
                             )
                         }
                     }
@@ -181,7 +188,7 @@ internal fun MissionInfoContent(
                             verticalArrangement = Arrangement.spacedBy(AppSpacing.sm),
                         ) {
                             SectionHeader("Did You Know?")
-                            FunFact(text = fact)
+                            FunFact(text = fact, modifier = Modifier.sharedRoverFunFact(state.rover.id))
                         }
                     }
                 }
@@ -239,7 +246,11 @@ private fun MissionHeroSection(rover: Rover, onBack: (() -> Unit)?) {
         )
     }
     Box(modifier = Modifier.fillMaxWidth()) {
-        RoverImageCard(rover = rover, aspectRatio = 16f / 9f)
+        RoverImageCard(
+            rover = rover,
+            aspectRatio = 16f / 9f,
+            modifier = Modifier.sharedRoverImage(rover.id),
+        )
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -275,8 +286,9 @@ private fun MissionHeroSection(rover: Rover, onBack: (() -> Unit)?) {
                 color = Color.White,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.sharedRoverName(rover.id),
             )
-            BadgeRow {
+            BadgeRow(modifier = Modifier.sharedRoverBadge(rover.id)) {
                 if (rover.isActive) StatusBadge("Active", activeStatusColor())
                 else AppBadge(rover.status.replaceFirstChar { it.uppercaseChar() })
             }
@@ -395,9 +407,9 @@ private fun StatCard(label: String, value: String, modifier: Modifier = Modifier
 // ── Objectives ────────────────────────────────────────────────────────────────
 
 @Composable
-internal fun V1Objectives(objectives: List<String>, twoCol: Boolean = false) {
+internal fun V1Objectives(objectives: List<String>, twoCol: Boolean = false, modifier: Modifier = Modifier) {
     if (twoCol) {
-        Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
+        Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
             objectives.chunked(2).forEach { pair ->
                 Row(horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
                     pair.forEach { obj ->
@@ -408,7 +420,7 @@ internal fun V1Objectives(objectives: List<String>, twoCol: Boolean = false) {
             }
         }
     } else {
-        Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
+        Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
             objectives.forEachIndexed { i, obj -> ObjectiveRow(index = i, text = obj) }
         }
     }
@@ -534,8 +546,9 @@ private fun V1CamerasAccordion(
 internal fun CamerasGrid(
     cameras: ImmutableList<CameraSpec>,
     onCameraClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    AppOutlinedCard {
+    AppOutlinedCard(modifier = modifier) {
         Row(
             modifier = Modifier.padding(AppSpacing.lg),
             verticalAlignment = Alignment.CenterVertically,

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/MissionInfoSections.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/MissionInfoSections.kt
@@ -1,0 +1,689 @@
+package com.sirelon.marsroverphotos.presentation.screens
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.sp
+import com.sirelon.marsroverphotos.domain.models.Rover
+import com.sirelon.marsroverphotos.domain.models.mission.CameraSpec
+import com.sirelon.marsroverphotos.presentation.theme.AppSize
+import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
+import com.sirelon.marsroverphotos.presentation.theme.AppTypography
+import com.sirelon.marsroverphotos.presentation.theme.activeStatusColor
+import com.sirelon.marsroverphotos.presentation.ui.AppBadge
+import com.sirelon.marsroverphotos.presentation.ui.AppButton
+import com.sirelon.marsroverphotos.presentation.ui.AppCard
+import com.sirelon.marsroverphotos.presentation.ui.AppFactCard
+import com.sirelon.marsroverphotos.presentation.ui.AppIconBox
+import com.sirelon.marsroverphotos.presentation.ui.AppOutlinedCard
+import com.sirelon.marsroverphotos.presentation.ui.BadgeRow
+import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbol
+import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbolIcon
+import com.sirelon.marsroverphotos.presentation.ui.StatusBadge
+import com.sirelon.marsroverphotos.presentation.ui.painter
+import com.sirelon.marsroverphotos.presentation.viewmodels.MilestoneType
+import com.sirelon.marsroverphotos.presentation.viewmodels.MissionInfoState
+import com.sirelon.marsroverphotos.presentation.viewmodels.TimelineMilestone
+import com.sirelon.marsroverphotos.utils.formatThousands
+import kotlinx.collections.immutable.ImmutableList
+
+// ── Single-column content (compact + medium) ──────────────────────────────────
+
+@Composable
+internal fun MissionInfoContent(
+    state: MissionInfoState,
+    isMediumPlus: Boolean,
+    onCameraClick: (String) -> Unit,
+    onBrowsePhotos: () -> Unit,
+    onBack: (() -> Unit)?,
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(bottom = AppSpacing.x3l),
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.xl),
+    ) {
+        // Full-bleed hero — no horizontal padding
+        item {
+            MissionHeroSection(rover = state.rover, onBack = onBack)
+        }
+
+        item {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = AppSpacing.lg),
+                verticalArrangement = Arrangement.spacedBy(AppSpacing.xl),
+            ) {
+                SectionHeader("Mission Timeline")
+                V1Timeline(
+                    milestones = state.timelineMilestones,
+                    status = state.rover.status,
+                    fillWidth = isMediumPlus,
+                )
+            }
+        }
+
+        item {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = AppSpacing.lg),
+                verticalArrangement = Arrangement.spacedBy(AppSpacing.sm),
+            ) {
+                SectionHeader("Statistics")
+                V1Stats(
+                    totalPhotos = state.rover.totalPhotos,
+                    daysActive = state.daysActive,
+                    earthDaysActive = state.earthDaysActive,
+                )
+            }
+        }
+
+        if (state.cameras.isNotEmpty()) {
+            item {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = AppSpacing.lg),
+                    verticalArrangement = Arrangement.spacedBy(AppSpacing.sm),
+                ) {
+                    SectionHeader("Cameras & Instruments")
+                    if (isMediumPlus) {
+                        CamerasGrid(cameras = state.cameras, onCameraClick = onCameraClick)
+                    } else {
+                        V1CamerasAccordion(cameras = state.cameras, onCameraClick = onCameraClick)
+                    }
+                }
+            }
+        }
+
+        when {
+            state.factsLoading -> item {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = AppSpacing.lg),
+                ) {
+                    SectionHeader("Mission Info")
+                    Spacer(Modifier.height(AppSpacing.sm))
+                    LinearProgressIndicator(Modifier.fillMaxWidth())
+                }
+            }
+
+            state.missionFacts != null -> {
+                if (state.missionFacts.objectives.isNotEmpty()) {
+                    item {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = AppSpacing.lg),
+                            verticalArrangement = Arrangement.spacedBy(AppSpacing.sm),
+                        ) {
+                            SectionHeader("Mission Objectives")
+                            V1Objectives(
+                                objectives = state.missionFacts.objectives,
+                                twoCol = isMediumPlus,
+                            )
+                        }
+                    }
+                }
+
+                state.missionFacts.funFacts.firstOrNull()?.let { fact ->
+                    item {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = AppSpacing.lg),
+                            verticalArrangement = Arrangement.spacedBy(AppSpacing.sm),
+                        ) {
+                            SectionHeader("Did You Know?")
+                            FunFact(text = fact)
+                        }
+                    }
+                }
+            }
+        }
+
+        // Browse Photos CTA — compact only (medium+ has it in the top bar)
+        if (!isMediumPlus) {
+            item {
+                BrowsePhotosButton(
+                    onClick = onBrowsePhotos,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = AppSpacing.lg),
+                )
+            }
+        }
+    }
+}
+
+// ── Hero ──────────────────────────────────────────────────────────────────────
+
+// ── Shared rover image with gradient ─────────────────────────────────────────
+
+@Composable
+internal fun RoverImageCard(
+    rover: Rover,
+    aspectRatio: Float,
+    modifier: Modifier = Modifier,
+) {
+    val bgColor = MaterialTheme.colorScheme.background
+    val gradient = remember(bgColor) {
+        Brush.verticalGradient(
+            0.45f to Color.Transparent,
+            1f to bgColor.copy(alpha = 0.96f),
+        )
+    }
+    Box(modifier = modifier.fillMaxWidth().aspectRatio(aspectRatio)) {
+        Image(
+            painter = rover.painter(),
+            contentDescription = rover.name,
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Crop,
+        )
+        Box(modifier = Modifier.fillMaxSize().background(gradient))
+    }
+}
+
+@Composable
+private fun MissionHeroSection(rover: Rover, onBack: (() -> Unit)?) {
+    val topGradient = remember {
+        Brush.verticalGradient(
+            0f to Color.Black.copy(alpha = 0.52f),
+            0.4f to Color.Transparent,
+        )
+    }
+    Box(modifier = Modifier.fillMaxWidth()) {
+        RoverImageCard(rover = rover, aspectRatio = 16f / 9f)
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(16f / 9f)
+                .background(topGradient),
+        )
+        if (onBack != null) {
+            IconButton(
+                onClick = onBack,
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .statusBarsPadding()
+                    .padding(AppSpacing.lg)
+                    .background(Color.Black.copy(alpha = 0.42f), CircleShape),
+            ) {
+                MaterialSymbolIcon(
+                    symbol = MaterialSymbol.ArrowBack,
+                    contentDescription = "Back",
+                    tint = Color.White,
+                    size = AppSize.iconDefault,
+                )
+            }
+        }
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(start = AppSpacing.xl, end = AppSpacing.xl, bottom = AppSpacing.xl),
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.sm),
+        ) {
+            Text(
+                text = rover.name,
+                style = MaterialTheme.typography.displaySmall.copy(fontWeight = FontWeight.ExtraBold),
+                color = Color.White,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            BadgeRow {
+                if (rover.isActive) StatusBadge("Active", activeStatusColor())
+                else AppBadge(rover.status.replaceFirstChar { it.uppercaseChar() })
+            }
+        }
+    }
+}
+
+// ── Timeline ──────────────────────────────────────────────────────────────────
+
+@Composable
+private fun V1Timeline(
+    milestones: ImmutableList<TimelineMilestone>,
+    status: String,
+    fillWidth: Boolean,
+) {
+    @Composable
+    fun connector(rowScope: androidx.compose.foundation.layout.RowScope) = with(rowScope) {
+        Box(
+            modifier = Modifier
+                .align(Alignment.CenterVertically)
+                .height(AppSize.hairline * 2)
+                .run { if (fillWidth) weight(0.25f) else width(AppSpacing.lg) }
+                .background(MaterialTheme.colorScheme.outlineVariant)
+        )
+    }
+
+    if (fillWidth) {
+        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.Top) {
+            milestones.forEachIndexed { i, milestone ->
+                TimelineCard(milestone = milestone, modifier = Modifier.weight(1f))
+                if (i < milestones.size - 1) connector(this)
+            }
+        }
+    } else {
+        Row(
+            modifier = Modifier.horizontalScroll(rememberScrollState()),
+            verticalAlignment = Alignment.Top,
+        ) {
+            milestones.forEachIndexed { i, milestone ->
+                TimelineCard(milestone = milestone)
+                if (i < milestones.size - 1) connector(this)
+            }
+        }
+    }
+}
+
+@Composable
+private fun TimelineCard(milestone: TimelineMilestone, modifier: Modifier = Modifier) {
+    val iconSymbol = when (milestone.type) {
+        MilestoneType.LAUNCH  -> MaterialSymbol.Rocket
+        MilestoneType.LANDING -> MaterialSymbol.FlightLand
+        MilestoneType.CURRENT -> MaterialSymbol.Star
+        MilestoneType.END     -> MaterialSymbol.Flag
+    }
+    AppCard(modifier = modifier) {
+        Column(modifier = Modifier.padding(AppSpacing.lg)) {
+            AppIconBox(
+                symbol = iconSymbol,
+                container = MaterialTheme.colorScheme.secondaryContainer,
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            Spacer(Modifier.height(AppSpacing.sm))
+            SectionLabel(milestone.label)
+            Text(
+                text = milestone.date,
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            milestone.sol?.let {
+                Text(
+                    text = "Sol $it",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+// ── Statistics ────────────────────────────────────────────────────────────────
+
+@Composable
+private fun V1Stats(totalPhotos: Int, daysActive: Long, earthDaysActive: Long) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
+    ) {
+        StatCard(label = "Total Photos", value = formatThousands(totalPhotos), modifier = Modifier.weight(1f))
+        StatCard(label = "Sols on Mars", value = formatThousands(daysActive),  modifier = Modifier.weight(1f))
+        StatCard(label = "Earth Days",   value = formatThousands(earthDaysActive), modifier = Modifier.weight(1f))
+    }
+}
+
+@Composable
+private fun StatCard(label: String, value: String, modifier: Modifier = Modifier) {
+    AppCard(modifier = modifier) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(AppSpacing.md),
+            horizontalAlignment = Alignment.Start,
+        ) {
+            SectionLabel(label)
+            Text(
+                text = value,
+                style = MaterialTheme.typography.titleLarge.copy(
+                    fontWeight = FontWeight.Bold,
+                    letterSpacing = (-0.3).sp,
+                ),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+    }
+}
+
+// ── Objectives ────────────────────────────────────────────────────────────────
+
+@Composable
+internal fun V1Objectives(objectives: List<String>, twoCol: Boolean = false) {
+    if (twoCol) {
+        Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
+            objectives.chunked(2).forEach { pair ->
+                Row(horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
+                    pair.forEach { obj ->
+                        ObjectiveCard(index = objectives.indexOf(obj), text = obj, modifier = Modifier.weight(1f))
+                    }
+                    if (pair.size == 1) Spacer(Modifier.weight(1f))
+                }
+            }
+        }
+    } else {
+        Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
+            objectives.forEachIndexed { i, obj -> ObjectiveRow(index = i, text = obj) }
+        }
+    }
+}
+
+@Composable
+private fun ObjectiveRow(index: Int, text: String) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.md),
+        verticalAlignment = Alignment.Top,
+    ) {
+        NumberCircle(number = index + 1)
+        Text(
+            text = text,
+            style = AppTypography.bodySecondary,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+private fun ObjectiveCard(index: Int, text: String, modifier: Modifier = Modifier) {
+    AppCard(modifier = modifier) {
+        Row(
+            modifier = Modifier.padding(AppSpacing.md),
+            horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
+            verticalAlignment = Alignment.Top,
+        ) {
+            NumberCircle(number = index + 1)
+            Text(
+                text = text,
+                style = AppTypography.bodySecondary,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun NumberCircle(number: Int) {
+    Box(
+        modifier = Modifier
+            .size(AppSpacing.xl + AppSpacing.xs)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.secondaryContainer),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "$number",
+            style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
+            color = MaterialTheme.colorScheme.secondary,
+        )
+    }
+}
+
+// ── Cameras ───────────────────────────────────────────────────────────────────
+
+@Composable
+private fun V1CamerasAccordion(
+    cameras: ImmutableList<CameraSpec>,
+    onCameraClick: (String) -> Unit,
+) {
+    var expanded by rememberSaveable { mutableStateOf(false) }
+    val arrowRotation by animateFloatAsState(
+        targetValue = if (expanded) 180f else 0f,
+        label = "accordionArrow",
+    )
+
+    AppOutlinedCard {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { expanded = !expanded }
+                .padding(AppSpacing.lg),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(AppSpacing.md),
+        ) {
+            AppIconBox(
+                symbol = MaterialSymbol.CameraAlt,
+                container = MaterialTheme.colorScheme.secondaryContainer,
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Cameras",
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = "${cameras.size} instruments aboard",
+                    style = AppTypography.bodySecondary,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            MaterialSymbolIcon(
+                symbol = MaterialSymbol.ExpandMore,
+                contentDescription = if (expanded) "Collapse" else "Expand",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.rotate(arrowRotation),
+            )
+        }
+
+        AnimatedVisibility(
+            visible = expanded,
+            enter = expandVertically(),
+            exit = shrinkVertically(),
+        ) {
+            Column(modifier = Modifier.padding(AppSpacing.sm)) {
+                HorizontalDivider(modifier = Modifier.padding(horizontal = AppSpacing.sm))
+                Spacer(Modifier.height(AppSpacing.sm))
+                cameras.forEach { camera ->
+                    CameraItemCard(camera = camera, onClick = { onCameraClick(camera.name) })
+                    Spacer(Modifier.height(AppSpacing.sm))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+internal fun CamerasGrid(
+    cameras: ImmutableList<CameraSpec>,
+    onCameraClick: (String) -> Unit,
+) {
+    AppOutlinedCard {
+        Row(
+            modifier = Modifier.padding(AppSpacing.lg),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(AppSpacing.md),
+        ) {
+            AppIconBox(
+                symbol = MaterialSymbol.CameraAlt,
+                container = MaterialTheme.colorScheme.secondaryContainer,
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            Column {
+                Text(
+                    text = "Cameras & Instruments",
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = "${cameras.size} cameras aboard",
+                    style = AppTypography.bodySecondary,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        HorizontalDivider()
+        cameras.chunked(2).forEach { pair ->
+            Row {
+                pair.forEachIndexed { colIdx, camera ->
+                    CameraItemCard(
+                        camera = camera,
+                        onClick = { onCameraClick(camera.name) },
+                        modifier = Modifier.weight(1f),
+                    )
+                    if (colIdx == 0 && pair.size == 2) {
+                        VerticalDivider(modifier = Modifier.height(AppSize.cardRadius * 8))
+                    }
+                }
+                if (pair.size == 1) Spacer(Modifier.weight(1f))
+            }
+            HorizontalDivider()
+        }
+    }
+}
+
+@Composable
+private fun CameraItemCard(
+    camera: CameraSpec,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .clickable(onClick = onClick)
+            .padding(AppSpacing.lg),
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.xs),
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = camera.name,
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = camera.fullName,
+                style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.SemiBold),
+                color = MaterialTheme.colorScheme.secondary,
+                modifier = Modifier
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.secondaryContainer)
+                    .padding(horizontal = AppSpacing.sm, vertical = AppSpacing.xs),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        Text(
+            text = camera.description,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+// ── Fun Fact ──────────────────────────────────────────────────────────────────
+
+@Composable
+internal fun FunFact(text: String, modifier: Modifier = Modifier) {
+    AppFactCard(modifier = modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(AppSpacing.xl)) {
+            SectionLabel("✨  Did You Know?")
+            Spacer(Modifier.height(AppSpacing.sm))
+            Text(
+                text = text,
+                style = AppTypography.body,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+        }
+    }
+}
+
+// ── Browse Photos CTA ─────────────────────────────────────────────────────────
+
+@Composable
+private fun BrowsePhotosButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
+    AppButton(
+        onClick = onClick,
+        modifier = modifier,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.secondary,
+            contentColor = MaterialTheme.colorScheme.onSecondary,
+        ),
+    ) {
+        MaterialSymbolIcon(
+            symbol = MaterialSymbol.CameraAlt,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSecondary,
+            size = AppSize.iconInline,
+        )
+        Spacer(Modifier.width(AppSpacing.sm))
+        Text(
+            text = "Browse Photos",
+            style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Bold),
+        )
+    }
+}
+
+// ── Shared screen-level helpers ───────────────────────────────────────────────
+
+/** Small uppercase accent label used inside cards (stat labels, timeline type, etc.). */
+@Composable
+internal fun SectionLabel(text: String) {
+    Text(
+        text = text.uppercase(),
+        style = MaterialTheme.typography.labelSmall.copy(
+            fontWeight = FontWeight.Bold,
+            letterSpacing = 1.1.sp,
+        ),
+        color = MaterialTheme.colorScheme.secondary,
+    )
+}
+
+/** Screen-level section title, e.g. "Mission Timeline". */
+@Composable
+private fun SectionHeader(title: String) {
+    Text(
+        text = title,
+        style = AppTypography.sectionHeader,
+        color = MaterialTheme.colorScheme.tertiary,
+    )
+}

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/MissionInfoSections.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/MissionInfoSections.kt
@@ -41,7 +41,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
@@ -179,7 +179,7 @@ internal fun MissionInfoContent(
                     }
                 }
 
-                state.missionFacts.funFacts.firstOrNull()?.let { fact ->
+                state.missionFacts.funFacts.randomOrNull()?.let { fact ->
                     item {
                         Column(
                             modifier = Modifier
@@ -226,7 +226,7 @@ internal fun RoverImageCard(
             1f to bgColor.copy(alpha = 0.96f),
         )
     }
-    Box(modifier = modifier.fillMaxWidth().aspectRatio(aspectRatio)) {
+    Box(modifier = modifier.aspectRatio(aspectRatio)) {
         Image(
             painter = rover.painter(),
             contentDescription = rover.name,
@@ -238,18 +238,18 @@ internal fun RoverImageCard(
 }
 
 @Composable
-private fun MissionHeroSection(rover: Rover, onBack: (() -> Unit)?) {
+private fun MissionHeroSection(rover: Rover, onBack: (() -> Unit)?, modifier: Modifier = Modifier) {
     val topGradient = remember {
         Brush.verticalGradient(
             0f to Color.Black.copy(alpha = 0.52f),
             0.4f to Color.Transparent,
         )
     }
-    Box(modifier = Modifier.fillMaxWidth()) {
+    Box(modifier = modifier.fillMaxWidth()) {
         RoverImageCard(
             rover = rover,
             aspectRatio = 16f / 9f,
-            modifier = Modifier.sharedRoverImage(rover.id),
+            modifier = Modifier.fillMaxWidth().sharedRoverImage(rover.id),
         )
         Box(
             modifier = Modifier
@@ -371,9 +371,9 @@ private fun TimelineCard(milestone: TimelineMilestone, modifier: Modifier = Modi
 // ── Statistics ────────────────────────────────────────────────────────────────
 
 @Composable
-private fun V1Stats(totalPhotos: Int, daysActive: Long, earthDaysActive: Long) {
+private fun V1Stats(totalPhotos: Int, daysActive: Long, earthDaysActive: Long, modifier: Modifier = Modifier) {
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
     ) {
         StatCard(label = "Total Photos", value = formatThousands(totalPhotos), modifier = Modifier.weight(1f))
@@ -410,10 +410,10 @@ private fun StatCard(label: String, value: String, modifier: Modifier = Modifier
 internal fun V1Objectives(objectives: List<String>, twoCol: Boolean = false, modifier: Modifier = Modifier) {
     if (twoCol) {
         Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
-            objectives.chunked(2).forEach { pair ->
+            objectives.chunked(2).forEachIndexed { chunkIdx, pair ->
                 Row(horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
-                    pair.forEach { obj ->
-                        ObjectiveCard(index = objectives.indexOf(obj), text = obj, modifier = Modifier.weight(1f))
+                    pair.forEachIndexed { colIdx, obj ->
+                        ObjectiveCard(index = chunkIdx * 2 + colIdx, text = obj, modifier = Modifier.weight(1f))
                     }
                     if (pair.size == 1) Spacer(Modifier.weight(1f))
                 }
@@ -427,8 +427,9 @@ internal fun V1Objectives(objectives: List<String>, twoCol: Boolean = false, mod
 }
 
 @Composable
-private fun ObjectiveRow(index: Int, text: String) {
+private fun ObjectiveRow(index: Int, text: String, modifier: Modifier = Modifier) {
     Row(
+        modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(AppSpacing.md),
         verticalAlignment = Alignment.Top,
     ) {
@@ -486,7 +487,7 @@ private fun V1CamerasAccordion(
     onCameraClick: (String) -> Unit,
 ) {
     var expanded by rememberSaveable { mutableStateOf(false) }
-    val arrowRotation by animateFloatAsState(
+    val arrowRotation = animateFloatAsState(
         targetValue = if (expanded) 180f else 0f,
         label = "accordionArrow",
     )
@@ -521,7 +522,7 @@ private fun V1CamerasAccordion(
                 symbol = MaterialSymbol.ExpandMore,
                 contentDescription = if (expanded) "Collapse" else "Expand",
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.rotate(arrowRotation),
+                modifier = Modifier.graphicsLayer { rotationZ = arrowRotation.value },
             )
         }
 
@@ -680,7 +681,7 @@ private fun BrowsePhotosButton(onClick: () -> Unit, modifier: Modifier = Modifie
 
 /** Small uppercase accent label used inside cards (stat labels, timeline type, etc.). */
 @Composable
-internal fun SectionLabel(text: String) {
+internal fun SectionLabel(text: String, modifier: Modifier = Modifier) {
     Text(
         text = text.uppercase(),
         style = MaterialTheme.typography.labelSmall.copy(
@@ -688,15 +689,17 @@ internal fun SectionLabel(text: String) {
             letterSpacing = 1.1.sp,
         ),
         color = MaterialTheme.colorScheme.secondary,
+        modifier = modifier,
     )
 }
 
 /** Screen-level section title, e.g. "Mission Timeline". */
 @Composable
-private fun SectionHeader(title: String) {
+private fun SectionHeader(title: String, modifier: Modifier = Modifier) {
     Text(
         text = title,
         style = AppTypography.sectionHeader,
         color = MaterialTheme.colorScheme.tertiary,
+        modifier = modifier,
     )
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoverMissionInfoScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoverMissionInfoScreen.kt
@@ -1,6 +1,13 @@
 package com.sirelon.marsroverphotos.presentation.screens
 
-import androidx.compose.animation.Crossfade
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -16,17 +23,21 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.animation.core.tween
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.window.core.layout.WindowSizeClass.Companion.WIDTH_DP_EXPANDED_LOWER_BOUND
 import androidx.window.core.layout.WindowSizeClass.Companion.WIDTH_DP_MEDIUM_LOWER_BOUND
+import com.sirelon.marsroverphotos.presentation.navigation.LocalMissionLayoutAnimatedVisibilityScope
 import com.sirelon.marsroverphotos.domain.models.Rover
 import com.sirelon.marsroverphotos.domain.models.mission.CameraSpec
 import com.sirelon.marsroverphotos.domain.models.mission.RoverMissionFacts
+import com.sirelon.marsroverphotos.presentation.theme.AppMotion
 import com.sirelon.marsroverphotos.presentation.theme.AppSize
 import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
 import com.sirelon.marsroverphotos.presentation.ui.AppButton
@@ -43,6 +54,12 @@ import org.koin.compose.viewmodel.koinViewModel
 
 data class RoverMissionInfoUiState(
     val missionInfoState: MissionInfoState? = null,
+)
+
+private data class MissionLayoutKey(
+    val data: MissionInfoState?,
+    val isExpanded: Boolean,
+    val isMediumPlus: Boolean,
 )
 
 // ── State-holder composable ───────────────────────────────────────────────────
@@ -119,26 +136,62 @@ private fun RoverMissionInfoScreen(
             }
         },
     ) { paddingValues ->
-        Crossfade(
-            targetState = state.missionInfoState,
-            label = "MissionInfoCrossfade",
+        AnimatedContent(
+            targetState = MissionLayoutKey(state.missionInfoState, isExpanded, isMediumPlus),
+            label = "MissionInfoContent",
             modifier = Modifier.padding(paddingValues),
-        ) { currentState ->
+            transitionSpec = {
+                val dur = AppMotion.SharedContainerMs
+                when {
+                    // Loading → content: fade + gentle upward reveal
+                    initialState.data == null -> ContentTransform(
+                        targetContentEnter = fadeIn(tween(dur)) +
+                            slideInVertically(tween(dur)) { it / 10 },
+                        initialContentExit = fadeOut(tween(dur / 2)),
+                        sizeTransform = null,
+                    )
+                    // Compact/medium → expanded (window widened): slide in from right
+                    targetState.isExpanded && !initialState.isExpanded -> ContentTransform(
+                        targetContentEnter = fadeIn(tween(dur)) +
+                            slideInHorizontally(tween(dur)) { it / 6 },
+                        initialContentExit = fadeOut(tween(dur / 2)) +
+                            slideOutHorizontally(tween(dur)) { -it / 6 },
+                        sizeTransform = null,
+                    )
+                    // Expanded → compact/medium (window narrowed): slide in from left
+                    !targetState.isExpanded && initialState.isExpanded -> ContentTransform(
+                        targetContentEnter = fadeIn(tween(dur)) +
+                            slideInHorizontally(tween(dur)) { -it / 6 },
+                        initialContentExit = fadeOut(tween(dur / 2)) +
+                            slideOutHorizontally(tween(dur)) { it / 6 },
+                        sizeTransform = null,
+                    )
+                    // Same layout tier, data change: simple crossfade
+                    else -> ContentTransform(
+                        targetContentEnter = fadeIn(tween(dur / 2)),
+                        initialContentExit = fadeOut(tween(dur / 2)),
+                        sizeTransform = null,
+                    )
+                }
+            },
+        ) { key ->
+            CompositionLocalProvider(LocalMissionLayoutAnimatedVisibilityScope provides this) {
             when {
-                currentState == null -> CenteredProgress()
-                isExpanded -> ExpandedLayout(
-                    state = currentState,
+                key.data == null -> CenteredProgress()
+                key.isExpanded -> ExpandedLayout(
+                    state = key.data,
                     onCameraClick = onCameraClick,
                     onBrowsePhotos = onBrowsePhotos,
                 )
                 else -> MissionInfoContent(
-                    state = currentState,
-                    isMediumPlus = isMediumPlus,
+                    state = key.data,
+                    isMediumPlus = key.isMediumPlus,
                     onCameraClick = onCameraClick,
                     onBrowsePhotos = onBrowsePhotos,
-                    onBack = if (!isMediumPlus) onBack else null,
+                    onBack = if (!key.isMediumPlus) onBack else null,
                 )
             }
+            } // CompositionLocalProvider
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoverMissionInfoScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoverMissionInfoScreen.kt
@@ -139,6 +139,7 @@ private fun RoverMissionInfoScreen(
         AnimatedContent(
             targetState = MissionLayoutKey(state.missionInfoState, isExpanded, isMediumPlus),
             label = "MissionInfoContent",
+            contentKey = { key -> Triple(key.data != null, key.isExpanded, key.isMediumPlus) },
             modifier = Modifier.padding(paddingValues),
             transitionSpec = {
                 val dur = AppMotion.SharedContainerMs

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoverMissionInfoScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoverMissionInfoScreen.kt
@@ -1,80 +1,46 @@
 package com.sirelon.marsroverphotos.presentation.screens
 
 import androidx.compose.animation.Crossfade
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.runtime.remember
-import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import com.sirelon.marsroverphotos.presentation.ui.AppCard
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.ScaffoldDefaults.contentWindowInsets
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.TopAppBarScrollBehavior
-import com.sirelon.marsroverphotos.presentation.ui.AppTopBar
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
-import com.sirelon.marsroverphotos.presentation.theme.AppTypography
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.window.core.layout.WindowSizeClass.Companion.WIDTH_DP_EXPANDED_LOWER_BOUND
+import androidx.window.core.layout.WindowSizeClass.Companion.WIDTH_DP_MEDIUM_LOWER_BOUND
 import com.sirelon.marsroverphotos.domain.models.Rover
 import com.sirelon.marsroverphotos.domain.models.mission.CameraSpec
 import com.sirelon.marsroverphotos.domain.models.mission.RoverMissionFacts
+import com.sirelon.marsroverphotos.presentation.theme.AppSize
+import com.sirelon.marsroverphotos.presentation.theme.AppSpacing
+import com.sirelon.marsroverphotos.presentation.ui.AppButton
+import com.sirelon.marsroverphotos.presentation.ui.AppTopBar
 import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbol
 import com.sirelon.marsroverphotos.presentation.ui.MaterialSymbolIcon
-import com.sirelon.marsroverphotos.presentation.ui.painter
 import com.sirelon.marsroverphotos.presentation.viewmodels.MilestoneType
 import com.sirelon.marsroverphotos.presentation.viewmodels.MissionInfoState
 import com.sirelon.marsroverphotos.presentation.viewmodels.RoverMissionInfoViewModel
 import com.sirelon.marsroverphotos.presentation.viewmodels.TimelineMilestone
-import com.sirelon.marsroverphotos.utils.formatThousands
-import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
 
-/**
- * Immutable UI state for [RoverMissionInfoScreen].
- *
- * [missionInfoState] is null while the data is loading — the screen shows a
- * centered progress indicator in that case.
- */
 data class RoverMissionInfoUiState(
     val missionInfoState: MissionInfoState? = null,
 )
@@ -87,24 +53,21 @@ fun RoverMissionInfoScreen(
     roverId: Long,
     onBack: () -> Unit,
     onCameraClick: (String) -> Unit = {},
-    viewModel: RoverMissionInfoViewModel = koinViewModel()
+    onBrowsePhotos: () -> Unit = {},
+    viewModel: RoverMissionInfoViewModel = koinViewModel(),
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
 
-    LaunchedEffect(roverId) {
-        viewModel.setRoverId(roverId)
-    }
-
+    LaunchedEffect(roverId) { viewModel.setRoverId(roverId) }
     LaunchedEffect(state?.rover?.id) {
-        state?.rover?.let {
-            viewModel.trackEvent("mission_info_opened_${it.name}")
-        }
+        state?.rover?.let { viewModel.trackEvent("mission_info_opened_${it.name}") }
     }
 
     RoverMissionInfoScreen(
         state = RoverMissionInfoUiState(missionInfoState = state),
         onBack = onBack,
         onCameraClick = onCameraClick,
+        onBrowsePhotos = onBrowsePhotos,
     )
 }
 
@@ -116,455 +79,74 @@ private fun RoverMissionInfoScreen(
     state: RoverMissionInfoUiState,
     onBack: () -> Unit,
     onCameraClick: (String) -> Unit = {},
+    onBrowsePhotos: () -> Unit = {},
 ) {
-    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
+    val isMediumPlus = windowSizeClass.isWidthAtLeastBreakpoint(WIDTH_DP_MEDIUM_LOWER_BOUND)
+    val isExpanded   = windowSizeClass.isWidthAtLeastBreakpoint(WIDTH_DP_EXPANDED_LOWER_BOUND)
+
+    val scrollBehavior = if (isMediumPlus) TopAppBarDefaults.enterAlwaysScrollBehavior() else null
+
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        modifier = if (scrollBehavior != null)
+            Modifier.nestedScroll(scrollBehavior.nestedScrollConnection) else Modifier,
         contentWindowInsets = WindowInsets(),
         topBar = {
-            AppTopBar(
-                scrollBehavior = scrollBehavior,
-                title = { Text(state.missionInfoState?.rover?.name ?: "Mission Info") },
-                onBack = onBack,
-            )
-        }
+            if (isMediumPlus) {
+                AppTopBar(
+                    scrollBehavior = scrollBehavior,
+                    title = { Text(state.missionInfoState?.rover?.name ?: "Mission Info") },
+                    onBack = onBack,
+                    actions = {
+                        AppButton(
+                            onClick = onBrowsePhotos,
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = MaterialTheme.colorScheme.secondary,
+                                contentColor = MaterialTheme.colorScheme.onSecondary,
+                            ),
+                        ) {
+                            MaterialSymbolIcon(
+                                symbol = MaterialSymbol.CameraAlt,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSecondary,
+                                size = AppSize.iconInline,
+                            )
+                            Spacer(Modifier.width(AppSpacing.xs))
+                            Text("Browse Photos")
+                        }
+                    },
+                )
+            }
+        },
     ) { paddingValues ->
         Crossfade(
             targetState = state.missionInfoState,
             label = "MissionInfoCrossfade",
-            modifier = Modifier.padding(paddingValues)
+            modifier = Modifier.padding(paddingValues),
         ) { currentState ->
             when {
                 currentState == null -> CenteredProgress()
+                isExpanded -> ExpandedLayout(
+                    state = currentState,
+                    onCameraClick = onCameraClick,
+                    onBrowsePhotos = onBrowsePhotos,
+                )
                 else -> MissionInfoContent(
                     state = currentState,
-                    onCameraClick = onCameraClick
+                    isMediumPlus = isMediumPlus,
+                    onCameraClick = onCameraClick,
+                    onBrowsePhotos = onBrowsePhotos,
+                    onBack = if (!isMediumPlus) onBack else null,
                 )
             }
         }
     }
 }
-
-// ── Content ──────────────────────────────────────────────────────────────────
 
 @Composable
 private fun CenteredProgress() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
-    ) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         CircularProgressIndicator()
-    }
-}
-
-@Composable
-private fun MissionInfoContent(
-    state: MissionInfoState,
-    onCameraClick: (String) -> Unit = {}
-) {
-    LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = AppSpacing.lg),
-        verticalArrangement = Arrangement.spacedBy(AppSpacing.xl),
-        contentPadding = PaddingValues(vertical = AppSpacing.lg),
-    ) {
-        item { RoverHeader(state.rover) }
-
-        item {
-            SectionHeader("Mission Timeline")
-            Spacer(modifier = Modifier.height(AppSpacing.sm))
-            MissionTimeline(
-                milestones = state.timelineMilestones,
-                status = state.rover.status
-            )
-        }
-
-        item {
-            SectionHeader("Statistics")
-            Spacer(modifier = Modifier.height(AppSpacing.sm))
-            MissionStatistics(
-                totalPhotos = state.rover.totalPhotos,
-                daysActive = state.daysActive,
-                earthDaysActive = state.earthDaysActive,
-                status = state.rover.status
-            )
-        }
-
-        item {
-            SectionHeader("Cameras")
-            Spacer(modifier = Modifier.height(AppSpacing.sm))
-            CamerasList(
-                cameras = state.cameras,
-                onCameraClick = onCameraClick
-            )
-        }
-
-        when {
-            state.factsLoading -> item {
-                SectionHeader("Mission Info")
-                Spacer(modifier = Modifier.height(AppSpacing.sm))
-                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
-            }
-
-            state.missionFacts != null -> {
-                if (state.missionFacts.objectives.isNotEmpty()) {
-                    item {
-                        SectionHeader("Mission Objectives")
-                        Spacer(modifier = Modifier.height(AppSpacing.sm))
-                        MissionObjectives(objectives = state.missionFacts.objectives)
-                    }
-                }
-                if (state.missionFacts.funFacts.isNotEmpty()) {
-                    item {
-                        SectionHeader("Fun Facts")
-                        Spacer(modifier = Modifier.height(AppSpacing.sm))
-                        FunFacts(facts = state.missionFacts.funFacts)
-                    }
-                }
-            }
-
-            // When facts fail to load we intentionally render nothing here —
-            // hiding the section avoids showing a broken-looking error banner
-            // on first run.
-        }
-    }
-}
-
-// ── Sections ─────────────────────────────────────────────────────────────────
-
-@Composable
-private fun RoverHeader(rover: Rover) {
-    AppCard(
-        modifier = Modifier.fillMaxWidth(),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
-    ) {
-        Column(
-            modifier = Modifier.padding(AppSpacing.lg),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Image(
-                painter = rover.painter(),
-                contentDescription = rover.name,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(200.dp)
-                    .clip(MaterialTheme.shapes.medium),
-                contentScale = ContentScale.Fit
-            )
-            Spacer(modifier = Modifier.height(AppSpacing.lg))
-            Text(
-                text = rover.name,
-                style = AppTypography.roverTitle,
-                color = MaterialTheme.colorScheme.tertiary
-            )
-        }
-    }
-}
-
-@Composable
-private fun SectionHeader(title: String) {
-    Text(
-        text = title,
-        style = AppTypography.sectionHeader,
-        color = MaterialTheme.colorScheme.tertiary
-    )
-}
-
-@Composable
-private fun MissionTimeline(milestones: ImmutableList<TimelineMilestone>, status: String) {
-    val roverActive = status.equals("active", ignoreCase = true)
-    val milestoneColor = if (roverActive) {
-        MaterialTheme.colorScheme.tertiary
-    } else {
-        MaterialTheme.colorScheme.secondary
-    }
-
-    // Animate the Landing→Current segment from 0f → 1f on first composition for active rovers.
-    // Completed rovers snap straight to 1f. Using Animatable so snapTo(0f) + animateTo(1f) are
-    // two distinct frames — animateFloatAsState + a boolean flag batches both writes into one
-    // snapshot and the animation never resets on rover change.
-    val landingToCurrentProgress = remember { Animatable(0f) }
-    LaunchedEffect(milestones) {
-        if (roverActive) {
-            landingToCurrentProgress.snapTo(0f)
-            landingToCurrentProgress.animateTo(1f, animationSpec = tween(durationMillis = 600))
-        } else {
-            landingToCurrentProgress.snapTo(1f)
-        }
-    }
-
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
-        milestones.forEachIndexed { index, milestone ->
-            Column(
-                modifier = Modifier.weight(1f),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Text(
-                    text = milestone.label,
-                    style = AppTypography.milestoneLabel,
-                    textAlign = TextAlign.Center
-                )
-                Spacer(modifier = Modifier.height(AppSpacing.xs))
-                Box(
-                    modifier = Modifier
-                        .size(32.dp)
-                        .clip(CircleShape)
-                        .background(milestoneColor),
-                    contentAlignment = Alignment.Center
-                ) {
-                    val icon = when (milestone.type) {
-                        MilestoneType.LAUNCH  -> MaterialSymbol.Rocket
-                        MilestoneType.LANDING -> MaterialSymbol.FlightLand
-                        MilestoneType.CURRENT -> MaterialSymbol.Star
-                        MilestoneType.END     -> MaterialSymbol.Flag
-                    }
-                    MaterialSymbolIcon(
-                        symbol = icon,
-                        contentDescription = milestone.label,
-                        tint = Color.White,
-                        modifier = Modifier.size(20.dp)
-                    )
-                }
-                Spacer(modifier = Modifier.height(AppSpacing.xs))
-                Text(
-                    text = milestone.date,
-                    style = MaterialTheme.typography.bodySmall,
-                    textAlign = TextAlign.Center
-                )
-                milestone.sol?.let {
-                    Text(
-                        text = "Sol $it",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.secondary,
-                        textAlign = TextAlign.Center
-                    )
-                }
-            }
-
-            if (index < milestones.size - 1) {
-                // First connector (Launch → Landing) is always 100% — that
-                // journey is complete once the rover has landed.
-                // Second connector (Landing → Current/End) is animated for
-                // active rovers and fully filled for completed missions.
-                val segmentProgress = when {
-                    index == 0 -> 1f
-                    !roverActive -> 1f
-                    else -> landingToCurrentProgress.value
-                }
-                TimelineSegment(
-                    progress = { segmentProgress },
-                    modifier = Modifier
-                        .weight(0.5f)
-                        .align(Alignment.CenterVertically)
-                        .padding(horizontal = AppSpacing.xs)
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun TimelineSegment(progress: () -> Float, modifier: Modifier = Modifier) {
-    val shape = RoundedCornerShape(3.dp)
-    val fillColor = MaterialTheme.colorScheme.tertiary
-    val trackColor = MaterialTheme.colorScheme.outlineVariant
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(6.dp)
-            .clip(shape)
-            .drawBehind {
-                drawRect(trackColor)
-                drawRect(
-                    color = fillColor,
-                    size = Size(size.width * progress().coerceIn(0f, 1f), size.height),
-                )
-            },
-    )
-}
-
-/**
- * 2×2 stat grid using plain Row/Column — avoids nested-scrollable issues
- * and doesn't need a fixed height override.
- */
-@Composable
-private fun MissionStatistics(
-    totalPhotos: Int,
-    daysActive: Long,
-    earthDaysActive: Long,
-    status: String
-) {
-    Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm)
-        ) {
-            StatCard(
-                label = "Total Photos",
-                value = formatThousands(totalPhotos),
-                modifier = Modifier.weight(1f)
-            )
-            StatCard(
-                label = "Days on Mars",
-                value = "${formatThousands(daysActive)} sols",
-                modifier = Modifier.weight(1f)
-            )
-        }
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm)
-        ) {
-            StatCard(
-                label = "Earth Days",
-                value = "${formatThousands(earthDaysActive)} days",
-                modifier = Modifier.weight(1f)
-            )
-            StatCard(
-                label = "Status",
-                value = status.replaceFirstChar { it.uppercaseChar() },
-                modifier = Modifier.weight(1f)
-            )
-        }
-    }
-}
-
-@Composable
-private fun StatCard(label: String, value: String, modifier: Modifier = Modifier) {
-    AppCard(modifier = modifier) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(AppSpacing.lg),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Text(
-                text = label,
-                style = AppTypography.statLabel,
-                color = MaterialTheme.colorScheme.secondary,
-                textAlign = TextAlign.Center
-            )
-            Spacer(modifier = Modifier.height(AppSpacing.sm))
-            Text(
-                text = value,
-                style = AppTypography.statValue,
-                textAlign = TextAlign.Center
-            )
-        }
-    }
-}
-
-@Composable
-private fun CamerasList(
-    cameras: ImmutableList<CameraSpec>,
-    onCameraClick: (String) -> Unit = {}
-) {
-    if (cameras.isEmpty()) {
-        Text(
-            text = "No camera information available",
-            style = AppTypography.bodySecondary,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-        return
-    }
-    AppCard(modifier = Modifier.fillMaxWidth()) {
-        Column(modifier = Modifier.padding(AppSpacing.lg)) {
-            cameras.forEachIndexed { index, camera ->
-                CameraItem(
-                    camera = camera,
-                    onClick = { onCameraClick(camera.name) }
-                )
-                if (index < cameras.size - 1) {
-                    HorizontalDivider(modifier = Modifier.padding(vertical = AppSpacing.md))
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun CameraItem(
-    camera: CameraSpec,
-    onClick: () -> Unit = {}
-) {
-    Column(modifier = Modifier.clickable(onClick = onClick)) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            MaterialSymbolIcon(
-                symbol = MaterialSymbol.CameraAlt,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(24.dp)
-            )
-            Spacer(modifier = Modifier.width(AppSpacing.md))
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = camera.name,
-                    style = AppTypography.factHeader
-                )
-                Text(
-                    text = camera.fullName,
-                    style = AppTypography.bodySecondary,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
-        Spacer(modifier = Modifier.height(AppSpacing.sm))
-        Text(
-            text = camera.description,
-            style = MaterialTheme.typography.bodySmall,
-            modifier = Modifier.padding(start = 36.dp)
-        )
-    }
-}
-
-@Composable
-private fun MissionObjectives(objectives: List<String>) {
-    AppCard(modifier = Modifier.fillMaxWidth()) {
-        Column(modifier = Modifier.padding(AppSpacing.lg)) {
-            objectives.forEach { objective ->
-                Row(modifier = Modifier.padding(vertical = AppSpacing.xs)) {
-                    Text(
-                        text = "•",
-                        style = AppTypography.body,
-                        color = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.padding(end = AppSpacing.sm)
-                    )
-                    Text(
-                        text = objective,
-                        style = AppTypography.body
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun FunFacts(facts: List<String>) {
-    AppCard(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.primaryContainer,
-            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        ),
-    ) {
-        Column(modifier = Modifier.padding(AppSpacing.lg)) {
-            facts.forEach { fact ->
-                Row(modifier = Modifier.padding(vertical = AppSpacing.xs)) {
-                    Text(text = "✨", modifier = Modifier.padding(end = AppSpacing.sm))
-                    Text(
-                        text = fact,
-                        style = AppTypography.body
-                    )
-                }
-            }
-        }
     }
 }
 
@@ -577,6 +159,7 @@ private fun RoverMissionInfoScreenLoadingPreview() {
         state = RoverMissionInfoUiState(missionInfoState = null),
         onBack = {},
         onCameraClick = {},
+        onBrowsePhotos = {},
     )
 }
 
@@ -584,33 +167,23 @@ private fun RoverMissionInfoScreenLoadingPreview() {
 @Composable
 private fun RoverMissionInfoScreenLoadedPreview() {
     val previewRover = Rover(
-        id = 5,
-        name = "Curiosity",
-        drawableName = "curiosity",
-        landingDate = "2012-08-06",
-        launchDate = "2011-11-26",
-        status = "active",
-        maxSol = 4000,
-        maxDate = "2023-10-01",
-        totalPhotos = 695670
+        id = 5, name = "Curiosity", drawableName = "curiosity",
+        landingDate = "2012-08-06", launchDate = "2011-11-26",
+        status = "active", maxSol = 4000, maxDate = "2023-10-01", totalPhotos = 695670,
     )
     val previewMilestones = persistentListOf(
-        TimelineMilestone(label = "Launch", date = "2011-11-26", sol = null, type = MilestoneType.LAUNCH),
-        TimelineMilestone(label = "Landing", date = "2012-08-06", sol = null, type = MilestoneType.LANDING),
-        TimelineMilestone(label = "Today", date = "2023-10-01", sol = 4000L, type = MilestoneType.CURRENT),
+        TimelineMilestone(label = "Launch",  date = "Nov 26, 2011", sol = null,   type = MilestoneType.LAUNCH),
+        TimelineMilestone(label = "Landing", date = "Aug 6, 2012",  sol = null,   type = MilestoneType.LANDING),
+        TimelineMilestone(label = "Today",   date = "Oct 1, 2023",  sol = 4000L,  type = MilestoneType.CURRENT),
     )
     val previewCameras = persistentListOf(
-        CameraSpec(
-            name = "MAST",
-            fullName = "Mast Camera",
-            description = "Two cameras mounted on the mast for color imaging."
-        )
+        CameraSpec(name = "MAST", fullName = "Mast Camera",         description = "Two cameras for color imaging."),
+        CameraSpec(name = "FHAZ", fullName = "Front Hazard Camera",  description = "Wide-angle hazard detection."),
     )
     val previewFacts = RoverMissionFacts(
-        roverId = 5,
-        roverName = "Curiosity",
+        roverId = 5, roverName = "Curiosity",
         objectives = listOf("Assess habitability", "Study Martian climate"),
-        funFacts = listOf("Curiosity is the size of a small car.")
+        funFacts = listOf("Curiosity is the size of a small car."),
     )
     RoverMissionInfoScreen(
         state = RoverMissionInfoUiState(
@@ -627,5 +200,6 @@ private fun RoverMissionInfoScreenLoadedPreview() {
         ),
         onBack = {},
         onCameraClick = {},
+        onBrowsePhotos = {},
     )
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoverMissionInfoScreen.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/screens/RoverMissionInfoScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material3.IconButton
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -178,7 +180,7 @@ private fun RoverMissionInfoScreen(
         ) { key ->
             CompositionLocalProvider(LocalMissionLayoutAnimatedVisibilityScope provides this) {
             when {
-                key.data == null -> CenteredProgress()
+                key.data == null -> CenteredProgress(onBack = if (!key.isMediumPlus) onBack else null)
                 key.isExpanded -> ExpandedLayout(
                     state = key.data,
                     onCameraClick = onCameraClick,
@@ -198,9 +200,24 @@ private fun RoverMissionInfoScreen(
 }
 
 @Composable
-private fun CenteredProgress() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        CircularProgressIndicator()
+private fun CenteredProgress(onBack: (() -> Unit)? = null) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+        if (onBack != null) {
+            IconButton(
+                onClick = onBack,
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .statusBarsPadding()
+                    .padding(AppSpacing.lg),
+            ) {
+                MaterialSymbolIcon(
+                    symbol = MaterialSymbol.ArrowBack,
+                    contentDescription = "Back",
+                    size = AppSize.iconDefault,
+                )
+            }
+        }
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/AppMotion.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/theme/AppMotion.kt
@@ -3,6 +3,7 @@ package com.sirelon.marsroverphotos.presentation.theme
 import androidx.compose.animation.BoundsTransform
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
 
 /**
@@ -40,4 +41,8 @@ object AppMotion {
     /** Bounds spec for the favorite heart shared element — same curve as the photo. */
     @OptIn(ExperimentalSharedTransitionApi::class)
     val FavoriteBoundsTransform = BoundsTransform { _, _ -> tween(SharedContainerMs, easing = Emphasized) }
+
+    /** Bounds spec for text/badge elements — linear tween avoids spring overshoot on text bounds. */
+    @OptIn(ExperimentalSharedTransitionApi::class)
+    val TextBoundsTransform = BoundsTransform { _, _ -> tween(SharedContainerMs, easing = FastOutSlowInEasing) }
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/SharedPhotoTransition.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/SharedPhotoTransition.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.navigation3.ui.LocalNavAnimatedContentScope
+import com.sirelon.marsroverphotos.presentation.navigation.LocalMissionLayoutAnimatedVisibilityScope
 import com.sirelon.marsroverphotos.presentation.navigation.LocalSharedTransitionScope
 import com.sirelon.marsroverphotos.presentation.theme.AppMotion
 
@@ -73,6 +74,102 @@ fun Modifier.sharedFavorite(id: String, enabled: Boolean = true): Modifier {
             sharedContentState = rememberSharedContentState(key = "photo_favorite_$id"),
             animatedVisibilityScope = animatedScope,
             boundsTransform = AppMotion.FavoriteBoundsTransform,
+        )
+    }
+}
+
+/**
+ * Shared bounds for the rover hero/portrait image between the Mission Info compact and expanded
+ * layouts. Uses `sharedBounds` because the two ends have different aspect ratios (16:9 vs 4:3).
+ */
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun Modifier.sharedRoverImage(roverId: Long): Modifier {
+    val shared = LocalSharedTransitionScope.current ?: return this
+    val animatedScope = LocalMissionLayoutAnimatedVisibilityScope.current ?: return this
+    return with(shared) {
+        sharedBounds(
+            sharedContentState = rememberSharedContentState(key = "mission_rover_image_$roverId"),
+            animatedVisibilityScope = animatedScope,
+            boundsTransform = AppMotion.PhotoBoundsTransform,
+        )
+    }
+}
+
+/**
+ * Shared bounds for the rover name text between the Mission Info compact (hero overlay) and
+ * expanded (identity card) layouts. Uses `sharedBounds` because the text styles differ.
+ */
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun Modifier.sharedRoverName(roverId: Long): Modifier {
+    val shared = LocalSharedTransitionScope.current ?: return this
+    val animatedScope = LocalMissionLayoutAnimatedVisibilityScope.current ?: return this
+    return with(shared) {
+        sharedBounds(
+            sharedContentState = rememberSharedContentState(key = "mission_rover_name_$roverId"),
+            animatedVisibilityScope = animatedScope,
+            boundsTransform = AppMotion.PhotoBoundsTransform,
+        )
+    }
+}
+
+/** Shared bounds for the rover status badge (flies with the name between hero and identity card). */
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun Modifier.sharedRoverBadge(roverId: Long): Modifier {
+    val shared = LocalSharedTransitionScope.current ?: return this
+    val animatedScope = LocalMissionLayoutAnimatedVisibilityScope.current ?: return this
+    return with(shared) {
+        sharedBounds(
+            sharedContentState = rememberSharedContentState(key = "mission_rover_badge_$roverId"),
+            animatedVisibilityScope = animatedScope,
+            boundsTransform = AppMotion.PhotoBoundsTransform,
+        )
+    }
+}
+
+/** Shared bounds for the fun-fact card (same composable in both layouts, morphs to new position). */
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun Modifier.sharedRoverFunFact(roverId: Long): Modifier {
+    val shared = LocalSharedTransitionScope.current ?: return this
+    val animatedScope = LocalMissionLayoutAnimatedVisibilityScope.current ?: return this
+    return with(shared) {
+        sharedBounds(
+            sharedContentState = rememberSharedContentState(key = "mission_rover_funfact_$roverId"),
+            animatedVisibilityScope = animatedScope,
+            boundsTransform = AppMotion.PhotoBoundsTransform,
+        )
+    }
+}
+
+/** Shared bounds for the objectives section (exact same composable in both layouts). */
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun Modifier.sharedRoverObjectives(roverId: Long): Modifier {
+    val shared = LocalSharedTransitionScope.current ?: return this
+    val animatedScope = LocalMissionLayoutAnimatedVisibilityScope.current ?: return this
+    return with(shared) {
+        sharedBounds(
+            sharedContentState = rememberSharedContentState(key = "mission_rover_objectives_$roverId"),
+            animatedVisibilityScope = animatedScope,
+            boundsTransform = AppMotion.PhotoBoundsTransform,
+        )
+    }
+}
+
+/** Shared bounds for the cameras grid (exact same composable in both layouts). */
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun Modifier.sharedRoverCameras(roverId: Long): Modifier {
+    val shared = LocalSharedTransitionScope.current ?: return this
+    val animatedScope = LocalMissionLayoutAnimatedVisibilityScope.current ?: return this
+    return with(shared) {
+        sharedBounds(
+            sharedContentState = rememberSharedContentState(key = "mission_rover_cameras_$roverId"),
+            animatedVisibilityScope = animatedScope,
+            boundsTransform = AppMotion.PhotoBoundsTransform,
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/SharedPhotoTransition.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/ui/SharedPhotoTransition.kt
@@ -109,7 +109,7 @@ fun Modifier.sharedRoverName(roverId: Long): Modifier {
         sharedBounds(
             sharedContentState = rememberSharedContentState(key = "mission_rover_name_$roverId"),
             animatedVisibilityScope = animatedScope,
-            boundsTransform = AppMotion.PhotoBoundsTransform,
+            boundsTransform = AppMotion.TextBoundsTransform,
         )
     }
 }
@@ -124,7 +124,7 @@ fun Modifier.sharedRoverBadge(roverId: Long): Modifier {
         sharedBounds(
             sharedContentState = rememberSharedContentState(key = "mission_rover_badge_$roverId"),
             animatedVisibilityScope = animatedScope,
-            boundsTransform = AppMotion.PhotoBoundsTransform,
+            boundsTransform = AppMotion.TextBoundsTransform,
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/RoverMissionInfoViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/presentation/viewmodels/RoverMissionInfoViewModel.kt
@@ -1,5 +1,6 @@
 package com.sirelon.marsroverphotos.presentation.viewmodels
 
+import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.sirelon.marsroverphotos.domain.models.Rover
@@ -172,6 +173,7 @@ private sealed interface MissionFactsStatus {
 /**
  * State for the mission info screen.
  */
+@Immutable
 data class MissionInfoState(
     val rover: Rover,
     val daysActive: Long,
@@ -186,6 +188,7 @@ data class MissionInfoState(
 /**
  * Represents a milestone in the mission timeline.
  */
+@Immutable
 data class TimelineMilestone(
     val label: String,
     val date: String,


### PR DESCRIPTION
## Summary

- Rewrites `RoverMissionInfoScreen` with a fully adaptive layout: compact single-column (phone), medium two-pane with top bar, and expanded desktop two-panel view (`MissionInfoExpandedLayout`)
- Adds a rover hero image section, timeline milestone cards, and a cameras accordion with animated expand/collapse
- Introduces shared-bounds transitions (`sharedRoverImage`, `sharedRoverName`, `sharedRoverBadge`, `sharedRoverFunFact`, `sharedRoverObjectives`, `sharedRoverCameras`) wired through a new `LocalMissionLayoutAnimatedVisibilityScope` so elements morph between compact and expanded layouts
- Adds `AppMotion.TextBoundsTransform` (FastOutSlowIn tween) for text/badge shared bounds to avoid spring overshoot, and a `contentKey` on `AnimatedContent` so in-place data refreshes don't trigger layout transitions

## Test plan
- [ ] Phone: scroll mission info, expand/collapse cameras accordion, verify no spurious crossfades on facts load-in
- [ ] Tablet/resizable: resize window across compact↔expanded breakpoints and verify slide transition fires once per tier change
- [ ] Desktop: two-panel layout renders correctly, "Browse Photos" button in top bar works
- [ ] Shared bounds morph smoothly; name/badge have no overshoot

🤖 Generated with [Claude Code](https://claude.com/claude-code)