### PR TITLE
iOS: fix empty app version on About screen + bump to 5.0.0

### DIFF
--- a/buildSrc/src/main/kotlin/AppVersion.kt
+++ b/buildSrc/src/main/kotlin/AppVersion.kt
@@ -2,6 +2,6 @@
 // Android and Desktop read this directly. After bumping, run
 // `./gradlew syncIosVersion` to push the values into the Xcode project.
 object AppVersion {
-    const val name = "4.0.0"
-    const val code = 50
+    const val name = "5.0.0"
+    const val code = 51
 }

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -355,7 +355,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = iosApp/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Mars Rover Photos";
@@ -367,7 +367,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.0.0;
+				MARKETING_VERSION = 5.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sirelon.marsroverphotos;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -383,7 +383,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 50;
+				CURRENT_PROJECT_VERSION = 51;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = iosApp/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Mars Rover Photos";
@@ -395,7 +395,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.0.0;
+				MARKETING_VERSION = 5.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sirelon.marsroverphotos;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/shared/src/iosMain/kotlin/Main.ios.kt
+++ b/shared/src/iosMain/kotlin/Main.ios.kt
@@ -1,6 +1,7 @@
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.window.ComposeUIViewController
+import com.sirelon.marsroverphotos.platform.BuildInfo
 import com.sirelon.marsroverphotos.presentation.App
 import com.sirelon.marsroverphotos.presentation.navigation.DeepLink
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -56,6 +57,7 @@ fun MainViewController(): UIViewController {
         App(
             deepLink = deepLink,
             onDeepLinkConsumed = { pendingDeepLink.value = null },
+            appVersion = BuildInfo.versionName,
             rateAppUrl = "https://apps.apple.com/app/mars-rover-photos"
         )
     }


### PR DESCRIPTION
The About screen hero badge was always empty on iOS because `MainViewController` never passed `appVersion` to the `App` composable — it defaulted to `""`. The fix forwards `BuildInfo.versionName` (already populated from `CFBundleShortVersionString` via `IosApp.start()`) into the call site in `Main.ios.kt`. Also bumps the app version to 5.0.0 (build code 51) across Android, iOS, and Desktop via `AppVersion.kt` and `syncIosVersion`.