### PR TITLE
Enable Firebase Firestore on desktop (JVM)

### DIFF
--- a/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/platform/FirebasePhotosImpl.kt
+++ b/shared/src/commonMain/kotlin/com/sirelon/marsroverphotos/platform/FirebasePhotosImpl.kt
@@ -144,17 +144,17 @@ class FirebasePhotosImpl : IFirebasePhotos {
 }
 
 private fun DocumentSnapshot.toFirebasePhoto() = FirebasePhoto(
-    id = get<String>("id") ?: id,
-    sol = get<Long>("sol") ?: 0L,
-    name = get<String>("name") ?: "",
-    imageUrl = get<String>("imageUrl") ?: "",
-    earthDate = get<String>("earthDate") ?: "",
-    seeCounter = get<Long>("seeCounter") ?: 0L,
-    scaleCounter = get<Long>("scaleCounter") ?: 0L,
-    saveCounter = get<Long>("saveCounter") ?: 0L,
-    shareCounter = get<Long>("shareCounter") ?: 0L,
-    favoriteCounter = get<Long>("favoriteCounter") ?: 0L,
-    roverId = get<Long>("roverId") ?: 0L
+    id = get<String?>("id") ?: id,
+    sol = get<Long?>("sol") ?: 0L,
+    name = get<String?>("name") ?: "",
+    imageUrl = get<String?>("imageUrl") ?: "",
+    earthDate = get<String?>("earthDate") ?: "",
+    seeCounter = get<Long?>("seeCounter") ?: 0L,
+    scaleCounter = get<Long?>("scaleCounter") ?: 0L,
+    saveCounter = get<Long?>("saveCounter") ?: 0L,
+    shareCounter = get<Long?>("shareCounter") ?: 0L,
+    favoriteCounter = get<Long?>("favoriteCounter") ?: 0L,
+    roverId = get<Long?>("roverId") ?: 0L
 )
 
 private fun FirebasePhoto.withBackfilledRoverId(roverId: Long): FirebasePhoto {

--- a/shared/src/desktopMain/kotlin/com/sirelon/marsroverphotos/di/KoinInit.desktop.kt
+++ b/shared/src/desktopMain/kotlin/com/sirelon/marsroverphotos/di/KoinInit.desktop.kt
@@ -2,6 +2,9 @@ package com.sirelon.marsroverphotos.di
 
 import com.sirelon.marsroverphotos.domain.repositories.RoversRepository
 import com.sirelon.marsroverphotos.platform.BuildInfo
+import dev.gitlive.firebase.Firebase
+import dev.gitlive.firebase.FirebaseOptions
+import dev.gitlive.firebase.initialize
 import org.koin.core.context.startKoin
 
 /**
@@ -9,6 +12,30 @@ import org.koin.core.context.startKoin
  * Called from the desktop app's main function.
  */
 fun initKoinDesktop() {
+    val platform = object : com.google.firebase.FirebasePlatform() {
+        private val storage = mutableMapOf<String, String>()
+        override fun store(key: String, value: String) { storage[key] = value }
+        override fun retrieve(key: String): String? = storage[key]
+        override fun clear(key: String) { storage.remove(key) }
+        override fun log(msg: String) { println("[Firebase] $msg") }
+    }
+    com.google.firebase.FirebasePlatform::class.java
+        .getDeclaredField("firebasePlatform")
+        .apply { isAccessible = true }
+        .set(null, platform)
+
+    Firebase.initialize(
+        context = android.app.Application(),
+        options = FirebaseOptions(
+            applicationId = "1:947086751944:android:c96a933297fcdc16",
+            apiKey = "AIzaSyDQtKGkug6YiqzEUxjjfV-Jh8K4KwIfEgs",
+            databaseUrl = "https://mars-rover-photos.firebaseio.com",
+            storageBucket = "mars-rover-photos.appspot.com",
+            projectId = "mars-rover-photos",
+            gcmSenderId = "947086751944"
+        )
+    )
+
     BuildInfo.init(
         versionName = System.getProperty("app.version") ?: "unknown",
         isDebug = System.getProperty("app.debug") == "true",


### PR DESCRIPTION
Initialize Firebase before Koin on desktop using `android.app.Application()` as the context stub and a `FirebasePlatform` implementation set via reflection (the field is `internal` in Kotlin). Fix `DocumentSnapshot` deserialization on JVM by switching all `get<T>()` calls to nullable `get<T?>()` — the gitlive JVM layer throws on null Firestore fields unlike Android. Popular Photos and other Firestore-backed features now work on the desktop app.